### PR TITLE
[FIX] ui: show bot uptime instead of UI process uptime

### DIFF
--- a/core/internal_api/server.py
+++ b/core/internal_api/server.py
@@ -9,8 +9,9 @@ Plugin-specific endpoints are discovered from plugins/{name}/api/routes.py.
 import asyncio
 import importlib.util
 import json
+import time
 
-from fastapi import APIRouter, Depends, FastAPI
+from fastapi import APIRouter, Depends, FastAPI, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
@@ -448,6 +449,26 @@ async def vault_list_by_prefix(
     entries = secrets_manager.list_keys_by_prefix(prefix)
     keys = [e["key_name"] for e in entries]
     return api_ok(data={"prefix": prefix, "keys": keys})
+
+
+@router.get(
+    "/health",
+    response_model=ApiResponse[dict],
+    response_model_exclude_none=True,
+)
+async def health(
+    request: Request,
+    _auth: None = Depends(verify_internal_auth),
+):
+    """Return bot health status including uptime."""
+    bot_start_time = getattr(request.app.state, "bot_start_time", None)
+    elapsed = time.time() - bot_start_time if bot_start_time else 0
+    return api_ok(
+        data={
+            "status": "ok",
+            "uptime_seconds": elapsed,
+        }
+    )
 
 
 async def _single_event(event: dict):

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import asyncio
 import os
 import signal
 import sys
+import time
 from pathlib import Path
 
 from config.logging_config import logger
@@ -1180,6 +1181,7 @@ async def main():
         from core.internal_api.server import create_app as create_internal_app
 
         internal_app = create_internal_app(plugin_manager=plugin_manager)
+        internal_app.state.bot_start_time = time.time()
         api_config = uvicorn.Config(
             internal_app, host="0.0.0.0", port=8000, log_level="warning"
         )

--- a/ui/app.py
+++ b/ui/app.py
@@ -598,10 +598,35 @@ async def get_mcp_servers_info() -> list[dict]:
     return servers
 
 
+async def _fetch_bot_uptime() -> str:
+    """Fetch uptime from the bot's /api/health endpoint."""
+    import aiohttp
+
+    gridbear_url = os.getenv("GRIDBEAR_INTERNAL_URL", "http://gridbear:8000")
+    secret = os.getenv("INTERNAL_API_SECRET", "")
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{gridbear_url}/api/health",
+                headers={"Authorization": f"Bearer {secret}"},
+                timeout=aiohttp.ClientTimeout(total=3),
+            ) as resp:
+                if resp.status == 200:
+                    data = await resp.json()
+                    elapsed = data.get("data", {}).get("uptime_seconds", 0)
+                    days = int(elapsed // 86400)
+                    hours = int((elapsed % 86400) // 3600)
+                    if days > 0:
+                        return f"{days}d {hours}h"
+                    minutes = int((elapsed % 3600) // 60)
+                    return f"{hours}h {minutes}m"
+    except Exception:
+        pass
+    return "restarting..."
+
+
 async def get_system_info() -> dict:
     """Gather system health information."""
-    import time
-
     from core.registry import get_database
 
     info = {
@@ -629,17 +654,8 @@ async def get_system_info() -> dict:
     except Exception:
         pass
 
-    # Uptime
-    start_time = getattr(app.state, "start_time", None)
-    if start_time:
-        elapsed = time.time() - start_time
-        days = int(elapsed // 86400)
-        hours = int((elapsed % 86400) // 3600)
-        if days > 0:
-            info["uptime"] = f"{days}d {hours}h"
-        else:
-            minutes = int((elapsed % 3600) // 60)
-            info["uptime"] = f"{hours}h {minutes}m"
+    # Bot uptime (from gridbear container, not UI process)
+    info["uptime"] = await _fetch_bot_uptime()
 
     return info
 

--- a/ui/routes/agents.py
+++ b/ui/routes/agents.py
@@ -305,8 +305,8 @@ async def restart_gridbear(request: Request, _: dict = Depends(require_login)):
     with open(restart_file, "w") as f:
         json.dump(request_data, f, indent=2)
 
-    # Redirect immediately - the service will restart
-    return RedirectResponse(url="/agents/?restart=requested", status_code=303)
+    # Redirect to dashboard — user can see uptime reset to confirm restart
+    return RedirectResponse(url="/?restart=requested", status_code=303)
 
 
 def _get_runner_models() -> dict[str, list[tuple[str, str]]]:


### PR DESCRIPTION
## Summary
- Dashboard was showing the UI container's own uptime, misleading after a bot restart
- Added `GET /api/health` endpoint to the bot internal API exposing real `uptime_seconds`
- Dashboard now fetches bot uptime via internal HTTP call, shows **"restarting..."** while bot is booting
- Restart action redirects to dashboard (`/`) instead of agents page, so the user sees the uptime reset as confirmation

## Changes
| File | Change |
|------|--------|
| `main.py` | Store `bot_start_time` in internal app state |
| `core/internal_api/server.py` | New `GET /api/health` endpoint |
| `ui/app.py` | `get_system_info()` fetches bot uptime via `/api/health` |
| `ui/routes/agents.py` | Restart redirect → `/` instead of `/agents/` |

## Test plan
- [ ] Start services, verify dashboard shows bot uptime (not UI uptime)
- [ ] Restart bot from UI, confirm redirect to dashboard
- [ ] During restart, verify "restarting..." is shown
- [ ] After restart completes, refresh and verify uptime resets to 0h 0m

🤖 Generated with [Claude Code](https://claude.com/claude-code)