### PR TITLE
[ADD] main: fire ON_STARTUP hook at initial boot

### DIFF
--- a/main.py
+++ b/main.py
@@ -1157,6 +1157,9 @@ async def main():
         logger.error(f"Failed to provision MCP gateway tokens: {e}")
         logger.warning("Agents will run without MCP gateway access")
 
+    # Fire lifecycle hooks — let plugins self-wire after agents are loaded
+    await plugin_manager.hooks.execute(HookName.ON_STARTUP, {})
+
     def signal_handler():
         logger.info("Shutdown signal received")
         stop_event.set()


### PR DESCRIPTION
## Summary
- Fires `HookName.ON_STARTUP` after MCP token provisioning during initial boot
- Mirrors the existing pattern at agent reload (line 908)

## Context
Plugins using `@hook("on_startup")` for self-wiring (heartbeat, video-call, adversarial) only executed their hook on agent **reload**, not on first boot. This meant they required a manual reload to function.

## Test plan
- [x] Bot starts without errors
- [x] Plugins with on_startup hooks self-wire at boot (verified via logs)
- [x] Agent reload still fires the hook as before