### PR TITLE
[FIX] docker: scope uvicorn reload watcher to source dirs

### DIFF
--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -17,7 +17,18 @@ services:
 
   ui:
     init: true
-    command: uvicorn ui.app:app --host 0.0.0.0 --port 8080 --reload --timeout-graceful-shutdown 5
+    command: >
+      uvicorn ui.app:app --host 0.0.0.0 --port 8080
+      --reload
+      --reload-dir /app/ui
+      --reload-dir /app/core
+      --reload-dir /app/plugins
+      --reload-exclude '*.pyc'
+      --reload-exclude '__pycache__'
+      --reload-exclude '.ruff_cache'
+      --reload-exclude '.pytest_cache'
+      --reload-exclude 'data/*'
+      --timeout-graceful-shutdown 5
 
   # Sandboxed code execution (no internet access)
   executor:


### PR DESCRIPTION
## Summary
- Restricts `--reload` watcher to `/app/ui`, `/app/core`, `/app/plugins`
- Excludes `*.pyc`, `__pycache__`, `.ruff_cache`, `.pytest_cache`, `data/*`

## Context
Unrestricted `--reload` monitors the entire `/app/` directory including `data/`, Playwright screenshots, and volume mounts. The `watchfiles` library can enter a busy loop on Docker volume mounts, pinning the uvicorn spawn worker at 100% CPU indefinitely. This has happened multiple times in dev.

## Test plan
- [x] UI container starts normally with scoped reload
- [x] Reload still triggers on code changes in `ui/`, `core/`, `plugins/`
- [x] CPU stays normal after extended uptime