### PR TITLE
Fix agents list collaboration label

### DIFF
--- a/ui/templates/agents/list.html
+++ b/ui/templates/agents/list.html
@@ -186,7 +186,7 @@
             </div>
             <div>
                 <div class="text-sm font-medium text-void-900 dark:text-white">Collaboration</div>
-                <div class="text-xs text-void-500 dark:text-void-400">[ASK_AGENT: id]</div>
+                <div class="text-xs text-void-500 dark:text-void-400">ask_agent tool (built-in)</div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- Update collaboration info from obsolete `[ASK_AGENT: id]` tag syntax to `ask_agent tool (built-in)`

## Test plan
- [ ] `/agents` page shows correct label in Multi-Agent Architecture card