### PR TITLE
[FIX] gitignore: update avatar/icon paths after admin→ui rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,10 +97,10 @@ temp/
 *.backup
 
 # Generated PWA icons
-admin/static/icons/
+ui/static/icons/
 
 # Uploaded avatars
-admin/static/avatars/
+ui/static/avatars/
 
 # Serena IDE config
 .serena/

--- a/tests/unit/test_agent_channel_names.py
+++ b/tests/unit/test_agent_channel_names.py
@@ -1,0 +1,26 @@
+"""Test Agent.get_channel_names() method."""
+
+from unittest.mock import MagicMock
+
+
+def test_get_channel_names_returns_list():
+    """get_channel_names() returns list of channel platform names."""
+    from core.agent import Agent
+
+    agent = Agent.__new__(Agent)
+    agent._channels = {"telegram": MagicMock(), "discord": MagicMock()}
+
+    result = agent.get_channel_names()
+
+    assert isinstance(result, list)
+    assert sorted(result) == ["discord", "telegram"]
+
+
+def test_get_channel_names_empty():
+    """get_channel_names() returns empty list when no channels."""
+    from core.agent import Agent
+
+    agent = Agent.__new__(Agent)
+    agent._channels = {}
+
+    assert agent.get_channel_names() == []


### PR DESCRIPTION
## Summary
- Updates `.gitignore` avatar and icon paths from `admin/static/` to `ui/static/`
- Adds unit test for `Agent.get_channel_names()` helper

## Context
After the `admin/` → `ui/` directory rename, uploaded avatars and generated icons were no longer ignored by git. This caused `ui/static/avatars/peggy.jpg` to appear as untracked.

## Test plan
- [x] `ui/static/avatars/` files no longer appear in `git status`
- [x] `pytest tests/unit/test_agent_channel_names.py` passes