### PR TITLE
[FIX] ui: plugin admin route priority

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -468,7 +468,9 @@ app.include_router(
     notifications.router, prefix="/notifications", tags=["notifications"]
 )
 
-app.include_router(plugins.router, prefix="/plugins", tags=["plugins"])
+# NOTE: plugins.router is registered in the startup handler AFTER
+# plugin-specific admin routes, so /plugins/ms365 etc. take priority
+# over the generic /plugins/{plugin_name} catch-all.
 
 app.include_router(secrets_routes.router)
 app.include_router(settings_routes.router)
@@ -900,7 +902,10 @@ async def startup_cleanup():
         logger.info("Admin: template loader rebuilt with active theme")
 
         # Register plugin admin routes (requires ORM/DB — cannot run at import time)
+        # Plugin-specific routes FIRST so they take priority over the
+        # generic /plugins/{plugin_name} catch-all.
         plugin_registry.register_plugin_routes(app)
+        app.include_router(plugins.router, prefix="/plugins", tags=["plugins"])
         logger.info("Admin: plugin admin routes registered")
 
         # Initialize OAuth2 database (requires PostgreSQL)


### PR DESCRIPTION
## Summary
- Plugin-specific admin routes (`/plugins/ms365`, `/plugins/github`, etc.) were shadowed by the generic `/plugins/{plugin_name}` catch-all, which was registered at module level before plugin routes (registered during startup)
- Moved `plugins.router` registration into the startup handler, after `register_plugin_routes()`, so specific routes take priority
- Affects all plugins with custom admin pages (ms365, github, gmail, agentic-development, etc.)

## Test plan
- [ ] Verify `/plugins/ms365` shows custom tenant management page (not generic config form)
- [ ] Verify `/plugins/github` shows custom repo management page
- [ ] Verify `/plugins/` list page still works
- [ ] Verify plugin enable/disable/reload still works