### PR TITLE
[ADD] Webchat context, channel metadata, Drive comments, timeout fixes

### DIFF
--- a/core/interfaces/channel.py
+++ b/core/interfaces/channel.py
@@ -26,6 +26,8 @@ class Message:
         False  # If True, response will be TTS - no emojis/special chars
     )
     is_group_chat: bool = False
+    context_prompt: str | None = None
+    channel_metadata: dict = field(default_factory=dict)
 
 
 @dataclass

--- a/core/internal_api/server.py
+++ b/core/internal_api/server.py
@@ -34,6 +34,8 @@ class ChatRequest(BaseModel):
     platform: str = "webchat"
     agent_name: str
     attachments: list[str] = []
+    context_prompt: str | None = None
+    channel_metadata: dict = {}
 
 
 @router.post("/chat")
@@ -94,6 +96,8 @@ async def chat(
         text=request.text,
         attachments=request.attachments,
         platform=request.platform,
+        context_prompt=request.context_prompt,
+        channel_metadata=request.channel_metadata,
     )
 
     user_info = UserInfo(
@@ -200,7 +204,7 @@ async def rlm_query(
                 use_pool=False,
                 model=request.model or None,
             ),
-            timeout=120.0,
+            timeout=900.0,
         )
         return api_ok(
             data={

--- a/main.py
+++ b/main.py
@@ -109,12 +109,20 @@ class MessageProcessor:
 
         session = None
         if sessions_service:
+            # For webchat, use conversation_id as session key so each
+            # conversation gets its own runner session (separate Claude context).
+            session_user_id = user_info.user_id
+            session_platform = message.platform
+            conv_id = message.channel_metadata.get("conversation_id")
+            if conv_id and message.platform == "webchat":
+                session_platform = f"webchat:{conv_id}"
+
             session = await sessions_service.get_session(
-                user_info.user_id, message.platform
+                session_user_id, session_platform
             )
             if not session:
                 session = await sessions_service.create_session(
-                    user_info.user_id, message.platform
+                    session_user_id, session_platform
                 )
                 # HOOK: on_session_created
                 await self.hooks.execute(
@@ -179,6 +187,10 @@ class MessageProcessor:
         builder.set_plugin_context(
             await self.plugin_manager.get_all_context_injections(unified_id=unified_id)
         )
+        if message.context_prompt:
+            builder.set_conversation_context(message.context_prompt)
+        if message.channel_metadata:
+            builder.set_channel_metadata(message.channel_metadata)
 
         if hook_data.attachments:
             for attachment in hook_data.attachments:
@@ -318,10 +330,24 @@ class MessageProcessor:
                 )
 
                 memory_content = f"User: {user_text}\nAssistant: {assistant_text}"
+                mem_metadata = {}
+                if message.channel_metadata:
+                    mem_metadata["channel"] = message.channel_metadata.get(
+                        "channel", ""
+                    )
+                    if message.channel_metadata.get("conversation_id"):
+                        mem_metadata["conversation_id"] = message.channel_metadata[
+                            "conversation_id"
+                        ]
+                    if message.channel_metadata.get("conversation_context"):
+                        mem_metadata["conversation_context"] = message.channel_metadata[
+                            "conversation_context"
+                        ]
                 asyncio.create_task(
                     memory_service.add_declarative_memory(
                         content=memory_content,
                         user_id=unified_id,
+                        metadata=mem_metadata if mem_metadata else None,
                     )
                 )
 
@@ -430,12 +456,20 @@ class AgentAwareMessageProcessor(MessageProcessor):
 
         session = None
         if sessions_service:
+            # For webchat, use conversation_id as session key so each
+            # conversation gets its own runner session (separate Claude context).
+            session_user_id = user_info.user_id
+            session_platform = message.platform
+            conv_id = message.channel_metadata.get("conversation_id")
+            if conv_id and message.platform == "webchat":
+                session_platform = f"webchat:{conv_id}"
+
             session = await sessions_service.get_session(
-                user_info.user_id, message.platform
+                session_user_id, session_platform
             )
             if not session:
                 session = await sessions_service.create_session(
-                    user_info.user_id, message.platform
+                    session_user_id, session_platform
                 )
                 await self.hooks.execute(
                     HookName.ON_SESSION_CREATED,
@@ -524,6 +558,11 @@ class AgentAwareMessageProcessor(MessageProcessor):
         builder.set_agent_email_settings(self.agent_context.get("email"))
         # Set tool loading mode (full or search)
         builder.set_tool_loading(self.agent_context.get("tool_loading", "full"))
+        # Set per-conversation context if provided
+        if message.context_prompt:
+            builder.set_conversation_context(message.context_prompt)
+        if message.channel_metadata:
+            builder.set_channel_metadata(message.channel_metadata)
 
         # Inject inter-agent context if multi-agent
         if not ctx_opts.get("skip_inter_agent"):
@@ -720,10 +759,24 @@ class AgentAwareMessageProcessor(MessageProcessor):
                 )
 
                 memory_content = f"User: {user_text}\nAssistant: {assistant_text}"
+                mem_metadata = {}
+                if message.channel_metadata:
+                    mem_metadata["channel"] = message.channel_metadata.get(
+                        "channel", ""
+                    )
+                    if message.channel_metadata.get("conversation_id"):
+                        mem_metadata["conversation_id"] = message.channel_metadata[
+                            "conversation_id"
+                        ]
+                    if message.channel_metadata.get("conversation_context"):
+                        mem_metadata["conversation_context"] = message.channel_metadata[
+                            "conversation_context"
+                        ]
                 asyncio.create_task(
                     memory_service.add_declarative_memory(
                         content=memory_content,
                         user_id=unified_id,
+                        metadata=mem_metadata if mem_metadata else None,
                     )
                 )
 

--- a/plugins/claude/api_backend.py
+++ b/plugins/claude/api_backend.py
@@ -56,7 +56,9 @@ class ClaudeApiBackend:
     def __init__(self, config: dict):
         self.config = config
         self.model = config.get("model", os.getenv("CLAUDE_MODEL", "sonnet"))
-        self.timeout = config.get("timeout", 120)
+        self.timeout = config.get(
+            "timeout", int(os.getenv("CLAUDE_TIMEOUT_SECONDS", "900"))
+        )
         self.max_output_tokens = config.get("max_output_tokens", 8192)
         self.max_tool_iterations = config.get("max_tool_iterations", 20)
         self.max_retries = config.get("max_retries", 2)

--- a/plugins/claude/runner.py
+++ b/plugins/claude/runner.py
@@ -43,7 +43,7 @@ class ClaudeRunner(BaseRunner):
         super().__init__(config)
         self.model = config.get("model", os.getenv("CLAUDE_MODEL", "sonnet"))
         self.timeout = config.get(
-            "timeout", int(os.getenv("CLAUDE_TIMEOUT_SECONDS", "600"))
+            "timeout", int(os.getenv("CLAUDE_TIMEOUT_SECONDS", "900"))
         )
         self.max_retries = config.get("max_retries", 2)
         # Send "processing" message after this many seconds
@@ -446,15 +446,13 @@ class ClaudeRunner(BaseRunner):
                 except asyncio.TimeoutError:
                     logger.error(f"Claude CLI timed out after {self.timeout}s")
 
-                    # Notify about timeout
+                    # Notify about timeout (never include prompt content)
                     await self._notify_error_with_callback(
                         error_cb,
                         "timeout",
                         {
                             "timeout_seconds": self.timeout,
-                            "session_id": session_id,
                             "attempt": attempt + 1,
-                            "prompt_preview": prompt[:200] if prompt else "",
                         },
                     )
 

--- a/plugins/discord/adapter.py
+++ b/plugins/discord/adapter.py
@@ -760,6 +760,11 @@ class DiscordChannel(BaseChannel):
                 platform="discord",
                 respond_with_voice=True,
                 is_group_chat=not is_dm,
+                channel_metadata={
+                    "channel": "discord",
+                    "chat_id": str(user_id),
+                    "chat_type": "dm" if is_dm else "guild",
+                },
             )
             user_info = UserInfo(
                 user_id=user_id,
@@ -904,6 +909,11 @@ class DiscordChannel(BaseChannel):
                 attachments=attachment_paths,
                 platform="discord",
                 is_group_chat=not is_dm,
+                channel_metadata={
+                    "channel": "discord",
+                    "chat_id": str(user_id),
+                    "chat_type": "dm" if is_dm else "guild",
+                },
             )
             user_info = UserInfo(
                 user_id=user_id,
@@ -996,6 +1006,11 @@ class DiscordChannel(BaseChannel):
             text=content,
             platform="discord",
             is_group_chat=not is_dm,
+            channel_metadata={
+                "channel": "discord",
+                "chat_id": str(user_id),
+                "chat_type": "dm" if is_dm else "guild",
+            },
         )
         user_info = UserInfo(
             user_id=user_id,
@@ -1328,6 +1343,11 @@ class DiscordChannel(BaseChannel):
             username=username,
             text=prompt,
             platform="discord",
+            channel_metadata={
+                "channel": "discord",
+                "chat_id": str(user_id),
+                "chat_type": "scheduled",
+            },
         )
         user_info = UserInfo(
             user_id=user_id,

--- a/plugins/gmail/server.py
+++ b/plugins/gmail/server.py
@@ -501,7 +501,7 @@ class GmailMCPServer:
         body = self._get_text_content(payload)
         attachments = self._get_attachments(payload)
 
-        return {
+        result = {
             "id": response.get("id"),
             "subject": self._get_header(headers, "Subject"),
             "from": self._get_header(headers, "From"),
@@ -512,6 +512,10 @@ class GmailMCPServer:
             "hasAttachments": len(attachments) > 0,
             "attachmentCount": len(attachments),
         }
+        cc = self._get_header(headers, "Cc")
+        if cc:
+            result["cc"] = cc
+        return result
 
     def list_attachments(self, message_id: str) -> list:
         """List attachments of an email."""

--- a/plugins/google-workspace/server.py
+++ b/plugins/google-workspace/server.py
@@ -1167,6 +1167,89 @@ class GoogleWorkspaceMCPServer:
                     "required": ["file_id"],
                 },
             },
+            {
+                "name": "drive_list_comments",
+                "description": f"List comments on a Google Drive file ({email}). "
+                "Returns comment text, author, replies, and resolved status.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "file_id": {
+                            "type": "string",
+                            "description": "Google Drive file ID",
+                        },
+                        "include_resolved": {
+                            "type": "boolean",
+                            "description": "Include resolved comments (default: false)",
+                            "default": False,
+                        },
+                    },
+                    "required": ["file_id"],
+                },
+            },
+            {
+                "name": "drive_add_comment",
+                "description": f"Add a comment to a Google Drive file ({email}). "
+                "Optionally anchor to specific content in Google Docs.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "file_id": {
+                            "type": "string",
+                            "description": "Google Drive file ID",
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "Comment text",
+                        },
+                        "quoted_content": {
+                            "type": "string",
+                            "description": "Text in the document to anchor the comment to (optional)",
+                        },
+                    },
+                    "required": ["file_id", "content"],
+                },
+            },
+            {
+                "name": "drive_reply_comment",
+                "description": f"Reply to an existing comment on a Google Drive file ({email}).",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "file_id": {
+                            "type": "string",
+                            "description": "Google Drive file ID",
+                        },
+                        "comment_id": {
+                            "type": "string",
+                            "description": "Comment ID to reply to",
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "Reply text",
+                        },
+                    },
+                    "required": ["file_id", "comment_id", "content"],
+                },
+            },
+            {
+                "name": "drive_resolve_comment",
+                "description": f"Resolve (close) a comment on a Google Drive file ({email}).",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "file_id": {
+                            "type": "string",
+                            "description": "Google Drive file ID",
+                        },
+                        "comment_id": {
+                            "type": "string",
+                            "description": "Comment ID to resolve",
+                        },
+                    },
+                    "required": ["file_id", "comment_id"],
+                },
+            },
         ]
 
     def _track_operation(self, name: str, args: dict, result: dict) -> None:
@@ -1543,6 +1626,28 @@ class GoogleWorkspaceMCPServer:
                 args.get("sheet"),
                 args.get("max_rows", 500),
             )
+        elif name == "drive_list_comments":
+            return self._list_comments(
+                args["file_id"],
+                args.get("include_resolved", False),
+            )
+        elif name == "drive_add_comment":
+            return self._add_comment(
+                args["file_id"],
+                args["content"],
+                args.get("quoted_content"),
+            )
+        elif name == "drive_reply_comment":
+            return self._reply_comment(
+                args["file_id"],
+                args["comment_id"],
+                args["content"],
+            )
+        elif name == "drive_resolve_comment":
+            return self._resolve_comment(
+                args["file_id"],
+                args["comment_id"],
+            )
         else:
             return {
                 "success": False,
@@ -1551,6 +1656,126 @@ class GoogleWorkspaceMCPServer:
                 "recoverable": False,
                 "retry_after": None,
             }
+
+    # ── Drive Comments ──────────────────────────────────────────────
+
+    def _list_comments(self, file_id: str, include_resolved: bool = False) -> dict:
+        """List comments on a Drive file."""
+        try:
+            comments = []
+            page_token = None
+            while True:
+                resp = (
+                    self.drive_api.comments()
+                    .list(
+                        fileId=file_id,
+                        fields="comments(id,content,author(displayName,emailAddress),"
+                        "resolved,createdTime,modifiedTime,"
+                        "replies(id,content,author(displayName,emailAddress),createdTime),"
+                        "quotedFileContent(value)),nextPageToken",
+                        includeDeleted=False,
+                        pageToken=page_token,
+                    )
+                    .execute()
+                )
+                for c in resp.get("comments", []):
+                    if not include_resolved and c.get("resolved"):
+                        continue
+                    comment = {
+                        "id": c["id"],
+                        "author": c.get("author", {}).get("displayName", ""),
+                        "author_email": c.get("author", {}).get("emailAddress", ""),
+                        "content": c.get("content", ""),
+                        "resolved": c.get("resolved", False),
+                        "created": c.get("createdTime", ""),
+                        "modified": c.get("modifiedTime", ""),
+                    }
+                    quoted = c.get("quotedFileContent", {}).get("value")
+                    if quoted:
+                        comment["quoted_text"] = quoted
+                    replies = []
+                    for r in c.get("replies", []):
+                        replies.append(
+                            {
+                                "id": r["id"],
+                                "author": r.get("author", {}).get("displayName", ""),
+                                "content": r.get("content", ""),
+                                "created": r.get("createdTime", ""),
+                            }
+                        )
+                    if replies:
+                        comment["replies"] = replies
+                    comments.append(comment)
+                page_token = resp.get("nextPageToken")
+                if not page_token:
+                    break
+            return {
+                "success": True,
+                "data": {"comments": comments, "count": len(comments)},
+            }
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    def _add_comment(
+        self, file_id: str, content: str, quoted_content: str | None = None
+    ) -> dict:
+        """Add a comment to a Drive file."""
+        try:
+            body = {"content": content}
+            if quoted_content:
+                body["quotedFileContent"] = {"value": quoted_content}
+            result = (
+                self.drive_api.comments()
+                .create(
+                    fileId=file_id, body=body, fields="id,content,author(displayName)"
+                )
+                .execute()
+            )
+            return {
+                "success": True,
+                "data": {
+                    "comment_id": result["id"],
+                    "content": result.get("content", ""),
+                },
+            }
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    def _reply_comment(self, file_id: str, comment_id: str, content: str) -> dict:
+        """Reply to a comment on a Drive file."""
+        try:
+            result = (
+                self.drive_api.replies()
+                .create(
+                    fileId=file_id,
+                    commentId=comment_id,
+                    body={"content": content},
+                    fields="id,content,author(displayName)",
+                )
+                .execute()
+            )
+            return {
+                "success": True,
+                "data": {
+                    "reply_id": result["id"],
+                    "content": result.get("content", ""),
+                },
+            }
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    def _resolve_comment(self, file_id: str, comment_id: str) -> dict:
+        """Resolve a comment on a Drive file."""
+        try:
+            self.drive_api.comments().update(
+                fileId=file_id,
+                commentId=comment_id,
+                body={"resolved": True},
+                fields="id,resolved",
+            ).execute()
+            return {"success": True, "data": {"resolved": True}}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
 
     async def handle_request(self, request: dict) -> dict:
         """Handle MCP JSON-RPC request."""

--- a/plugins/telegram/adapter.py
+++ b/plugins/telegram/adapter.py
@@ -713,6 +713,11 @@ class TelegramChannel(BaseChannel):
                 text=text,
                 platform="telegram",
                 is_group_chat=not is_private,
+                channel_metadata={
+                    "channel": "telegram",
+                    "chat_id": str(user_id),
+                    "chat_type": "private" if is_private else "group",
+                },
             )
             user_info = UserInfo(
                 user_id=user_id,
@@ -1039,6 +1044,11 @@ class TelegramChannel(BaseChannel):
                 platform="telegram",
                 respond_with_voice=True,
                 is_group_chat=not is_private,
+                channel_metadata={
+                    "channel": "telegram",
+                    "chat_id": str(user_id),
+                    "chat_type": "private" if is_private else "group",
+                },
             )
             user_info = UserInfo(
                 user_id=user_id,
@@ -1213,6 +1223,11 @@ class TelegramChannel(BaseChannel):
                 attachments=[str(attachment_path)],
                 platform="telegram",
                 is_group_chat=not is_private,
+                channel_metadata={
+                    "channel": "telegram",
+                    "chat_id": str(user_id),
+                    "chat_type": "private" if is_private else "group",
+                },
             )
             user_info = UserInfo(
                 user_id=user_id,
@@ -1318,6 +1333,11 @@ class TelegramChannel(BaseChannel):
             username=username,
             text=prompt,
             platform="telegram",
+            channel_metadata={
+                "channel": "telegram",
+                "chat_id": str(user_id),
+                "chat_type": "scheduled",
+            },
         )
         user_info = UserInfo(
             user_id=user_id,

--- a/sessions/context_builder.py
+++ b/sessions/context_builder.py
@@ -43,7 +43,14 @@ After taking a screenshot or generating a file, call the tool with:
 Example flow:
 1. Take a screenshot with playwright → get file path
 2. Call send_file_to_chat(file_path=..., chat_id=..., platform=...)
-3. The user receives the file in their chat"""
+3. The user receives the file in their chat
+
+[Google Sheets / Docs Access]
+You have two ways to access Google documents:
+- gws-* tools (e.g. gws-davide_corio_dubhe_it): use the USER's Google account (OAuth). Use these when the user asks you to access THEIR documents.
+- google-sheets tools (e.g. google-sheets__sheets_read): use YOUR service account. Use these when accessing documents shared with your SA, or when you need to comment/edit as yourself.
+
+When the user shares a Google document link with you and asks you to access it with your account or service account, ALWAYS use the google-sheets__ prefixed tools, NOT the gws-* tools."""
 
 
 def _build_email_context() -> str:
@@ -132,6 +139,18 @@ class ContextBuilder:
         self._agent_system_prompt: str | None = None
         self._agent_email_settings: dict | None = None
         self._tool_loading: str = "full"
+        self._conversation_context: str | None = None
+        self._channel_metadata: dict | None = None
+
+    def set_channel_metadata(self, metadata: dict | None) -> "ContextBuilder":
+        """Set channel/conversation metadata for message source tracking."""
+        self._channel_metadata = metadata if metadata else None
+        return self
+
+    def set_conversation_context(self, context: str | None) -> "ContextBuilder":
+        """Set per-conversation working context."""
+        self._conversation_context = context if context else None
+        return self
 
     def add_user_info(self, user_info: UserInfo) -> "ContextBuilder":
         """Add user information to context."""
@@ -560,6 +579,18 @@ When sending emails as {self._agent_display_name or "yourself"}, ALWAYS append t
             )
             parts.append(user_ctx)
 
+        # Add channel/conversation metadata
+        if self._channel_metadata:
+            channel = self._channel_metadata.get("channel", "")
+            source_parts = [f"channel: {channel}"]
+            if self._channel_metadata.get("conversation_id"):
+                source_parts.append(
+                    f"conversation_id: {self._channel_metadata['conversation_id']}"
+                )
+            if self._channel_metadata.get("chat_type"):
+                source_parts.append(f"chat_type: {self._channel_metadata['chat_type']}")
+            parts.append("[Message Source]\n" + "\n".join(source_parts))
+
         # Language instruction
         lang_name = LOCALE_NAMES.get(self._locale, self._locale.upper())
         parts.append(
@@ -669,6 +700,29 @@ When sending emails as {self._agent_display_name or "yourself"}, ALWAYS append t
                 parts.append(
                     f"[Personal Memory - Information about this user:]\n{personal_text}"
                 )
+
+        # Include per-conversation working context
+        if self._conversation_context:
+            parts.append(
+                f"[Conversation Context — IMPORTANT]\n"
+                f"This conversation is dedicated to the following scope. "
+                f"All user messages in this conversation relate to this context "
+                f"unless they explicitly say otherwise. "
+                f"If a message seems unrelated to this context, ask the user "
+                f"if they are in the right conversation before proceeding.\n\n"
+                f"{self._conversation_context}"
+            )
+        elif self._channel_metadata and self._channel_metadata.get(
+            "conversation_title"
+        ):
+            title = self._channel_metadata["conversation_title"]
+            parts.append(
+                f"[Conversation Topic]\n"
+                f'This conversation is titled "{title}". '
+                f"User messages likely relate to this topic. "
+                f"If a message seems unrelated, ask the user "
+                f"if they are in the right conversation."
+            )
 
         # Include recent chat history for conversational context
         if self._chat_history:

--- a/tests/unit/plugins/claude/test_api_backend.py
+++ b/tests/unit/plugins/claude/test_api_backend.py
@@ -72,7 +72,7 @@ class TestClaudeApiBackendInit:
             os.environ.pop("CLAUDE_MODEL", None)
             b = ClaudeApiBackend({})
         assert b.model == "sonnet"
-        assert b.timeout == 120
+        assert b.timeout == 900
         assert b.max_output_tokens == 8192
         assert b.max_tool_iterations == 20
 

--- a/ui/routes/chat_api.py
+++ b/ui/routes/chat_api.py
@@ -90,6 +90,14 @@ def _ensure_db():
         else:
             conn.rollback()
 
+    # Ensure context_prompt column exists (idempotent)
+    with _db.acquire_sync() as conn:
+        conn.execute(
+            "ALTER TABLE chat.webchat_conversations "
+            "ADD COLUMN IF NOT EXISTS context_prompt TEXT"
+        )
+        conn.commit()
+
     _initialized = True
 
 
@@ -344,6 +352,72 @@ async def delete_conversation(
         )
         conn.commit()
     return api_ok()
+
+
+# --- Conversation context ---
+
+
+@router.get(
+    "/conversations/{conv_id}/context",
+    response_model=ApiResponse[dict],
+    response_model_exclude_none=True,
+)
+async def get_context(
+    request: Request, conv_id: str, user: dict = Depends(require_user)
+):
+    """Get conversation context prompt."""
+    _ensure_db()
+    uid = _uid(user)
+    with _db.acquire_sync() as conn:
+        row = conn.execute(
+            "SELECT context_prompt FROM chat.webchat_conversations "
+            "WHERE id = %s AND unified_id = %s",
+            (conv_id, uid),
+        ).fetchone()
+        if not row:
+            return api_error(404, "Not found", "not_found")
+    return api_ok(data={"context_prompt": row["context_prompt"]})
+
+
+@router.post(
+    "/conversations/{conv_id}/context",
+    response_model=ApiResponse[dict],
+    response_model_exclude_none=True,
+)
+async def set_context(
+    request: Request, conv_id: str, user: dict = Depends(require_user)
+):
+    """Set or update conversation context prompt."""
+    _ensure_db()
+    uid = _uid(user)
+    body = await request.json()
+    context_prompt = body.get("context_prompt", "")
+
+    # Validate length
+    if isinstance(context_prompt, str) and len(context_prompt) > 2000:
+        return api_error(
+            422, "Context prompt too long (max 2000 characters)", "validation_error"
+        )
+
+    # Normalize empty → NULL
+    context_prompt = context_prompt.strip() if context_prompt else None
+    context_prompt = context_prompt or None
+
+    with _db.acquire_sync() as conn:
+        row = conn.execute(
+            "SELECT 1 FROM chat.webchat_conversations "
+            "WHERE id = %s AND unified_id = %s",
+            (conv_id, uid),
+        ).fetchone()
+        if not row:
+            return api_error(404, "Not found", "not_found")
+
+        conn.execute(
+            "UPDATE chat.webchat_conversations SET context_prompt = %s WHERE id = %s",
+            (context_prompt, conv_id),
+        )
+        conn.commit()
+    return api_ok(data={"context_prompt": context_prompt})
 
 
 # --- File upload ---

--- a/ui/routes/users.py
+++ b/ui/routes/users.py
@@ -141,6 +141,7 @@ async def create_portal_user(
     username: str = Form(...),
     password: str = Form(...),
     display_name: str = Form(default=""),
+    email: str = Form(default=""),
     is_superadmin: str = Form(default=""),
     _: bool = Depends(require_login),
 ):
@@ -160,6 +161,7 @@ async def create_portal_user(
         password_hash=hash_password(password),
         display_name=display_name.strip() or None,
         is_superadmin=is_superadmin == "1",
+        email=email.strip() or None,
     )
 
     return RedirectResponse(url="/users", status_code=303)
@@ -170,6 +172,7 @@ async def update_portal_user(
     request: Request,
     user_id: int,
     display_name: str = Form(default=""),
+    email: str = Form(default=""),
     is_superadmin: str = Form(default=""),
     is_active: str = Form(default=""),
     _: bool = Depends(require_login),
@@ -180,6 +183,7 @@ async def update_portal_user(
         display_name=display_name.strip() or None,
         is_superadmin=is_superadmin == "1",
         is_active=is_active == "1",
+        email=email.strip() or None,
     )
     return RedirectResponse(url="/users", status_code=303)
 

--- a/ui/routes/ws_chat.py
+++ b/ui/routes/ws_chat.py
@@ -5,6 +5,7 @@ Routes messages through GridBear's internal API for full pipeline processing
 (sessions, memory, hooks, context builder, runner, MCP tools).
 """
 
+import asyncio
 import json
 import os
 from pathlib import Path
@@ -21,6 +22,9 @@ GRIDBEAR_SECRET = os.getenv("INTERNAL_API_SECRET", "")
 
 # Active WebSocket connections: {uid: websocket}
 _active_connections: dict[str, WebSocket] = {}
+
+# Background tasks — prevent garbage collection
+_background_tasks: set[asyncio.Task] = set()
 
 
 async def push_to_webchat(uid: str, event: dict) -> bool:
@@ -89,11 +93,16 @@ async def _stream_from_gridbear(
     text: str,
     user: dict,
     agent_name: str,
-    websocket: WebSocket,
+    websocket: WebSocket | None,
     conversation_id: str | None = None,
     attachments: list[str] | None = None,
+    context_prompt: str | None = None,
 ) -> str:
-    """Send message to GridBear internal API and stream NDJSON events to WebSocket."""
+    """Send message to GridBear internal API and stream NDJSON events to WebSocket.
+
+    If the WebSocket disconnects mid-stream, processing continues and the
+    response is still returned (and saved by the caller).
+    """
     uid = user["username"]
 
     payload = {
@@ -105,6 +114,36 @@ async def _stream_from_gridbear(
     }
     if attachments:
         payload["attachments"] = attachments
+    if context_prompt:
+        payload["context_prompt"] = context_prompt
+    if conversation_id:
+        payload["channel_metadata"] = {
+            "channel": "webchat",
+            "conversation_id": conversation_id,
+        }
+        # Add conversation title
+        try:
+            from ui.routes.chat_api import get_conversation_title
+
+            title = get_conversation_title(conversation_id)
+            if title:
+                payload["channel_metadata"]["conversation_title"] = title
+        except Exception:
+            pass
+        if context_prompt:
+            payload["channel_metadata"]["conversation_context"] = context_prompt
+
+    ws_alive = True
+
+    async def _try_send(event):
+        """Best-effort WebSocket send — silently stops if disconnected."""
+        nonlocal ws_alive
+        if not ws_alive or not websocket:
+            return
+        try:
+            await websocket.send_json(event)
+        except Exception:
+            ws_alive = False
 
     async with aiohttp.ClientSession() as session:
         try:
@@ -112,14 +151,14 @@ async def _stream_from_gridbear(
                 f"{GRIDBEAR_URL}/api/chat",
                 json=payload,
                 headers={"Authorization": f"Bearer {GRIDBEAR_SECRET}"},
-                timeout=aiohttp.ClientTimeout(total=600),
+                timeout=aiohttp.ClientTimeout(total=1800),
             ) as resp:
                 if resp.status != 200:
                     error_text = await resp.text()
                     logger.error(
                         f"WebChat: GridBear API error {resp.status}: {error_text}"
                     )
-                    await websocket.send_json(
+                    await _try_send(
                         {
                             "type": "error",
                             "text": f"GridBear API error: {resp.status}",
@@ -138,8 +177,8 @@ async def _stream_from_gridbear(
                     except json.JSONDecodeError:
                         continue
 
-                    # Forward event to browser WebSocket
-                    await websocket.send_json(event)
+                    # Forward event to browser (best-effort)
+                    await _try_send(event)
 
                     event_type = event.get("type")
                     if event_type == "message":
@@ -152,9 +191,18 @@ async def _stream_from_gridbear(
 
                 return result_text
 
+        except asyncio.TimeoutError:
+            logger.error("WebChat: GridBear API timed out")
+            await _try_send(
+                {
+                    "type": "error",
+                    "text": "La richiesta ha impiegato troppo tempo.",
+                }
+            )
+            return ""
         except aiohttp.ClientError as e:
             logger.error(f"WebChat: connection to GridBear failed: {e}")
-            await websocket.send_json(
+            await _try_send(
                 {
                     "type": "error",
                     "text": "Impossibile contattare il servizio GridBear",
@@ -235,6 +283,7 @@ async def ws_chat(websocket: WebSocket):
             if msg_type == "message":
                 text = data.get("text", "").strip()
                 attachments = data.get("attachments") or []
+                context_prompt = data.get("context_prompt") or None
                 if not text and not attachments:
                     continue
 
@@ -245,43 +294,75 @@ async def ws_chat(websocket: WebSocket):
                 _save_message(conversation_id, "user", save_text)
 
                 # Send typing indicator immediately
-                await websocket.send_json({"type": "typing"})
-
                 try:
-                    result = await _stream_from_gridbear(
+                    await websocket.send_json({"type": "typing"})
+                except Exception:
+                    pass
+
+                # Run in background so the response is saved even if
+                # the user switches conversation (WebSocket disconnects).
+                async def _process_message(
+                    _text, _user, _agent, _ws, _conv_id, _att, _ctx
+                ):
+                    try:
+                        result = await _stream_from_gridbear(
+                            _text,
+                            _user,
+                            _agent,
+                            _ws,
+                            _conv_id,
+                            attachments=_att,
+                            context_prompt=_ctx,
+                        )
+                        if result:
+                            _save_message(_conv_id, "assistant", result)
+                            # Notify user of new message (for unread indicator)
+                            logger.info(
+                                f"WebChat: sending unread for conv={_conv_id[:8]}..."
+                            )
+                            delivered = await push_to_webchat(
+                                _user["username"],
+                                {
+                                    "type": "unread",
+                                    "conversation_id": _conv_id,
+                                },
+                            )
+                            logger.info(
+                                f"WebChat: unread delivered={delivered} "
+                                f"conv={_conv_id[:8]}..."
+                            )
+
+                        if _conv_id:
+                            from ui.routes.chat_api import get_conversation_title
+
+                            title = get_conversation_title(_conv_id)
+                            if title:
+                                try:
+                                    await _ws.send_json(
+                                        {
+                                            "type": "conversation_update",
+                                            "conversation_id": _conv_id,
+                                            "title": title,
+                                        }
+                                    )
+                                except Exception:
+                                    pass
+                    except Exception:
+                        logger.exception("WebChat: background processing error")
+
+                task = asyncio.create_task(
+                    _process_message(
                         text,
                         user,
                         agent_name,
                         websocket,
                         conversation_id,
-                        attachments=attachments if attachments else None,
+                        attachments if attachments else None,
+                        context_prompt,
                     )
-                    # Persist agent response
-                    if result:
-                        _save_message(conversation_id, "assistant", result)
-
-                    # Send updated title if it was auto-generated
-                    if conversation_id:
-                        from ui.routes.chat_api import get_conversation_title
-
-                        title = get_conversation_title(conversation_id)
-                        if title:
-                            await websocket.send_json(
-                                {
-                                    "type": "conversation_update",
-                                    "conversation_id": conversation_id,
-                                    "title": title,
-                                }
-                            )
-
-                except Exception:
-                    logger.exception("WebChat: error processing message")
-                    await websocket.send_json(
-                        {
-                            "type": "error",
-                            "text": "An error occurred processing your message",
-                        }
-                    )
+                )
+                _background_tasks.add(task)
+                task.add_done_callback(_background_tasks.discard)
 
     except WebSocketDisconnect:
         pass

--- a/ui/templates/me/chat.html
+++ b/ui/templates/me/chat.html
@@ -149,13 +149,24 @@
                 <div class="conv-item px-3 py-3 cursor-pointer flex items-start gap-2 group"
                      :class="activeConversationId === conv.id ? 'conv-active' : ''"
                      @click="selectConversation(conv)">
-                    <div class="flex-1 min-w-0">
-                        <p class="text-sm font-medium truncate"
-                           :class="activeConversationId === conv.id ? 'text-nordic-700 dark:text-nordic-300' : 'text-void-700 dark:text-void-300'"
-                           x-text="conv.title || i18n.newConversation"></p>
-                        <p class="text-[10px] text-void-400 mt-0.5" x-text="formatDate(conv.updated_at)"></p>
+                    <div class="flex-1 min-w-0 flex items-center gap-1.5">
+                        <span x-show="conv.unread"
+                              class="w-2 h-2 rounded-full bg-nordic-500 flex-shrink-0"></span>
+                        <div class="min-w-0">
+                            <p class="text-sm font-medium truncate"
+                               :class="activeConversationId === conv.id ? 'text-nordic-700 dark:text-nordic-300' : conv.unread ? 'text-nordic-600 dark:text-nordic-400 font-semibold' : 'text-void-700 dark:text-void-300'"
+                               x-text="conv.title || i18n.newConversation"></p>
+                            <p class="text-[10px] text-void-400 mt-0.5" x-text="formatDate(conv.updated_at)"></p>
+                        </div>
                     </div>
                     <div class="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-all">
+                        <button @click.stop="selectConversation(conv); contextPanelOpen = !contextPanelOpen"
+                                class="p-1 rounded-lg hover:bg-nordic-500/10 text-void-400 hover:text-nordic-500 transition-all relative"
+                                title="{{ _("Context") }}">
+                            <i class="fas fa-gear text-xs"></i>
+                            <span x-show="conv.id === activeConversationId && conversationContext"
+                                  class="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-nordic-500"></span>
+                        </button>
                         <button @click.stop="renameConversation(conv)"
                                 class="p-1 rounded-lg hover:bg-nordic-500/10 text-void-400 hover:text-nordic-500 transition-all"
                                 title="{{ _("Rename") }}">
@@ -214,6 +225,32 @@
         <!-- Active conversation -->
         <template x-if="activeConversationId">
             <div class="flex-1 flex flex-col min-h-0">
+                <!-- Context editor panel -->
+                <div x-show="contextPanelOpen" x-transition
+                     class="mb-2 p-3 rounded-xl border border-void-200 dark:border-void-800 bg-white/50 dark:bg-void-900/30">
+                    <div class="flex items-center justify-between mb-2">
+                        <span class="text-xs font-medium text-void-500">{{ _("Conversation Context") }}</span>
+                        <div class="flex items-center gap-2">
+                            <span class="text-[10px] text-void-400"
+                                  x-text="conversationContext.length + '/2000'"></span>
+                            <button @click="saveContext(); contextPanelOpen = false"
+                                    class="p-1 rounded-lg hover:bg-void-100 dark:hover:bg-void-800/50 text-void-400 hover:text-void-600 transition-all"
+                                    title="{{ _('Close') }}">
+                                <i class="fas fa-xmark text-xs"></i>
+                            </button>
+                        </div>
+                    </div>
+                    <textarea x-model="conversationContext"
+                              @blur="saveContext()"
+                              @keydown.ctrl.enter="saveContext()"
+                              maxlength="2000"
+                              rows="3"
+                              placeholder="{{ _('Describe what you are working on...') }}"
+                              class="w-full px-3 py-2 rounded-lg bg-white dark:bg-void-800/50 border border-void-200 dark:border-void-700 text-sm focus:ring-2 focus:ring-nordic-500/40 focus:border-nordic-500 outline-none transition-all resize-none"></textarea>
+                    <div x-show="contextSaving" class="text-[10px] text-nordic-500 mt-1">
+                        <i class="fas fa-circle-notch fa-spin mr-1"></i> {{ _("Saving...") }}
+                    </div>
+                </div>
                 <!-- Messages -->
                 <div id="chat-messages" class="flex-1 overflow-y-auto space-y-3 rounded-2xl border border-void-200 dark:border-void-800 bg-white/50 dark:bg-void-900/30 p-4 relative"
                      @dragover.prevent="dragOver = true"
@@ -399,6 +436,12 @@ function chatApp() {
         sidebarLoading: false,
         messagesLoading: false,
         creatingConversation: false,
+
+        // Conversation context
+        conversationContext: '',
+        lastSavedContext: '',
+        contextPanelOpen: false,
+        contextSaving: false,
 
         // Attachments
         pendingFiles: [],  // [{file, previewUrl, uploading, uploadedPath, filename}]
@@ -622,6 +665,20 @@ function chatApp() {
             self.isTyping = false;
             self.messagesLoading = true;
             self._clearPendingFiles();
+            self.conversationContext = '';
+            self.lastSavedContext = '';
+            self.contextPanelOpen = false;
+            conv.unread = false;
+
+            // Load conversation context
+            fetch('/me/chat/api/conversations/' + conv.id + '/context')
+                .then(function(r) { return r.json(); })
+                .then(function(data) {
+                    var ctx = (data.data && data.data.context_prompt) || '';
+                    self.conversationContext = ctx;
+                    self.lastSavedContext = ctx;
+                })
+                .catch(function() {});
 
             // Load history
             fetch('/me/chat/api/conversations/' + conv.id + '/messages')
@@ -771,10 +828,11 @@ function chatApp() {
                     self.isTyping = true;
                 } else if (data.type === 'error') {
                     self.isTyping = false;
+                    var errMsg = data.text || data.details || data.error_type || 'unknown error';
                     self.messages.push({
                         id: ++self.msgCounter,
                         role: 'agent',
-                        text: i18n.error + ' ' + data.text,
+                        text: i18n.error + ' ' + errMsg,
                         time: new Date().toLocaleTimeString('it-IT', {hour: '2-digit', minute: '2-digit'}),
                     });
                 } else if (data.type === 'attachment') {
@@ -798,6 +856,16 @@ function chatApp() {
                     });
                     self.isTyping = false;
                     self.$nextTick(function() { self.scrollToBottom(); });
+                } else if (data.type === 'unread') {
+                    // Mark conversation as having unread messages
+                    if (data.conversation_id !== self.activeConversationId) {
+                        for (var i = 0; i < self.conversations.length; i++) {
+                            if (self.conversations[i].id === data.conversation_id) {
+                                self.conversations[i].unread = true;
+                                break;
+                            }
+                        }
+                    }
                 } else if (data.type === 'conversation_update') {
                     // Update title in sidebar
                     for (var i = 0; i < self.conversations.length; i++) {
@@ -877,6 +945,9 @@ function chatApp() {
             };
             if (attachments.length > 0) {
                 payload.attachments = attachments;
+            }
+            if (this.conversationContext) {
+                payload.context_prompt = this.conversationContext;
             }
             this.ws.send(JSON.stringify(payload));
 
@@ -1069,6 +1140,26 @@ function chatApp() {
         toggleEnterToSend() {
             this.enterToSend = !this.enterToSend;
             localStorage.setItem('gridbear_enter_to_send', this.enterToSend ? '1' : '0');
+        },
+
+        // --- Conversation context ---
+
+        saveContext() {
+            var self = this;
+            if (self.conversationContext === self.lastSavedContext) return;
+            if (!self.activeConversationId) return;
+            self.contextSaving = true;
+            fetch('/me/chat/api/conversations/' + self.activeConversationId + '/context', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json', 'X-CSRF-Token': document.querySelector('[name=csrf_token]') ? document.querySelector('[name=csrf_token]').value : ''},
+                body: JSON.stringify({ context_prompt: self.conversationContext }),
+            })
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                self.contextSaving = false;
+                if (data.ok) self.lastSavedContext = self.conversationContext;
+            })
+            .catch(function() { self.contextSaving = false; });
         },
 
         autoResize(event) {

--- a/ui/templates/users.html
+++ b/ui/templates/users.html
@@ -135,6 +135,11 @@
                                        class="w-32 bg-white dark:bg-void-800 border border-void-200 dark:border-void-700 rounded-lg py-1.5 px-2 text-sm text-void-900 dark:text-white focus:outline-none focus:border-nordic-500/50">
                             </div>
                             <div>
+                                <label class="block text-[10px] font-medium text-void-500 mb-1">Email</label>
+                                <input type="email" name="email" value="{{ user.email or '' }}" placeholder="user@example.com"
+                                       class="w-48 bg-white dark:bg-void-800 border border-void-200 dark:border-void-700 rounded-lg py-1.5 px-2 text-sm text-void-900 dark:text-white focus:outline-none focus:border-nordic-500/50">
+                            </div>
+                            <div>
                                 <label class="block text-[10px] font-medium text-void-500 mb-1">Admin</label>
                                 <select name="is_superadmin"
                                         class="w-20 bg-white dark:bg-void-800 border border-void-200 dark:border-void-700 rounded-lg py-1.5 px-2 text-sm text-void-900 dark:text-white focus:outline-none focus:border-nordic-500/50">
@@ -329,6 +334,12 @@
                 <input type="text" name="display_name"
                        class="w-full bg-white dark:bg-void-800 border border-void-200 dark:border-void-700 rounded-lg py-2 px-3 text-sm text-void-900 dark:text-white placeholder-void-400 focus:outline-none focus:border-nordic-500/50"
                        placeholder="Mario Rossi">
+            </div>
+            <div>
+                <label class="block text-xs font-medium text-void-500 dark:text-void-400 mb-1">Email</label>
+                <input type="email" name="email"
+                       class="w-full bg-white dark:bg-void-800 border border-void-200 dark:border-void-700 rounded-lg py-2 px-3 text-sm text-void-900 dark:text-white placeholder-void-400 focus:outline-none focus:border-nordic-500/50"
+                       placeholder="mario@example.com">
             </div>
             <div>
                 <label class="block text-xs font-medium text-void-500 dark:text-void-400 mb-1">Admin</label>


### PR DESCRIPTION
## Summary
- Per-conversation context prompt (gear icon, auto-save, injected in system prompt)
- Conversation title fallback when no context prompt set
- Agent asks "right conversation?" if message seems off-topic
- Channel metadata on all messages (webchat, Telegram, Discord)
- Memory auto-tagging with channel and conversation context
- Per-conversation runner sessions (webchat conversations don't share Claude context)
- Background message processing (response saved even if user switches conversation)
- Unread indicator on conversations with new responses
- Gmail CC field in get_email
- Google Workspace Drive comment tools (list, add, reply, resolve)
- Runner timeout unified to 900s, prompt leak removed from error callback
- Error "undefined" fixed in webchat
- Email field added to user create/edit

## Test plan
- [x] Context prompt saved and injected in agent responses
- [x] Conversation title shown as topic when no context set
- [x] Agent asks about conversation mismatch
- [x] Background processing continues after conversation switch
- [x] Unread indicator appears on conversations with new responses
- [x] Different conversations have separate runner sessions
- [x] Gmail CC visible in email details
- [x] Drive comments tools work
- [x] Timeout errors show details instead of "undefined"