### PR TITLE
[FIX] ui: move portal routes registration to startup event

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -424,9 +424,7 @@ def get_template_context(request: Request, **kwargs) -> dict:
 
 
 app.include_router(ws_chat.router, tags=["webchat"])  # /ws/chat (WebSocket, no prefix)
-# Register plugin portal routes BEFORE me.router so specific portal routes
-# (e.g. /me/workflows, /me/connections/whatsapp/*) take priority over catch-alls
-plugin_registry.register_portal_routes(app)
+# Plugin portal routes registered in startup event (requires ORM for get_enabled_plugins)
 app.include_router(me.router, tags=["user-portal"])  # /me/* (before auth prefix)
 app.include_router(chat_api.router, tags=["chat-api"])  # /me/chat/api/*
 app.include_router(chat_proxy.router, tags=["chat-proxy"])  # /api/proxy/chat
@@ -872,6 +870,9 @@ async def startup_cleanup():
         # Reload template loader now that DB is available (theme from SystemConfig)
         rebuild_template_loader()
         logger.info("Admin: template loader rebuilt with active theme")
+
+        # Register plugin portal routes (requires ORM/DB for get_enabled_plugins)
+        plugin_registry.register_portal_routes(app)
 
         # Register plugin admin routes (requires ORM/DB — cannot run at import time)
         # Plugin-specific routes FIRST so they take priority over the


### PR DESCRIPTION
## Summary
- `register_portal_routes()` was called at import-time (line 429) but depends on ORM for `get_enabled_plugins()` which queries PostgreSQL
- ORM is initialized in the startup event — the call silently failed (exception caught, empty list returned)
- **All** plugin portal routes (`/me/workflows`, `/me/connections/whatsapp/*`, gmail portal) were broken
- Fix: move the call to the startup event, alongside `register_plugin_routes()` which already had this pattern

## Test plan
- [ ] Navigate to `/me/workflows` — should load workflow list (was returning `{"detail":"Not Found"}`)
- [ ] Verify logs show `Registered portal routes for plugin: workflow` (and gmail, whatsapp)
- [ ] Verify other `/me/` pages still work (profile, connections, tools, chat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)