### PR TITLE
Fix MCP user identity propagation for user-aware servers

### DIFF
--- a/core/mcp_gateway/client_manager.py
+++ b/core/mcp_gateway/client_manager.py
@@ -1155,13 +1155,10 @@ class MCPClientManager:
             import json
 
             from core.mcp_gateway.provider_loader import (
-                PLUGINS_CONFIG,
                 _get_plugins_dir,
                 _load_provider_class,
             )
-
-            with open(PLUGINS_CONFIG) as f:
-                config = json.load(f)
+            from ui.plugin_helpers import load_plugin_config
 
             plugins_dir = _get_plugins_dir()
             # Use plugin_dir (actual directory name) instead of provider_name
@@ -1174,7 +1171,7 @@ class MCPClientManager:
 
                 provider_cls = _load_provider_class(plugin_dir, manifest)
                 if provider_cls and hasattr(provider_cls, "get_user_server_config"):
-                    plugin_config = config.get(plugin_dir, {})
+                    plugin_config = load_plugin_config(plugin_dir)
                     provider = provider_cls(plugin_config)
                     return provider.get_user_server_config(unified_id, credentials)
         except Exception as e:
@@ -1186,7 +1183,11 @@ class MCPClientManager:
 
         # Fallback: use global config with injected auth header
         base_config = dict(server_info.config)
-        token = credentials.get("token") or credentials.get("api_key")
+        token = (
+            credentials.get("access_token")
+            or credentials.get("token")
+            or credentials.get("api_key")
+        )
         if token and "url" in base_config:
             headers = dict(base_config.get("headers") or {})
             headers["Authorization"] = f"Bearer {token}"

--- a/plugins/claude/runner.py
+++ b/plugins/claude/runner.py
@@ -360,6 +360,10 @@ class ClaudeRunner(BaseRunner):
         # Fall back to subprocess mode
         feedback_task = None
 
+        # Tell MCP gateway which user is making this request
+        if unified_id:
+            await self._set_user_context(agent_id or "", unified_id)
+
         try:
             cmd = self._build_command(
                 prompt,
@@ -762,5 +766,9 @@ class ClaudeRunner(BaseRunner):
                 )
                 if resp.status_code != 200:
                     logger.warning("Set user context failed: HTTP %d", resp.status_code)
+                else:
+                    logger.debug(
+                        "Set user context: agent=%s user=%s", agent_id, unified_id
+                    )
         except Exception as e:
             logger.warning("Set user context failed: %s", e)


### PR DESCRIPTION
## Summary
- Fix subprocess mode missing `_set_user_context` call — user-aware MCP servers (Odoo, etc.) couldn't load per-user OAuth tokens
- Fix `_build_user_config` importing removed `PLUGINS_CONFIG` — provider `get_user_server_config()` was silently skipped after plugins.json→DB migration
- Add `access_token` to credential fallback lookup (OAuth tokens use `access_token`, not `token`)

## Test plan
- [ ] Webchat message → Peggy can use Odoo MCP tools with user's OAuth token
- [ ] `docker compose logs ui | grep "user context set"` shows correct user
- [ ] `docker compose logs ui | grep "Odoo user config"` shows provider being called