### PR TITLE
[ADD] agent: get_channel_names() helper

### DIFF
--- a/core/agent.py
+++ b/core/agent.py
@@ -228,6 +228,10 @@ class Agent:
         """Get channel by platform name."""
         return self._channels.get(platform)
 
+    def get_channel_names(self) -> list[str]:
+        """Return list of available channel platform names."""
+        return list(self._channels.keys())
+
     def add_service(self, name: str, service: "BaseService") -> None:
         """Add a per-agent service instance.
 


### PR DESCRIPTION
## Summary
- Adds `get_channel_names()` method to `Agent` class
- Returns list of channel names configured for the agent

## Context
Heartbeat and cron services need to discover available delivery channels when no explicit channel is configured. This helper avoids direct `_channels` dict access from external code.

## Test plan
- [x] Heartbeat service uses it for fallback channel discovery
- [ ] Unit test in `tests/unit/test_agent_channel_names.py` (follow-up)