### PR TITLE
[FIX] mcp_gateway: skip virtual transport providers

### DIFF
--- a/core/mcp_gateway/provider_loader.py
+++ b/core/mcp_gateway/provider_loader.py
@@ -40,6 +40,8 @@ def _classify_transport(config: dict) -> str:
     if "command" in config:
         return "stdio"
     cfg_type = config.get("type", "")
+    if cfg_type == "virtual":
+        return "virtual"  # handled by LocalToolProvider, no MCP server
     if cfg_type == "sse":
         return "sse"
     if cfg_type == "http":
@@ -329,6 +331,8 @@ def _expand_server_config(
     if _is_single_server_config(server_config):
         # Single server - use provider name as server name
         transport = _classify_transport(server_config)
+        if transport == "virtual":
+            return  # handled by LocalToolProvider, no MCP server to connect
         servers[provider_name] = ServerInfo(
             server_name=provider_name,
             config=server_config,


### PR DESCRIPTION
## Summary
- Add `virtual` transport type to `_classify_transport()` in provider_loader.py
- Skip server registration for virtual providers in `_expand_server_config()`
- Eliminates spurious `connection failed for hetzner: 'command'` errors in gateway logs

Providers returning `{"type": "virtual"}` from `get_server_config()` are handled entirely by `LocalToolProvider` — there is no MCP server process to connect to. Without this fix, the gateway tries to create a stdio session from the virtual config and logs connection errors.

## Test plan
- [x] `docker compose up -d --build ui` — no `connection failed` errors for virtual providers
- [x] Virtual tools still registered and functional (25 hetzner tools tested)
- [x] Non-virtual providers (HA, gmail, github) unaffected