### PR TITLE
[ADD] Agent email settings, webchat agent sorting, throttle fix

### DIFF
--- a/sessions/context_builder.py
+++ b/sessions/context_builder.py
@@ -483,6 +483,7 @@ class ContextBuilder:
         sender_name = self._agent_email_settings.get(
             "sender_name", self._agent_display_name or "Assistant"
         )
+        sender_alias = self._agent_email_settings.get("from_alias", "")
         signature = self._agent_email_settings.get("signature", "")
 
         # Derive MCP server name from account
@@ -492,16 +493,29 @@ class ContextBuilder:
 You have your own email account: {account}.
 When sending emails on your own behalf (not on behalf of the user), ALWAYS use:
 - Server: {server_name}
-- from_name: {sender_name}
+- from_name: {sender_name}"""
 
-Example: mcp__{server_name}__send_email with from_name="{sender_name}"
+        if sender_alias:
+            email_ctx += f"""
+- from_alias: {sender_alias}
 
-This applies to:
-- Responding to support requests received at your address
-- Sending notifications or updates as {self._agent_display_name or "yourself"}
-- Any email where YOU are the sender, not the user
+Example: mcp__{server_name}__send_email with from_alias="{sender_alias}" and from_name="{sender_name}" """
+        else:
+            email_ctx += f"""
 
-Only use the user's email account when they explicitly ask you to send an email as them."""
+Example: mcp__{server_name}__send_email with from_name="{sender_name}" """
+
+        email_ctx += f"""
+
+ALWAYS prefer sending from YOUR account ({account}) by default.
+This applies to ALL emails unless the user EXPLICITLY asks you to send from their account.
+Including:
+- Responding to support requests
+- Sending notifications or updates
+- Forwarding information
+- Any email the user asks you to send (use your account, not theirs)
+
+Only use the user's personal email account when they EXPLICITLY say "send from my account" or "send as me"."""
 
         if signature:
             email_ctx += f"""

--- a/ui/app.py
+++ b/ui/app.py
@@ -16,7 +16,7 @@ from config.logging_config import logger
 # ── Throttle anyio _deliver_cancellation (CPU leak fix) ─────────────
 # When a CancelScope cancels tasks blocked on slow I/O (MCP SSE/stdio),
 # anyio retries via call_soon() — a tight loop burning 100% CPU.
-# Replacing with call_later(0.01) adds 10ms between retries (~0% CPU).
+# Replacing with call_later(1.0) adds 1s between retries (~0% CPU).
 _orig_deliver_cancellation = _anyio_asyncio.CancelScope._deliver_cancellation
 
 
@@ -25,7 +25,7 @@ def _throttled_deliver_cancellation(self, origin):
     if origin is self and self._cancel_handle is not None:
         self._cancel_handle.cancel()
         self._cancel_handle = get_running_loop().call_later(
-            0.01, self._deliver_cancellation, origin
+            1.0, self._deliver_cancellation, origin
         )
     return result
 

--- a/ui/routes/agents.py
+++ b/ui/routes/agents.py
@@ -481,6 +481,10 @@ async def save_agent_config(
     voice_id: str = Form(""),
     voice_language: str = Form(""),
     image_provider: str = Form(""),
+    email_account: str = Form(""),
+    email_sender_name: str = Form(""),
+    email_from_alias: str = Form(""),
+    email_signature: str = Form(""),
     mcp_permissions: list[str] = Form([]),
     plugins_enabled: list[str] = Form([]),
     # Tool management
@@ -582,6 +586,16 @@ async def save_agent_config(
         config["image"] = {"provider": image_provider}
 
     # Email settings
+    if email_account.strip():
+        email_cfg = {"account": email_account.strip()}
+        if email_sender_name.strip():
+            email_cfg["sender_name"] = email_sender_name.strip()
+        if email_from_alias.strip():
+            email_cfg["from_alias"] = email_from_alias.strip()
+        if email_signature.strip():
+            email_cfg["signature"] = email_signature.strip()
+        config["email"] = email_cfg
+
     # MCP permissions - always save what form sends (allows deselecting all)
     config["mcp_permissions"] = mcp_permissions
 

--- a/ui/routes/me.py
+++ b/ui/routes/me.py
@@ -91,6 +91,36 @@ def _get_user_agents(user: dict) -> list[dict]:
                 }
             )
 
+    # Sort by last conversation activity (most recent first)
+    if agents:
+        try:
+            from core.registry import get_database
+
+            db = get_database()
+            if db:
+                uid = username
+                with db.acquire_sync() as conn:
+                    cur = conn.execute(
+                        """SELECT agent_name, MAX(updated_at) AS last_active
+                           FROM chat.webchat_conversations
+                           WHERE unified_id = %s
+                           GROUP BY agent_name""",
+                        (uid,),
+                    )
+                    last_active = {
+                        row["agent_name"]: row["last_active"] for row in cur.fetchall()
+                    }
+                if last_active:
+                    from datetime import datetime, timezone
+
+                    epoch = datetime.min.replace(tzinfo=timezone.utc)
+                    agents.sort(
+                        key=lambda a: last_active.get(a["name"], epoch),
+                        reverse=True,
+                    )
+        except Exception:
+            pass
+
     return agents
 
 

--- a/ui/templates/agents/edit.html
+++ b/ui/templates/agents/edit.html
@@ -277,6 +277,50 @@
         </div>
     </div>
 
+    <!-- Email -->
+    <div class="rounded-2xl bg-white dark:bg-void-900/50 border border-void-200 dark:border-void-800 overflow-hidden">
+        <div class="p-5 border-b border-void-200 dark:border-void-800 bg-gradient-to-r from-blue-500/5 to-transparent">
+            <h3 class="font-semibold text-void-900 dark:text-white flex items-center gap-2">
+                <i class="fas fa-envelope text-blue-500"></i>
+                Email
+            </h3>
+            <p class="text-sm text-void-500 dark:text-void-400 mt-1">Agent's own email identity for sending emails</p>
+        </div>
+        <div class="p-5">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+                <div class="space-y-2">
+                    <label class="block text-sm font-medium text-void-700 dark:text-void-200">Email Account (Gmail MCP)</label>
+                    <input type="text" name="email_account"
+                           value="{{ agent.email.account if agent and agent.email else '' }}"
+                           placeholder="hello@dubhe.it"
+                           class="w-full bg-void-50 dark:bg-void-800/50 border border-void-200 dark:border-void-700 rounded-xl py-2.5 px-4 text-void-900 dark:text-white placeholder-void-400 dark:placeholder-void-500 focus:outline-none focus:border-nordic-500/50 transition-all">
+                    <p class="text-xs text-void-500 dark:text-void-400">The Gmail account used to send (must be in MCP permissions)</p>
+                </div>
+                <div class="space-y-2">
+                    <label class="block text-sm font-medium text-void-700 dark:text-void-200">Sender Name</label>
+                    <input type="text" name="email_sender_name"
+                           value="{{ agent.email.sender_name if agent and agent.email else '' }}"
+                           placeholder="Supporto Dubhe"
+                           class="w-full bg-void-50 dark:bg-void-800/50 border border-void-200 dark:border-void-700 rounded-xl py-2.5 px-4 text-void-900 dark:text-white placeholder-void-400 dark:placeholder-void-500 focus:outline-none focus:border-nordic-500/50 transition-all">
+                </div>
+                <div class="space-y-2">
+                    <label class="block text-sm font-medium text-void-700 dark:text-void-200">From Alias</label>
+                    <input type="text" name="email_from_alias"
+                           value="{{ agent.email.from_alias if agent and agent.email else '' }}"
+                           placeholder="peggy@dubhe.it"
+                           class="w-full bg-void-50 dark:bg-void-800/50 border border-void-200 dark:border-void-700 rounded-xl py-2.5 px-4 text-void-900 dark:text-white placeholder-void-400 dark:placeholder-void-500 focus:outline-none focus:border-nordic-500/50 transition-all">
+                    <p class="text-xs text-void-500 dark:text-void-400">The "from" address shown to recipients (alias of the account)</p>
+                </div>
+                <div class="space-y-2 md:col-span-2">
+                    <label class="block text-sm font-medium text-void-700 dark:text-void-200">Signature</label>
+                    <textarea name="email_signature" rows="4"
+                              placeholder="--&#10;Peggy | Assistente Virtuale&#10;Dubhe Srls"
+                              class="w-full bg-void-50 dark:bg-void-800/50 border border-void-200 dark:border-void-700 rounded-xl py-2.5 px-4 text-void-900 dark:text-white placeholder-void-400 dark:placeholder-void-500 focus:outline-none focus:border-nordic-500/50 transition-all resize-y">{{ agent.email.signature if agent and agent.email and agent.email.signature else '' }}</textarea>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- MCP Permissions -->
     <div class="rounded-2xl bg-white dark:bg-void-900/50 border border-void-200 dark:border-void-800 overflow-hidden">
         <div class="p-5 border-b border-void-200 dark:border-void-800 bg-gradient-to-r from-ember-500/5 to-transparent">


### PR DESCRIPTION
## Summary
- Restore email settings in agent editor (account, sender_name, from_alias, signature)
- Context builder injects from_alias and instructs runner to prefer agent's own email account
- Webchat agent list sorted by last conversation activity (most recent first)
- Increase anyio cancellation throttle from 10ms to 1s

## Test plan
- [x] Email fields visible in agent editor, saved to YAML
- [x] Peggy uses from_alias and signature when sending emails
- [x] Webchat shows most-recently-used agent first
- [x] CPU stays stable with 1s throttle