### PR TITLE
[ADD] Shared multi-user webchat conversations

### DIFF
--- a/core/internal_api/server.py
+++ b/core/internal_api/server.py
@@ -90,6 +90,34 @@ async def chat(
 
     processor = AgentAwareMessageProcessor(plugin_manager, agent_context)
 
+    # Fetch participant list for shared conversations
+    ch_meta = dict(request.channel_metadata) if request.channel_metadata else {}
+    conv_id = ch_meta.get("conversation_id")
+    if conv_id:
+        try:
+            from core.registry import get_database
+
+            db = get_database()
+            if db:
+                with db.acquire_sync() as conn:
+                    rows = conn.execute(
+                        "SELECT p.unified_id, u.display_name "
+                        "FROM chat.webchat_participants p "
+                        "LEFT JOIN app.users u ON u.username = p.unified_id "
+                        "WHERE p.conversation_id = %s",
+                        (conv_id,),
+                    ).fetchall()
+                    if len(rows) > 1:
+                        ch_meta["participants"] = [
+                            {
+                                "uid": r["unified_id"],
+                                "name": r["display_name"] or r["unified_id"],
+                            }
+                            for r in rows
+                        ]
+        except Exception:
+            pass
+
     message = Message(
         user_id=0,
         username=request.username,
@@ -97,7 +125,7 @@ async def chat(
         attachments=request.attachments,
         platform=request.platform,
         context_prompt=request.context_prompt,
-        channel_metadata=request.channel_metadata,
+        channel_metadata=ch_meta,
     )
 
     user_info = UserInfo(

--- a/sessions/context_builder.py
+++ b/sessions/context_builder.py
@@ -595,6 +595,12 @@ When sending emails as {self._agent_display_name or "yourself"}, ALWAYS append t
                     for p in self._channel_metadata["participants"]
                 )
                 source_parts.append(f"participants: {names}")
+                source_parts.append(
+                    "This is a shared conversation. When replying, "
+                    "always start with @username of the person you are "
+                    "responding to (e.g. @dcorio). "
+                    "You only respond when mentioned with @your_name."
+                )
             parts.append("[Message Source]\n" + "\n".join(source_parts))
 
         # Language instruction

--- a/sessions/context_builder.py
+++ b/sessions/context_builder.py
@@ -589,6 +589,12 @@ When sending emails as {self._agent_display_name or "yourself"}, ALWAYS append t
                 )
             if self._channel_metadata.get("chat_type"):
                 source_parts.append(f"chat_type: {self._channel_metadata['chat_type']}")
+            if self._channel_metadata.get("participants"):
+                names = ", ".join(
+                    f"{p['name']} (@{p['uid']})"
+                    for p in self._channel_metadata["participants"]
+                )
+                source_parts.append(f"participants: {names}")
             parts.append("[Message Source]\n" + "\n".join(source_parts))
 
         # Language instruction

--- a/ui/routes/chat_api.py
+++ b/ui/routes/chat_api.py
@@ -96,6 +96,54 @@ def _ensure_db():
             "ALTER TABLE chat.webchat_conversations "
             "ADD COLUMN IF NOT EXISTS context_prompt TEXT"
         )
+        # Shared conversations schema
+        conn.execute(
+            "ALTER TABLE chat.webchat_conversations "
+            "ADD COLUMN IF NOT EXISTS type TEXT DEFAULT 'private'"
+        )
+        conn.execute(
+            "ALTER TABLE chat.webchat_messages ADD COLUMN IF NOT EXISTS sender_id TEXT"
+        )
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS chat.webchat_participants (
+                conversation_id TEXT NOT NULL
+                    REFERENCES chat.webchat_conversations(id) ON DELETE CASCADE,
+                unified_id TEXT NOT NULL,
+                role TEXT NOT NULL DEFAULT 'member',
+                joined_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (conversation_id, unified_id)
+            )
+        """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_webchat_participants_uid
+            ON chat.webchat_participants(unified_id)
+        """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS chat.webchat_invites (
+                token TEXT PRIMARY KEY,
+                conversation_id TEXT NOT NULL
+                    REFERENCES chat.webchat_conversations(id) ON DELETE CASCADE,
+                created_by TEXT NOT NULL,
+                created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                expires_at TIMESTAMPTZ NOT NULL,
+                max_uses INTEGER DEFAULT 0,
+                use_count INTEGER DEFAULT 0
+            )
+        """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_webchat_invites_conv
+            ON chat.webchat_invites(conversation_id)
+        """)
+        # Backfill: create owner participant for existing conversations
+        conn.execute("""
+            INSERT INTO chat.webchat_participants (conversation_id, unified_id, role)
+            SELECT id, unified_id, 'owner'
+            FROM chat.webchat_conversations
+            WHERE id NOT IN (
+                SELECT conversation_id FROM chat.webchat_participants
+            )
+            ON CONFLICT DO NOTHING
+        """)
         conn.commit()
 
     _initialized = True
@@ -114,20 +162,26 @@ def _serialize_row(row: dict) -> dict:
 
 
 def save_message(
-    conversation_id: str, role: str, content: str, metadata: dict | None = None
+    conversation_id: str,
+    role: str,
+    content: str,
+    metadata: dict | None = None,
+    sender_id: str | None = None,
 ):
     """Save a message and update conversation timestamp. Auto-title if empty."""
     _ensure_db()
     encrypted_content = encrypt(content)
     with _db.acquire_sync() as conn:
         conn.execute(
-            """INSERT INTO chat.webchat_messages (conversation_id, role, content, metadata_json)
-               VALUES (%s, %s, %s, %s)""",
+            """INSERT INTO chat.webchat_messages
+               (conversation_id, role, content, metadata_json, sender_id)
+               VALUES (%s, %s, %s, %s, %s)""",
             (
                 conversation_id,
                 role,
                 encrypted_content,
                 json.dumps(metadata) if metadata else None,
+                sender_id,
             ),
         )
         conn.execute(
@@ -163,7 +217,7 @@ def get_conversation_title(conversation_id: str) -> str:
 
 
 def validate_conversation_ownership(conversation_id: str, unified_id: str) -> bool:
-    """Check that a conversation belongs to the given user."""
+    """Check that a conversation belongs to the given user (legacy — private only)."""
     _ensure_db()
     with _db.acquire_sync() as conn:
         row = conn.execute(
@@ -171,6 +225,35 @@ def validate_conversation_ownership(conversation_id: str, unified_id: str) -> bo
             (conversation_id, unified_id),
         ).fetchone()
     return row is not None
+
+
+def validate_conversation_access(conversation_id: str, uid: str) -> str | None:
+    """Check if user is a participant (owner or member). Returns role or None."""
+    _ensure_db()
+    with _db.acquire_sync() as conn:
+        row = conn.execute(
+            "SELECT role FROM chat.webchat_participants "
+            "WHERE conversation_id = %s AND unified_id = %s",
+            (conversation_id, uid),
+        ).fetchone()
+        return row["role"] if row else None
+
+
+def is_conversation_owner(conversation_id: str, uid: str) -> bool:
+    """Check if user is the owner of a conversation."""
+    return validate_conversation_access(conversation_id, uid) == "owner"
+
+
+def list_conversation_participants(conversation_id: str) -> list[str]:
+    """Return list of participant unified_ids for a conversation."""
+    _ensure_db()
+    with _db.acquire_sync() as conn:
+        rows = conn.execute(
+            "SELECT unified_id FROM chat.webchat_participants "
+            "WHERE conversation_id = %s",
+            (conversation_id,),
+        ).fetchall()
+    return [r["unified_id"] for r in rows]
 
 
 # --- REST endpoints ---
@@ -188,18 +271,24 @@ async def list_conversations(request: Request, user: dict = Depends(require_user
     with _db.acquire_sync() as conn:
         if agent:
             cur = conn.execute(
-                """SELECT id, agent_name, title, created_at, updated_at
-                   FROM chat.webchat_conversations
-                   WHERE unified_id = %s AND agent_name = %s
-                   ORDER BY updated_at DESC""",
+                """SELECT c.id, c.agent_name, c.title, c.created_at,
+                          c.updated_at, c.type, c.context_prompt
+                   FROM chat.webchat_conversations c
+                   JOIN chat.webchat_participants p
+                        ON c.id = p.conversation_id
+                   WHERE p.unified_id = %s AND c.agent_name = %s
+                   ORDER BY c.updated_at DESC""",
                 (uid, agent),
             )
         else:
             cur = conn.execute(
-                """SELECT id, agent_name, title, created_at, updated_at
-                   FROM chat.webchat_conversations
-                   WHERE unified_id = %s
-                   ORDER BY updated_at DESC""",
+                """SELECT c.id, c.agent_name, c.title, c.created_at,
+                          c.updated_at, c.type, c.context_prompt
+                   FROM chat.webchat_conversations c
+                   JOIN chat.webchat_participants p
+                        ON c.id = p.conversation_id
+                   WHERE p.unified_id = %s
+                   ORDER BY c.updated_at DESC""",
                 (uid,),
             )
         rows = [_serialize_row(dict(r)) for r in cur.fetchall()]
@@ -240,9 +329,16 @@ async def create_conversation(request: Request, user: dict = Depends(require_use
                VALUES (%s, %s, %s)""",
             (conv_id, uid, agent_name),
         )
+        # Create owner participant
+        conn.execute(
+            """INSERT INTO chat.webchat_participants
+               (conversation_id, unified_id, role)
+               VALUES (%s, %s, 'owner')""",
+            (conv_id, uid),
+        )
         conn.commit()
         row = conn.execute(
-            """SELECT id, agent_name, title, created_at, updated_at
+            """SELECT id, agent_name, title, created_at, updated_at, type
                FROM chat.webchat_conversations WHERE id = %s""",
             (conv_id,),
         ).fetchone()
@@ -420,6 +516,253 @@ async def set_context(
     return api_ok(data={"context_prompt": context_prompt})
 
 
+# --- Participants ---
+
+
+@router.get(
+    "/conversations/{conv_id}/participants",
+    response_model=ApiResponse[dict],
+    response_model_exclude_none=True,
+)
+async def list_participants(
+    request: Request, conv_id: str, user: dict = Depends(require_user)
+):
+    """List participants of a conversation."""
+    _ensure_db()
+    uid = _uid(user)
+    if not validate_conversation_access(conv_id, uid):
+        return api_error(404, "Not found", "not_found")
+    with _db.acquire_sync() as conn:
+        rows = conn.execute(
+            """SELECT p.unified_id, p.role, p.joined_at, u.display_name
+               FROM chat.webchat_participants p
+               LEFT JOIN app.users u ON u.username = p.unified_id
+               WHERE p.conversation_id = %s
+               ORDER BY p.joined_at""",
+            (conv_id,),
+        ).fetchall()
+    participants = [
+        {
+            "uid": r["unified_id"],
+            "role": r["role"],
+            "display_name": r["display_name"] or r["unified_id"],
+            "joined_at": r["joined_at"].isoformat() if r["joined_at"] else None,
+        }
+        for r in rows
+    ]
+    return api_ok(data={"participants": participants})
+
+
+@router.post(
+    "/conversations/{conv_id}/invite",
+    response_model=ApiResponse[dict],
+    response_model_exclude_none=True,
+)
+async def invite_user(
+    request: Request, conv_id: str, user: dict = Depends(require_user)
+):
+    """Invite a registered user to a conversation. Owner only."""
+    _ensure_db()
+    uid = _uid(user)
+    if not is_conversation_owner(conv_id, uid):
+        return api_error(403, "Only the owner can invite", "forbidden")
+
+    body = await request.json()
+    target = body.get("username", "").strip().lower()
+    if not target:
+        return api_error(400, "username required", "validation_error")
+    if target == uid:
+        return api_error(400, "Cannot invite yourself", "validation_error")
+
+    # Check target user exists
+    from ui.auth.database import AuthDatabase
+
+    auth_db = AuthDatabase()
+    target_user = auth_db.get_user_by_username(target)
+    if not target_user:
+        return api_error(404, f"User '{target}' not found", "not_found")
+
+    # Check not already participant
+    if validate_conversation_access(conv_id, target):
+        return api_error(400, "User already in conversation", "validation_error")
+
+    with _db.acquire_sync() as conn:
+        # Convert private → shared on first invite
+        conv = conn.execute(
+            "SELECT type FROM chat.webchat_conversations WHERE id = %s",
+            (conv_id,),
+        ).fetchone()
+        if conv and conv["type"] == "private":
+            conn.execute(
+                "UPDATE chat.webchat_conversations SET type = 'shared' WHERE id = %s",
+                (conv_id,),
+            )
+
+        # Add participant
+        conn.execute(
+            """INSERT INTO chat.webchat_participants
+               (conversation_id, unified_id, role)
+               VALUES (%s, %s, 'member')
+               ON CONFLICT DO NOTHING""",
+            (conv_id, target),
+        )
+        conn.commit()
+
+    # Notify via WebSocket
+    from ui.routes.ws_chat import push_to_webchat
+
+    await push_to_webchat(
+        target,
+        {
+            "type": "conversation_invited",
+            "conversation_id": conv_id,
+        },
+    )
+    return api_ok(data={"invited": target})
+
+
+@router.post(
+    "/conversations/{conv_id}/invite-link",
+    response_model=ApiResponse[dict],
+    response_model_exclude_none=True,
+)
+async def create_invite_link(
+    request: Request, conv_id: str, user: dict = Depends(require_user)
+):
+    """Generate a shareable invite link. Owner only."""
+    import secrets as stdlib_secrets
+
+    _ensure_db()
+    uid = _uid(user)
+    if not is_conversation_owner(conv_id, uid):
+        return api_error(403, "Only the owner can create invite links", "forbidden")
+
+    body = await request.json()
+    expires_hours = body.get("expires_hours", 72)
+    max_uses = body.get("max_uses", 0)
+
+    token = stdlib_secrets.token_urlsafe(32)
+    with _db.acquire_sync() as conn:
+        conn.execute(
+            """INSERT INTO chat.webchat_invites
+               (token, conversation_id, created_by, expires_at, max_uses)
+               VALUES (%s, %s, %s, NOW() + INTERVAL '%s hours', %s)""",
+            (token, conv_id, uid, expires_hours, max_uses),
+        )
+        # Convert to shared if private
+        conn.execute(
+            "UPDATE chat.webchat_conversations "
+            "SET type = 'shared' WHERE id = %s AND type = 'private'",
+            (conv_id,),
+        )
+        conn.commit()
+
+    return api_ok(data={"url": f"/me/chat/join/{token}", "token": token})
+
+
+@router.post(
+    "/conversations/{conv_id}/leave",
+    response_model=ApiResponse,
+    response_model_exclude_none=True,
+)
+async def leave_conversation(
+    request: Request, conv_id: str, user: dict = Depends(require_user)
+):
+    """Leave a shared conversation. Owner must transfer first."""
+    _ensure_db()
+    uid = _uid(user)
+    role = validate_conversation_access(conv_id, uid)
+    if not role:
+        return api_error(404, "Not found", "not_found")
+    if role == "owner":
+        return api_error(
+            400,
+            "Owner must transfer ownership before leaving",
+            "validation_error",
+        )
+
+    with _db.acquire_sync() as conn:
+        conn.execute(
+            "DELETE FROM chat.webchat_participants "
+            "WHERE conversation_id = %s AND unified_id = %s",
+            (conv_id, uid),
+        )
+        conn.commit()
+    return api_ok()
+
+
+@router.post(
+    "/conversations/{conv_id}/transfer-ownership",
+    response_model=ApiResponse,
+    response_model_exclude_none=True,
+)
+async def transfer_ownership(
+    request: Request, conv_id: str, user: dict = Depends(require_user)
+):
+    """Transfer conversation ownership to another participant. Owner only."""
+    _ensure_db()
+    uid = _uid(user)
+    if not is_conversation_owner(conv_id, uid):
+        return api_error(403, "Only the owner can transfer", "forbidden")
+
+    body = await request.json()
+    new_owner = body.get("new_owner", "").strip().lower()
+    if not new_owner or new_owner == uid:
+        return api_error(400, "Invalid new_owner", "validation_error")
+
+    if not validate_conversation_access(conv_id, new_owner):
+        return api_error(400, "Target is not a participant", "validation_error")
+
+    with _db.acquire_sync() as conn:
+        conn.execute(
+            "UPDATE chat.webchat_participants SET role = 'member' "
+            "WHERE conversation_id = %s AND unified_id = %s",
+            (conv_id, uid),
+        )
+        conn.execute(
+            "UPDATE chat.webchat_participants SET role = 'owner' "
+            "WHERE conversation_id = %s AND unified_id = %s",
+            (conv_id, new_owner),
+        )
+        conn.commit()
+    return api_ok()
+
+
+@router.post(
+    "/conversations/{conv_id}/remove-participant",
+    response_model=ApiResponse,
+    response_model_exclude_none=True,
+)
+async def remove_participant(
+    request: Request, conv_id: str, user: dict = Depends(require_user)
+):
+    """Remove a participant from the conversation. Owner only."""
+    _ensure_db()
+    uid = _uid(user)
+    if not is_conversation_owner(conv_id, uid):
+        return api_error(403, "Only the owner can remove participants", "forbidden")
+
+    body = await request.json()
+    target = body.get("username", "").strip().lower()
+    if not target or target == uid:
+        return api_error(400, "Invalid target", "validation_error")
+
+    with _db.acquire_sync() as conn:
+        conn.execute(
+            "DELETE FROM chat.webchat_participants "
+            "WHERE conversation_id = %s AND unified_id = %s",
+            (conv_id, target),
+        )
+        conn.commit()
+
+    from ui.routes.ws_chat import push_to_webchat
+
+    await push_to_webchat(
+        target, {"type": "participant_removed", "conversation_id": conv_id}
+    )
+    return api_ok()
+
+
 # --- File upload ---
 
 
@@ -477,7 +820,9 @@ _file_tokens: dict[str, dict] = {}
 _FILE_TOKEN_TTL = 3600  # 1 hour
 
 
-def create_file_token(file_path: str, uid: str) -> str:
+def create_file_token(
+    file_path: str, uid: str, conversation_id: str | None = None
+) -> str:
     """Create a short-lived token to serve a file to a specific user."""
     import secrets
 
@@ -485,6 +830,7 @@ def create_file_token(file_path: str, uid: str) -> str:
     _file_tokens[token] = {
         "path": file_path,
         "uid": uid,
+        "conversation_id": conversation_id,
         "expires": time.time() + _FILE_TOKEN_TTL,
     }
     # Prune expired tokens periodically (every 100 creates)
@@ -509,7 +855,10 @@ async def serve_file(token: str, user: dict = Depends(require_user)):
 
     uid = _uid(user)
     if entry["uid"] != uid:
-        return api_error(403, "Access denied", "forbidden")
+        # Allow access if user is a participant of the same conversation
+        conv_id = entry.get("conversation_id")
+        if not conv_id or not validate_conversation_access(conv_id, uid):
+            return api_error(403, "Access denied", "forbidden")
 
     file_path = Path(entry["path"])
     if not file_path.exists():

--- a/ui/routes/chat_api.py
+++ b/ui/routes/chat_api.py
@@ -690,6 +690,17 @@ async def leave_conversation(
             "WHERE conversation_id = %s AND unified_id = %s",
             (conv_id, uid),
         )
+        # Revert to private if only owner remains
+        remaining = conn.execute(
+            "SELECT count(*) as cnt FROM chat.webchat_participants "
+            "WHERE conversation_id = %s",
+            (conv_id,),
+        ).fetchone()
+        if remaining and remaining["cnt"] <= 1:
+            conn.execute(
+                "UPDATE chat.webchat_conversations SET type = 'private' WHERE id = %s",
+                (conv_id,),
+            )
         conn.commit()
     return api_ok()
 
@@ -756,6 +767,17 @@ async def remove_participant(
             "WHERE conversation_id = %s AND unified_id = %s",
             (conv_id, target),
         )
+        # Revert to private if only owner remains
+        remaining = conn.execute(
+            "SELECT count(*) as cnt FROM chat.webchat_participants "
+            "WHERE conversation_id = %s",
+            (conv_id,),
+        ).fetchone()
+        if remaining and remaining["cnt"] <= 1:
+            conn.execute(
+                "UPDATE chat.webchat_conversations SET type = 'private' WHERE id = %s",
+                (conv_id,),
+            )
         conn.commit()
 
     from ui.routes.ws_chat import push_to_webchat

--- a/ui/routes/chat_api.py
+++ b/ui/routes/chat_api.py
@@ -541,12 +541,15 @@ async def list_participants(
                ORDER BY p.joined_at""",
             (conv_id,),
         ).fetchall()
+    from ui.routes.ws_chat import _active_connections
+
     participants = [
         {
             "uid": r["unified_id"],
             "role": r["role"],
             "display_name": r["display_name"] or r["unified_id"],
             "joined_at": r["joined_at"].isoformat() if r["joined_at"] else None,
+            "online": r["unified_id"] in _active_connections,
         }
         for r in rows
     ]

--- a/ui/routes/me.py
+++ b/ui/routes/me.py
@@ -978,3 +978,81 @@ async def chat_page(request: Request, user: dict = Depends(require_user)):
             "agents": agents,
         },
     )
+
+
+@router.get("/chat/join/{token}", response_class=HTMLResponse)
+async def chat_join_page(
+    request: Request, token: str, user: dict = Depends(require_user)
+):
+    """Show invite confirmation page."""
+    from ui.routes.chat_api import _db, _ensure_db
+
+    _ensure_db()
+    with _db.acquire_sync() as conn:
+        row = conn.execute(
+            """SELECT i.conversation_id, i.expires_at, i.max_uses, i.use_count,
+                      c.title, c.agent_name
+               FROM chat.webchat_invites i
+               JOIN chat.webchat_conversations c ON c.id = i.conversation_id
+               WHERE i.token = %s AND i.expires_at > NOW()
+                 AND (i.max_uses = 0 OR i.use_count < i.max_uses)""",
+            (token,),
+        ).fetchone()
+
+    if not row:
+        return templates.TemplateResponse(
+            "me/chat_join.html",
+            {"request": request, "user": user, "error": "Invite expired or invalid"},
+        )
+
+    return templates.TemplateResponse(
+        "me/chat_join.html",
+        {
+            "request": request,
+            "user": user,
+            "token": token,
+            "conversation_title": row["title"] or "Untitled",
+            "agent_name": row["agent_name"],
+        },
+    )
+
+
+@router.post("/chat/join/{token}")
+async def chat_join_accept(
+    request: Request, token: str, user: dict = Depends(require_user)
+):
+    """Accept an invite and join the conversation."""
+    from ui.routes.chat_api import _db, _ensure_db
+
+    uid = user["username"]
+    _ensure_db()
+
+    with _db.acquire_sync() as conn:
+        # Atomic token redemption
+        row = conn.execute(
+            """UPDATE chat.webchat_invites
+               SET use_count = use_count + 1
+               WHERE token = %s
+                 AND expires_at > NOW()
+                 AND (max_uses = 0 OR use_count < max_uses)
+               RETURNING conversation_id""",
+            (token,),
+        ).fetchone()
+
+        if not row:
+            conn.rollback()
+            return RedirectResponse(url="/me/chat", status_code=303)
+
+        conv_id = row["conversation_id"]
+
+        # Add as participant (ignore if already member)
+        conn.execute(
+            """INSERT INTO chat.webchat_participants
+               (conversation_id, unified_id, role)
+               VALUES (%s, %s, 'member')
+               ON CONFLICT DO NOTHING""",
+            (conv_id, uid),
+        )
+        conn.commit()
+
+    return RedirectResponse(url="/me/chat", status_code=303)

--- a/ui/routes/me.py
+++ b/ui/routes/me.py
@@ -76,7 +76,9 @@ def _get_user_agents(user: dict) -> list[dict]:
             agents.append(
                 {
                     "name": agent_file.stem,
-                    "display_name": agent_config.get("display_name", agent_file.stem),
+                    "display_name": agent_config.get(
+                        "name", agent_config.get("display_name", agent_file.stem)
+                    ),
                     "description": agent_config.get("description", ""),
                     "avatar": agent_config.get("avatar", ""),
                 }

--- a/ui/routes/ws_chat.py
+++ b/ui/routes/ws_chat.py
@@ -73,7 +73,11 @@ async def broadcast_to_conversation(
 ) -> None:
     """Send an event to all users currently viewing a conversation."""
     viewers = _conversation_viewers.get(conversation_id, set())
-    for uid in viewers:
+    logger.info(
+        f"broadcast conv={conversation_id[:8]}... viewers={viewers} "
+        f"exclude={exclude_uid} event_type={event.get('type')}"
+    )
+    for uid in list(viewers):
         if uid == exclude_uid:
             continue
         ws = _active_connections.get(uid)
@@ -270,14 +274,19 @@ async def _stream_from_gridbear(
             return ""
 
 
-def _save_message(conversation_id: str | None, role: str, content: str):
+def _save_message(
+    conversation_id: str | None,
+    role: str,
+    content: str,
+    sender_id: str | None = None,
+):
     """Persist a message if conversation tracking is active."""
     if not conversation_id or not content:
         return
     try:
         from ui.routes.chat_api import save_message
 
-        save_message(conversation_id, role, content)
+        save_message(conversation_id, role, content, sender_id=sender_id)
     except Exception as e:
         logger.warning(f"WebChat: failed to save message: {e}")
 
@@ -321,9 +330,26 @@ async def ws_chat(websocket: WebSocket):
             await websocket.close(code=4003, reason="Forbidden")
             return
 
+    # Check if shared conversation
+    is_shared = False
+    if conversation_id:
+        try:
+            from ui.routes.chat_api import _db, _ensure_db
+
+            _ensure_db()
+            with _db.acquire_sync() as conn:
+                row = conn.execute(
+                    "SELECT type FROM chat.webchat_conversations WHERE id = %s",
+                    (conversation_id,),
+                ).fetchone()
+                is_shared = row and row["type"] == "shared"
+        except Exception:
+            pass
+
     logger.info(
         f"WebChat: user {uid} connected to agent {agent_name or 'default'}"
         + (f" conv={conversation_id[:8]}..." if conversation_id else "")
+        + (" (shared)" if is_shared else "")
     )
 
     _active_connections[uid] = websocket
@@ -341,6 +367,20 @@ async def ws_chat(websocket: WebSocket):
 
             msg_type = data.get("type", "")
 
+            if msg_type == "user_typing":
+                # Broadcast typing indicator to other viewers
+                if conversation_id:
+                    await broadcast_to_conversation(
+                        conversation_id,
+                        {
+                            "type": "user_typing",
+                            "sender": uid,
+                            "display_name": user.get("display_name", uid),
+                        },
+                        exclude_uid=uid,
+                    )
+                continue
+
             if msg_type == "message":
                 text = data.get("text", "").strip()
                 attachments = data.get("attachments") or []
@@ -355,6 +395,9 @@ async def ws_chat(websocket: WebSocket):
                 _save_message(conversation_id, "user", save_text, sender_id=uid)
 
                 # Broadcast user_message to other viewers
+                logger.info(
+                    f"WebChat: about to broadcast user_message conv={conversation_id}"
+                )
                 if conversation_id:
                     await broadcast_to_conversation(
                         conversation_id,
@@ -371,11 +414,29 @@ async def ws_chat(websocket: WebSocket):
                         exclude_uid=uid,
                     )
 
-                # Send typing indicator
-                try:
-                    await websocket.send_json({"type": "typing"})
-                except Exception:
-                    pass
+                # In shared conversations, only invoke the agent if @mentioned
+                agent_mentioned = True
+                if is_shared and text:
+                    mention = f"@{agent_name}" if agent_name else None
+                    agent_mentioned = bool(mention and mention.lower() in text.lower())
+                    logger.info(
+                        f"WebChat: shared mention check: "
+                        f"is_shared={is_shared} mention={mention} "
+                        f"agent_mentioned={agent_mentioned} text={text[:50]}"
+                    )
+
+                if not agent_mentioned:
+                    # User-only message, no agent response needed
+                    continue
+
+                # Send typing indicator to all viewers
+                if conversation_id:
+                    await broadcast_to_conversation(conversation_id, {"type": "typing"})
+                else:
+                    try:
+                        await websocket.send_json({"type": "typing"})
+                    except Exception:
+                        pass
 
                 # Run in background
                 async def _process_message(

--- a/ui/routes/ws_chat.py
+++ b/ui/routes/ws_chat.py
@@ -23,8 +23,65 @@ GRIDBEAR_SECRET = os.getenv("INTERNAL_API_SECRET", "")
 # Active WebSocket connections: {uid: websocket}
 _active_connections: dict[str, WebSocket] = {}
 
+# Per-user: which conversation they're currently viewing
+_active_conversations: dict[str, str] = {}
+
+# Per-conversation: set of uids currently viewing
+_conversation_viewers: dict[str, set[str]] = {}
+
+# Per-conversation: asyncio lock for serializing agent calls
+_conversation_locks: dict[str, asyncio.Lock] = {}
+
 # Background tasks — prevent garbage collection
 _background_tasks: set[asyncio.Task] = set()
+
+
+def _get_conversation_lock(conversation_id: str) -> asyncio.Lock:
+    if conversation_id not in _conversation_locks:
+        _conversation_locks[conversation_id] = asyncio.Lock()
+    return _conversation_locks[conversation_id]
+
+
+def _register_viewer(uid: str, conversation_id: str) -> None:
+    """Register a user as viewing a conversation."""
+    # Deregister from previous conversation
+    old_conv = _active_conversations.get(uid)
+    if old_conv and old_conv != conversation_id:
+        viewers = _conversation_viewers.get(old_conv, set())
+        viewers.discard(uid)
+        if not viewers:
+            _conversation_viewers.pop(old_conv, None)
+            _conversation_locks.pop(old_conv, None)
+
+    _active_conversations[uid] = conversation_id
+    _conversation_viewers.setdefault(conversation_id, set()).add(uid)
+
+
+def _deregister_viewer(uid: str) -> None:
+    """Remove a user from the viewer registry."""
+    conv_id = _active_conversations.pop(uid, None)
+    if conv_id:
+        viewers = _conversation_viewers.get(conv_id, set())
+        viewers.discard(uid)
+        if not viewers:
+            _conversation_viewers.pop(conv_id, None)
+            _conversation_locks.pop(conv_id, None)
+
+
+async def broadcast_to_conversation(
+    conversation_id: str, event: dict, exclude_uid: str | None = None
+) -> None:
+    """Send an event to all users currently viewing a conversation."""
+    viewers = _conversation_viewers.get(conversation_id, set())
+    for uid in viewers:
+        if uid == exclude_uid:
+            continue
+        ws = _active_connections.get(uid)
+        if ws:
+            try:
+                await ws.send_json(event)
+            except Exception:
+                pass
 
 
 async def push_to_webchat(uid: str, event: dict) -> bool:
@@ -136,14 +193,16 @@ async def _stream_from_gridbear(
     ws_alive = True
 
     async def _try_send(event):
-        """Best-effort WebSocket send — silently stops if disconnected."""
+        """Best-effort send to all viewers of the conversation."""
         nonlocal ws_alive
-        if not ws_alive or not websocket:
-            return
-        try:
-            await websocket.send_json(event)
-        except Exception:
-            ws_alive = False
+        if conversation_id:
+            # Broadcast to all viewers
+            await broadcast_to_conversation(conversation_id, event)
+        elif ws_alive and websocket:
+            try:
+                await websocket.send_json(event)
+            except Exception:
+                ws_alive = False
 
     async with aiohttp.ClientSession() as session:
         try:
@@ -268,6 +327,8 @@ async def ws_chat(websocket: WebSocket):
     )
 
     _active_connections[uid] = websocket
+    if conversation_id:
+        _register_viewer(uid, conversation_id)
 
     try:
         while True:
@@ -287,66 +348,94 @@ async def ws_chat(websocket: WebSocket):
                 if not text and not attachments:
                     continue
 
-                # Persist user message (include attachment info in text if no text)
+                # Persist user message
                 save_text = text
                 if attachments and not text:
                     save_text = "[allegato]"
-                _save_message(conversation_id, "user", save_text)
+                _save_message(conversation_id, "user", save_text, sender_id=uid)
 
-                # Send typing indicator immediately
+                # Broadcast user_message to other viewers
+                if conversation_id:
+                    await broadcast_to_conversation(
+                        conversation_id,
+                        {
+                            "type": "user_message",
+                            "sender": uid,
+                            "display_name": user.get("display_name", uid),
+                            "text": text,
+                            "time": __import__("datetime")
+                            .datetime.now()
+                            .strftime("%H:%M"),
+                            "attachments": None,
+                        },
+                        exclude_uid=uid,
+                    )
+
+                # Send typing indicator
                 try:
                     await websocket.send_json({"type": "typing"})
                 except Exception:
                     pass
 
-                # Run in background so the response is saved even if
-                # the user switches conversation (WebSocket disconnects).
+                # Run in background
                 async def _process_message(
                     _text, _user, _agent, _ws, _conv_id, _att, _ctx
                 ):
                     try:
-                        result = await _stream_from_gridbear(
-                            _text,
-                            _user,
-                            _agent,
-                            _ws,
-                            _conv_id,
-                            attachments=_att,
-                            context_prompt=_ctx,
-                        )
+                        # Acquire conversation lock for shared conversations
+                        lock = _get_conversation_lock(_conv_id) if _conv_id else None
+                        if lock:
+                            await lock.acquire()
+                        try:
+                            result = await _stream_from_gridbear(
+                                _text,
+                                _user,
+                                _agent,
+                                _ws,
+                                _conv_id,
+                                attachments=_att,
+                                context_prompt=_ctx,
+                            )
+                        finally:
+                            if lock and lock.locked():
+                                lock.release()
+
                         if result:
                             _save_message(_conv_id, "assistant", result)
-                            # Notify user of new message (for unread indicator)
-                            logger.info(
-                                f"WebChat: sending unread for conv={_conv_id[:8]}..."
-                            )
-                            delivered = await push_to_webchat(
-                                _user["username"],
-                                {
-                                    "type": "unread",
-                                    "conversation_id": _conv_id,
-                                },
-                            )
-                            logger.info(
-                                f"WebChat: unread delivered={delivered} "
-                                f"conv={_conv_id[:8]}..."
-                            )
+                            # Send unread to all participants not viewing
+                            if _conv_id:
+                                try:
+                                    from ui.routes.chat_api import (
+                                        list_conversation_participants,
+                                    )
+
+                                    parts = list_conversation_participants(_conv_id)
+                                    viewers = _conversation_viewers.get(_conv_id, set())
+                                    for p_uid in parts:
+                                        if p_uid not in viewers:
+                                            await push_to_webchat(
+                                                p_uid,
+                                                {
+                                                    "type": "unread",
+                                                    "conversation_id": _conv_id,
+                                                },
+                                            )
+                                except Exception:
+                                    pass
 
                         if _conv_id:
                             from ui.routes.chat_api import get_conversation_title
 
                             title = get_conversation_title(_conv_id)
                             if title:
-                                try:
-                                    await _ws.send_json(
-                                        {
-                                            "type": "conversation_update",
-                                            "conversation_id": _conv_id,
-                                            "title": title,
-                                        }
-                                    )
-                                except Exception:
-                                    pass
+                                await broadcast_to_conversation(
+                                    _conv_id,
+                                    {
+                                        "type": "conversation_update",
+                                        "conversation_id": _conv_id,
+                                        "title": title,
+                                    },
+                                )
                     except Exception:
                         logger.exception("WebChat: background processing error")
 
@@ -370,4 +459,5 @@ async def ws_chat(websocket: WebSocket):
         logger.error(f"WebChat: connection error: {e}")
     finally:
         _active_connections.pop(uid, None)
+        _deregister_viewer(uid)
         logger.info(f"WebChat: user {uid} disconnected")

--- a/ui/routes/ws_chat.py
+++ b/ui/routes/ws_chat.py
@@ -310,11 +310,11 @@ async def ws_chat(websocket: WebSocket):
                 await websocket.close(code=4003, reason="Forbidden")
                 return
 
-    # Validate conversation ownership if provided
+    # Validate conversation access (owner or member)
     if conversation_id:
-        from ui.routes.chat_api import validate_conversation_ownership
+        from ui.routes.chat_api import validate_conversation_access
 
-        if not validate_conversation_ownership(conversation_id, uid):
+        if not validate_conversation_access(conversation_id, uid):
             await websocket.send_json(
                 {"type": "error", "text": "Conversazione non valida"}
             )

--- a/ui/routes/ws_chat.py
+++ b/ui/routes/ws_chat.py
@@ -399,20 +399,38 @@ async def ws_chat(websocket: WebSocket):
                     f"WebChat: about to broadcast user_message conv={conversation_id}"
                 )
                 if conversation_id:
+                    user_msg_event = {
+                        "type": "user_message",
+                        "sender": uid,
+                        "display_name": user.get("display_name", uid),
+                        "text": text,
+                        "time": __import__("datetime").datetime.now().strftime("%H:%M"),
+                        "attachments": None,
+                    }
                     await broadcast_to_conversation(
                         conversation_id,
-                        {
-                            "type": "user_message",
-                            "sender": uid,
-                            "display_name": user.get("display_name", uid),
-                            "text": text,
-                            "time": __import__("datetime")
-                            .datetime.now()
-                            .strftime("%H:%M"),
-                            "attachments": None,
-                        },
+                        user_msg_event,
                         exclude_uid=uid,
                     )
+                    # Notify participants not currently viewing
+                    try:
+                        from ui.routes.chat_api import list_conversation_participants
+
+                        all_parts = list_conversation_participants(conversation_id)
+                        viewers = _conversation_viewers.get(conversation_id, set())
+                        for p_uid in all_parts:
+                            if p_uid != uid and p_uid not in viewers:
+                                # Send the message itself + unread indicator
+                                await push_to_webchat(p_uid, user_msg_event)
+                                await push_to_webchat(
+                                    p_uid,
+                                    {
+                                        "type": "unread",
+                                        "conversation_id": conversation_id,
+                                    },
+                                )
+                    except Exception:
+                        pass
 
                 # In shared conversations, only invoke the agent if @mentioned
                 agent_mentioned = True

--- a/ui/templates/me/chat.html
+++ b/ui/templates/me/chat.html
@@ -7,6 +7,7 @@
 <style>
     #chat-messages { scroll-behavior: smooth; }
     .msg-user { background: linear-gradient(135deg, rgba(14, 165, 233, 0.1), rgba(45, 212, 191, 0.05)); }
+    .msg-other-user { background: linear-gradient(135deg, rgba(245, 158, 11, 0.1), rgba(251, 191, 36, 0.05)); }
     .msg-agent { background: rgba(100, 116, 139, 0.05); }
     .typing-indicator span {
         animation: blink 1.4s infinite both;
@@ -153,9 +154,11 @@
                         <span x-show="conv.unread"
                               class="w-2 h-2 rounded-full bg-nordic-500 flex-shrink-0"></span>
                         <div class="min-w-0">
-                            <p class="text-sm font-medium truncate"
-                               :class="activeConversationId === conv.id ? 'text-nordic-700 dark:text-nordic-300' : conv.unread ? 'text-nordic-600 dark:text-nordic-400 font-semibold' : 'text-void-700 dark:text-void-300'"
-                               x-text="conv.title || i18n.newConversation"></p>
+                            <p class="text-sm font-medium truncate flex items-center gap-1"
+                               :class="activeConversationId === conv.id ? 'text-nordic-700 dark:text-nordic-300' : conv.unread ? 'text-nordic-600 dark:text-nordic-400 font-semibold' : 'text-void-700 dark:text-void-300'">
+                                <i x-show="conv.type === 'shared'" class="fas fa-users text-[9px] text-void-400"></i>
+                                <span x-text="conv.title || i18n.newConversation" class="truncate"></span>
+                            </p>
                             <p class="text-[10px] text-void-400 mt-0.5" x-text="formatDate(conv.updated_at)"></p>
                         </div>
                     </div>
@@ -166,6 +169,11 @@
                             <i class="fas fa-gear text-xs"></i>
                             <span x-show="conv.id === activeConversationId && conversationContext"
                                   class="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-nordic-500"></span>
+                        </button>
+                        <button @click.stop="selectConversation(conv); loadParticipants(); participantsPanelOpen = !participantsPanelOpen"
+                                class="p-1 rounded-lg hover:bg-nordic-500/10 text-void-400 hover:text-nordic-500 transition-all"
+                                title="{{ _("Participants") }}">
+                            <i class="fas fa-users text-xs"></i>
                         </button>
                         <button @click.stop="renameConversation(conv)"
                                 class="p-1 rounded-lg hover:bg-nordic-500/10 text-void-400 hover:text-nordic-500 transition-all"
@@ -251,6 +259,37 @@
                         <i class="fas fa-circle-notch fa-spin mr-1"></i> {{ _("Saving...") }}
                     </div>
                 </div>
+                <!-- Participants panel -->
+                <div x-show="participantsPanelOpen" x-transition
+                     class="mb-2 p-3 rounded-xl border border-void-200 dark:border-void-800 bg-white/50 dark:bg-void-900/30">
+                    <div class="flex items-center justify-between mb-2">
+                        <span class="text-xs font-medium text-void-500">{{ _("Participants") }}</span>
+                        <button @click="participantsPanelOpen = false"
+                                class="p-1 rounded-lg hover:bg-void-100 dark:hover:bg-void-800/50 text-void-400 hover:text-void-600 transition-all">
+                            <i class="fas fa-xmark text-xs"></i>
+                        </button>
+                    </div>
+                    <div class="space-y-1 mb-3">
+                        <template x-for="p in participants" :key="p.uid">
+                            <div class="flex items-center justify-between py-1 px-2 rounded-lg hover:bg-void-50 dark:hover:bg-void-800/30">
+                                <div class="flex items-center gap-2">
+                                    <span class="w-2 h-2 rounded-full" :class="isParticipantOnline(p.uid) ? 'bg-green-500' : 'bg-void-300'"></span>
+                                    <span class="text-sm" x-text="p.display_name"></span>
+                                    <span x-show="p.role === 'owner'" class="text-[9px] px-1.5 py-0.5 rounded-full bg-nordic-500/10 text-nordic-500">owner</span>
+                                </div>
+                            </div>
+                        </template>
+                    </div>
+                    <!-- Invite input -->
+                    <div class="flex gap-2">
+                        <input type="text" x-model="inviteUsername" placeholder="{{ _('Username to invite...') }}"
+                               class="flex-1 px-3 py-1.5 rounded-lg bg-white dark:bg-void-800/50 border border-void-200 dark:border-void-700 text-sm focus:ring-2 focus:ring-nordic-500/40 focus:border-nordic-500 outline-none">
+                        <button @click="inviteUser()" :disabled="!inviteUsername.trim()"
+                                class="px-3 py-1.5 rounded-lg bg-nordic-500 hover:bg-nordic-600 text-white text-xs font-medium transition-colors disabled:opacity-50">
+                            <i class="fas fa-user-plus mr-1"></i> {{ _("Invite") }}
+                        </button>
+                    </div>
+                </div>
                 <!-- Messages -->
                 <div id="chat-messages" class="flex-1 overflow-y-auto space-y-3 rounded-2xl border border-void-200 dark:border-void-800 bg-white/50 dark:bg-void-900/30 p-4 relative"
                      @dragover.prevent="dragOver = true"
@@ -272,7 +311,7 @@
                         </div>
                     </template>
                     <template x-for="msg in messages" :key="msg.id">
-                        <div :class="msg.role === 'user' ? 'msg-user ml-2 sm:ml-8' : msg.role === 'system' ? 'mx-2 sm:mx-8 text-center' : 'msg-agent mr-2 sm:mr-8'" class="rounded-xl p-4">
+                        <div :class="msg.role === 'user' ? 'msg-user ml-2 sm:ml-8' : msg.role === 'other_user' ? 'msg-other-user mr-2 sm:mr-8' : msg.role === 'system' ? 'mx-2 sm:mx-8 text-center' : 'msg-agent mr-2 sm:mr-8'" class="rounded-xl p-4">
                             <template x-if="msg.role === 'system'">
                                 <div class="text-[11px] text-void-400 italic" x-text="msg.text"></div>
                             </template>
@@ -280,8 +319,8 @@
                                 <div>
                                     <div class="flex items-center gap-2 mb-1">
                                         <span class="text-[10px] font-semibold uppercase tracking-wide"
-                                              :class="msg.role === 'user' ? 'text-frost-500' : 'text-nordic-500'"
-                                              x-text="msg.role === 'user' ? '{{ user.display_name or user.username }}' : msg.agent || selectedAgent"></span>
+                                              :class="msg.role === 'user' ? 'text-frost-500' : msg.role === 'other_user' ? 'text-amber-500' : 'text-nordic-500'"
+                                              x-text="msg.role === 'user' ? '{{ user.display_name or user.username }}' : msg.role === 'other_user' ? msg.display_name : msg.agent || selectedAgent"></span>
                                         <span class="text-[10px] text-void-400" x-text="msg.time"></span>
                                     </div>
                                     <!-- Attachment thumbnails in message -->
@@ -442,6 +481,11 @@ function chatApp() {
         lastSavedContext: '',
         contextPanelOpen: false,
         contextSaving: false,
+
+        // Participants
+        participantsPanelOpen: false,
+        participants: [],
+        inviteUsername: '',
 
         // Attachments
         pendingFiles: [],  // [{file, previewUrl, uploading, uploadedPath, filename}]
@@ -856,6 +900,41 @@ function chatApp() {
                     });
                     self.isTyping = false;
                     self.$nextTick(function() { self.scrollToBottom(); });
+                } else if (data.type === 'user_message') {
+                    // Message from another user in shared conversation
+                    self.messages.push({
+                        id: ++self.msgCounter,
+                        role: 'other_user',
+                        sender: data.sender,
+                        display_name: data.display_name || data.sender,
+                        text: data.text,
+                        time: data.time || new Date().toLocaleTimeString('it-IT', {hour: '2-digit', minute: '2-digit'}),
+                    });
+                    self.$nextTick(function() { self.scrollToBottom(); });
+                } else if (data.type === 'participant_joined') {
+                    self.messages.push({
+                        id: ++self.msgCounter,
+                        role: 'system',
+                        text: (data.display_name || data.uid) + ' joined the conversation',
+                        time: new Date().toLocaleTimeString('it-IT', {hour: '2-digit', minute: '2-digit'}),
+                    });
+                } else if (data.type === 'participant_removed' || data.type === 'participant_left') {
+                    self.messages.push({
+                        id: ++self.msgCounter,
+                        role: 'system',
+                        text: (data.display_name || data.uid || 'A participant') + ' left the conversation',
+                        time: new Date().toLocaleTimeString('it-IT', {hour: '2-digit', minute: '2-digit'}),
+                    });
+                } else if (data.type === 'conversation_invited') {
+                    // Reload conversations to show the new one
+                    self.loadConversations();
+                } else if (data.type === 'conversation_deleted') {
+                    // Remove from sidebar and deselect if active
+                    self.conversations = self.conversations.filter(function(c) { return c.id !== data.conversation_id; });
+                    if (self.activeConversationId === data.conversation_id) {
+                        self.activeConversationId = null;
+                        self.messages = [];
+                    }
                 } else if (data.type === 'unread') {
                     // Mark conversation as having unread messages
                     if (data.conversation_id !== self.activeConversationId) {
@@ -1160,6 +1239,44 @@ function chatApp() {
                 if (data.ok) self.lastSavedContext = self.conversationContext;
             })
             .catch(function() { self.contextSaving = false; });
+        },
+
+        // --- Participants ---
+
+        loadParticipants() {
+            var self = this;
+            if (!self.activeConversationId) return;
+            fetch('/me/chat/api/conversations/' + self.activeConversationId + '/participants')
+                .then(function(r) { return r.json(); })
+                .then(function(data) {
+                    self.participants = (data.data && data.data.participants) || [];
+                })
+                .catch(function() { self.participants = []; });
+        },
+
+        inviteUser() {
+            var self = this;
+            var target = self.inviteUsername.trim().toLowerCase();
+            if (!target || !self.activeConversationId) return;
+            fetch('/me/chat/api/conversations/' + self.activeConversationId + '/invite', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json', 'X-CSRF-Token': document.querySelector('[name=csrf_token]') ? document.querySelector('[name=csrf_token]').value : ''},
+                body: JSON.stringify({ username: target }),
+            })
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (data.ok) {
+                    self.inviteUsername = '';
+                    self.loadParticipants();
+                } else {
+                    alert(data.detail || data.error || 'Error');
+                }
+            });
+        },
+
+        isParticipantOnline(uid) {
+            // Simplified: check if uid is in active connections (via unread events)
+            return false; // TODO: implement with presence events
         },
 
         autoResize(event) {

--- a/ui/templates/me/chat.html
+++ b/ui/templates/me/chat.html
@@ -275,10 +275,24 @@
                                 <div class="flex items-center gap-2">
                                     <span class="w-2 h-2 rounded-full" :class="isParticipantOnline(p.uid) ? 'bg-green-500' : 'bg-void-300'"></span>
                                     <span class="text-sm" x-text="p.display_name"></span>
+                                    <span class="text-[10px] text-void-400" x-text="'@' + p.uid"></span>
                                     <span x-show="p.role === 'owner'" class="text-[9px] px-1.5 py-0.5 rounded-full bg-nordic-500/10 text-nordic-500">owner</span>
                                 </div>
+                                <button x-show="p.role !== 'owner' && isCurrentUserOwner()"
+                                        @click="removeParticipant(p.uid)"
+                                        class="p-1 rounded-lg hover:bg-red-500/10 text-void-400 hover:text-red-500 transition-all"
+                                        title="{{ _('Remove') }}">
+                                    <i class="fas fa-user-minus text-xs"></i>
+                                </button>
                             </div>
                         </template>
+                    </div>
+                    <!-- Agent -->
+                    <div class="py-1 px-2 flex items-center gap-2 border-t border-void-100 dark:border-void-800 mt-1 pt-2">
+                        <span class="w-2 h-2 rounded-full bg-nordic-500"></span>
+                        <span class="text-sm font-medium text-nordic-500" x-text="agentNames[selectedAgent] || selectedAgent"></span>
+                        <span class="text-[10px] text-void-400" x-text="'@' + selectedAgent"></span>
+                        <span class="text-[9px] px-1.5 py-0.5 rounded-full bg-nordic-500/10 text-nordic-500">agent</span>
                     </div>
                     <!-- Invite input -->
                     <div class="flex gap-2">
@@ -345,12 +359,19 @@
                         </div>
                     </template>
 
-                    <!-- Typing indicator -->
-                    <div x-show="isTyping" class="msg-agent mr-2 sm:mr-8 rounded-xl p-4">
-                        <div class="typing-indicator text-void-400">
-                            <span></span><span></span><span></span>
+                    <!-- Typing indicators -->
+                    <template x-if="otherUserTyping">
+                        <div class="msg-other-user mr-2 sm:mr-8 rounded-xl px-4 py-2">
+                            <span class="text-[10px] text-amber-500 italic" x-text="otherUserTyping + ' {{ _("is typing...") }}'"></span>
                         </div>
-                    </div>
+                    </template>
+                    <template x-if="isTyping">
+                        <div class="msg-agent mr-2 sm:mr-8 rounded-xl p-4">
+                            <div class="typing-indicator text-void-400">
+                                <span></span><span></span><span></span>
+                            </div>
+                        </div>
+                    </template>
                 </div>
 
                 <!-- Attachment preview strip -->
@@ -386,7 +407,7 @@
                         <i class="fas fa-microphone text-red-400 mr-1"></i>
                         <span x-text="voiceInterim"></span>
                     </div>
-                    <div class="flex gap-2 items-end">
+                    <div class="flex gap-2 items-end relative">
                         <!-- Attach button -->
                         <button @click="$refs.fileInput ? $refs.fileInput.click() : document.getElementById('file-input').click()"
                                 :disabled="!wsConnected"
@@ -394,10 +415,22 @@
                                 title="{{ _("Attach file") }}">
                             <i class="fas fa-paperclip"></i>
                         </button>
+                        <!-- Mention autocomplete dropdown -->
+                        <div x-show="mentionOpen" class="absolute bottom-full left-0 mb-1 w-64 bg-white dark:bg-void-900 border border-void-200 dark:border-void-700 rounded-xl shadow-lg overflow-hidden z-50">
+                            <template x-for="(item, idx) in mentionSuggestions()" :key="item.uid">
+                                <button @mousedown.prevent="selectMention(item)"
+                                        class="w-full px-3 py-2 text-left text-sm flex items-center gap-2 transition-colors"
+                                        :class="idx === mentionIndex ? 'bg-nordic-500/10 text-nordic-600 dark:text-nordic-400' : 'hover:bg-void-50 dark:hover:bg-void-800/50'">
+                                    <span x-text="item.display_name" class="font-medium"></span>
+                                    <span class="text-[10px] text-void-400" x-text="'@' + item.uid"></span>
+                                    <span x-show="item.type === 'agent'" class="text-[9px] px-1 py-0.5 rounded-full bg-nordic-500/10 text-nordic-500 ml-auto">agent</span>
+                                </button>
+                            </template>
+                        </div>
                         <textarea x-model="inputText"
-                               @keydown="if ($event.key === 'Enter') handleEnter($event)"
+                               @keydown="handleKeydown($event)"
                                @paste="handlePaste($event)"
-                               @input="autoResize($event)"
+                               @input="autoResize($event); sendUserTyping(); checkMentionTrigger($event)"
                                placeholder="{{ _("Type a message or paste an image...") }}"
                                :disabled="!wsConnected"
                                rows="1"
@@ -460,6 +493,7 @@ window.i18n = {
 function chatApp() {
     return {
         selectedAgent: '{{ agents[0].name if agents else '' }}',
+        agentNames: { {% for agent in agents %}'{{ agent.name }}': '{{ agent.display_name or agent.name }}'{% if not loop.last %}, {% endif %}{% endfor %} },
         messages: [],
         inputText: '',
         isTyping: false,
@@ -486,6 +520,15 @@ function chatApp() {
         participantsPanelOpen: false,
         participants: [],
         inviteUsername: '',
+        _lastTypingSent: 0,
+        otherUserTyping: null,
+        _typingTimeout: null,
+
+        // Mention autocomplete
+        mentionOpen: false,
+        mentionFilter: '',
+        mentionIndex: 0,
+        _mentionStart: -1,
 
         // Attachments
         pendingFiles: [],  // [{file, previewUrl, uploading, uploadedPath, filename}]
@@ -560,6 +603,8 @@ function chatApp() {
 
         renderMarkdown(text) {
             if (!text) return '';
+            // Highlight @mentions
+            text = text.replace(/@(\w+)/g, '<span class="text-nordic-500 font-semibold">@$1</span>');
             if (typeof marked !== 'undefined') {
                 return marked.parse(text);
             }
@@ -712,7 +757,12 @@ function chatApp() {
             self.conversationContext = '';
             self.lastSavedContext = '';
             self.contextPanelOpen = false;
+            self.participantsPanelOpen = false;
+            self.participants = [];
             conv.unread = false;
+
+            // Load participants (for mention autocomplete)
+            self.loadParticipants();
 
             // Load conversation context
             fetch('/me/chat/api/conversations/' + conv.id + '/context')
@@ -870,6 +920,13 @@ function chatApp() {
                     self.$nextTick(function() { self.scrollToBottom(); });
                 } else if (data.type === 'typing') {
                     self.isTyping = true;
+                    self.$nextTick(function() { self.scrollToBottom(); });
+                } else if (data.type === 'user_typing') {
+                    self.otherUserTyping = data.display_name || data.sender || 'Someone';
+                    clearTimeout(self._typingTimeout);
+                    self._typingTimeout = setTimeout(function() {
+                        self.otherUserTyping = null;
+                    }, 4000);
                 } else if (data.type === 'error') {
                     self.isTyping = false;
                     var errMsg = data.text || data.details || data.error_type || 'unknown error';
@@ -1002,7 +1059,6 @@ function chatApp() {
             this.inputText = '';
             this._voiceCommitted = '';
             this.pendingFiles = [];
-            this.isTyping = true;
 
             // Reset textarea height after send
             this.$nextTick(function() {
@@ -1200,6 +1256,35 @@ function chatApp() {
 
         // --- Enter behavior ---
 
+        handleKeydown(event) {
+            // Mention autocomplete takes priority
+            if (this.mentionOpen) {
+                if (event.key === 'ArrowDown') {
+                    event.preventDefault();
+                    var s = this.mentionSuggestions();
+                    this.mentionIndex = (this.mentionIndex + 1) % s.length;
+                    return;
+                } else if (event.key === 'ArrowUp') {
+                    event.preventDefault();
+                    var s = this.mentionSuggestions();
+                    this.mentionIndex = (this.mentionIndex - 1 + s.length) % s.length;
+                    return;
+                } else if (event.key === 'Tab' || event.key === 'Enter') {
+                    event.preventDefault();
+                    var s = this.mentionSuggestions();
+                    if (s[this.mentionIndex]) this.selectMention(s[this.mentionIndex]);
+                    return;
+                } else if (event.key === 'Escape') {
+                    this.mentionOpen = false;
+                    return;
+                }
+            }
+            // Normal Enter handling
+            if (event.key === 'Enter') {
+                this.handleEnter(event);
+            }
+        },
+
         handleEnter(event) {
             if (this.enterToSend) {
                 // Enter = send, Shift+Enter or Ctrl+Enter = newline
@@ -1277,6 +1362,95 @@ function chatApp() {
         isParticipantOnline(uid) {
             var p = this.participants.find(function(x) { return x.uid === uid; });
             return p ? p.online : false;
+        },
+
+        mentionSuggestions() {
+            var filter = this.mentionFilter.toLowerCase();
+            var items = [];
+            // Add participants
+            for (var i = 0; i < this.participants.length; i++) {
+                var p = this.participants[i];
+                items.push({ uid: p.uid, display_name: p.display_name, type: 'user' });
+            }
+            // Add agent
+            items.push({
+                uid: this.selectedAgent,
+                display_name: this.agentNames[this.selectedAgent] || this.selectedAgent,
+                type: 'agent',
+            });
+            if (!filter) return items;
+            return items.filter(function(item) {
+                return item.uid.toLowerCase().indexOf(filter) !== -1
+                    || item.display_name.toLowerCase().indexOf(filter) !== -1;
+            });
+        },
+
+        checkMentionTrigger(event) {
+            var ta = event.target || document.querySelector('textarea[x-model="inputText"]');
+            if (!ta) { this.mentionOpen = false; return; }
+            var val = ta.value;
+            var pos = ta.selectionStart;
+            // Find @ before cursor
+            var before = val.substring(0, pos);
+            var atIdx = before.lastIndexOf('@');
+            if (atIdx >= 0 && (atIdx === 0 || before[atIdx - 1] === ' ' || before[atIdx - 1] === '\n')) {
+                var partial = before.substring(atIdx + 1);
+                if (partial.indexOf(' ') === -1 && partial.length < 30) {
+                    this.mentionFilter = partial;
+                    this._mentionStart = atIdx;
+                    this.mentionIndex = 0;
+                    this.mentionOpen = this.mentionSuggestions().length > 0;
+                    return;
+                }
+            }
+            this.mentionOpen = false;
+        },
+
+
+        selectMention(item) {
+            var ta = document.querySelector('textarea[x-model="inputText"]');
+            var cursorPos = ta ? ta.selectionStart : this.inputText.length;
+            var before = this.inputText.substring(0, this._mentionStart);
+            var after = this.inputText.substring(cursorPos);
+            this.inputText = before + '@' + item.uid + ' ' + after;
+            this.mentionOpen = false;
+            this.$nextTick(function() {
+                if (ta) {
+                    var pos = before.length + item.uid.length + 2;
+                    ta.selectionStart = pos;
+                    ta.selectionEnd = pos;
+                    ta.focus();
+                }
+            });
+        },
+
+        sendUserTyping() {
+            var now = Date.now();
+            if (now - this._lastTypingSent < 3000) return;
+            this._lastTypingSent = now;
+            if (this.ws && this.ws.readyState === 1) {
+                this.ws.send(JSON.stringify({ type: 'user_typing' }));
+            }
+        },
+
+        isCurrentUserOwner() {
+            var self = this;
+            var me = self.participants.find(function(p) { return p.uid === '{{ user.username }}'; });
+            return me && me.role === 'owner';
+        },
+
+        removeParticipant(uid) {
+            var self = this;
+            if (!confirm('Remove ' + uid + ' from this conversation?')) return;
+            fetch('/me/chat/api/conversations/' + self.activeConversationId + '/remove-participant', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json', 'X-CSRF-Token': document.querySelector('[name=csrf_token]') ? document.querySelector('[name=csrf_token]').value : ''},
+                body: JSON.stringify({ username: uid }),
+            })
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (data.ok) self.loadParticipants();
+            });
         },
 
         autoResize(event) {

--- a/ui/templates/me/chat.html
+++ b/ui/templates/me/chat.html
@@ -1275,8 +1275,8 @@ function chatApp() {
         },
 
         isParticipantOnline(uid) {
-            // Simplified: check if uid is in active connections (via unread events)
-            return false; // TODO: implement with presence events
+            var p = this.participants.find(function(x) { return x.uid === uid; });
+            return p ? p.online : false;
         },
 
         autoResize(event) {

--- a/ui/templates/me/chat.html
+++ b/ui/templates/me/chat.html
@@ -558,6 +558,10 @@ function chatApp() {
             if (typeof marked !== 'undefined') {
                 marked.setOptions({ breaks: true, gfm: true });
             }
+            // Request notification permission
+            if ('Notification' in window && Notification.permission === 'default') {
+                Notification.requestPermission();
+            }
             this.loadConversations();
 
             // Wire up the global file input
@@ -870,10 +874,13 @@ function chatApp() {
                 var data = JSON.parse(event.data);
                 if (data.type === 'message') {
                     self.isTyping = false;
+                    var agentName = data.agent || self.selectedAgent;
+                    var agentMentionedMe = (data.text || '').toLowerCase().indexOf('@{{ user.username }}') !== -1;
+                    self._notify(self.agentNames[agentName] || agentName, (data.text || '').substring(0, 100), agentMentionedMe);
                     self.messages.push({
                         id: ++self.msgCounter,
                         role: 'agent',
-                        agent: data.agent || self.selectedAgent,
+                        agent: agentName,
                         text: data.text,
                         time: new Date().toLocaleTimeString('it-IT', {hour: '2-digit', minute: '2-digit'}),
                     });
@@ -959,6 +966,8 @@ function chatApp() {
                     self.$nextTick(function() { self.scrollToBottom(); });
                 } else if (data.type === 'user_message') {
                     // Message from another user in shared conversation
+                    var mentioned = (data.text || '').toLowerCase().indexOf('@{{ user.username }}') !== -1;
+                    self._notify(data.display_name || data.sender, (data.text || '').substring(0, 100), mentioned);
                     self.messages.push({
                         id: ++self.msgCounter,
                         role: 'other_user',
@@ -998,6 +1007,7 @@ function chatApp() {
                         for (var i = 0; i < self.conversations.length; i++) {
                             if (self.conversations[i].id === data.conversation_id) {
                                 self.conversations[i].unread = true;
+                                self._notify('New message', self.conversations[i].title || 'New message in conversation', true);
                                 break;
                             }
                         }
@@ -1422,6 +1432,13 @@ function chatApp() {
                     ta.focus();
                 }
             });
+        },
+
+        _notify(title, body, force) {
+            if ('Notification' in window && Notification.permission === 'granted' && (document.hidden || force)) {
+                var n = new Notification(title, { body: body, icon: '/static/img/logo.svg', tag: 'webchat-' + Date.now() });
+                n.onclick = function() { window.focus(); n.close(); };
+            }
         },
 
         sendUserTyping() {

--- a/ui/templates/me/chat_join.html
+++ b/ui/templates/me/chat_join.html
@@ -1,0 +1,34 @@
+{% extends "me/base.html" %}
+
+{% block title %}Join Conversation - GridBear{% endblock %}
+
+{% block me_content %}
+<div class="flex items-center justify-center min-h-[400px]">
+    <div class="bg-white dark:bg-void-900/50 rounded-2xl border border-void-200 dark:border-void-800 p-8 max-w-md w-full text-center">
+        {% if error %}
+        <div class="mb-4">
+            <i class="fas fa-link-slash text-4xl text-void-300 mb-4"></i>
+            <h2 class="text-lg font-semibold text-void-900 dark:text-white mb-2">{{ _("Invalid Invite") }}</h2>
+            <p class="text-sm text-void-500">{{ error }}</p>
+            <a href="/me/chat" class="inline-block mt-4 px-4 py-2 rounded-xl bg-nordic-500 hover:bg-nordic-600 text-white text-sm font-medium transition-colors">
+                {{ _("Back to Chat") }}
+            </a>
+        </div>
+        {% else %}
+        <i class="fas fa-user-plus text-4xl text-nordic-500 mb-4"></i>
+        <h2 class="text-lg font-semibold text-void-900 dark:text-white mb-2">{{ _("Join Conversation") }}</h2>
+        <p class="text-sm text-void-500 mb-1">{{ conversation_title }}</p>
+        <p class="text-xs text-void-400 mb-6">{{ _("Agent") }}: {{ agent_name }}</p>
+        <form method="POST" action="/me/chat/join/{{ token }}">
+            {% include "partials/csrf_field.html" %}
+            <button type="submit" class="px-6 py-2.5 rounded-xl bg-nordic-500 hover:bg-nordic-600 text-white font-medium transition-colors">
+                <i class="fas fa-sign-in-alt mr-2"></i> {{ _("Join") }}
+            </button>
+        </form>
+        <a href="/me/chat" class="inline-block mt-3 text-sm text-void-400 hover:text-void-600 transition-colors">
+            {{ _("Cancel") }}
+        </a>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
Multi-user webchat conversations — users can collaborate with an agent in the same chat.

## Changes
- **Schema**: `webchat_participants`, `webchat_invites` tables; `type` and `sender_id` columns
- **API**: invite, invite-link, join, leave, transfer-ownership, remove-participant, list-participants
- **WebSocket**: 3-level registry (user/conversation/viewers), conversation lock, broadcasting
- **Frontend**: `user_message` and `other_user` role, participant panel, invite input, membership events, shared conversation icons
- **Bot context**: participant list injected in system prompt for shared conversations
- **Join page**: Invite confirmation with atomic token redemption (POST, not GET)
- **File access**: Shared conversation participants can access each other's files

## Spec
`docs/superpowers/specs/2026-04-01-shared-webchat-design.md` (reviewed and approved)

## Test plan
- [ ] Create conversation, invite user → user sees it in sidebar
- [ ] Both users send messages → messages broadcast to all viewers
- [ ] Agent responses broadcast to all viewers
- [ ] User not viewing gets unread indicator
- [ ] Generate invite link → open in another session → join
- [ ] Transfer ownership → leave conversation
- [ ] Private conversations unchanged
- [ ] File tokens work cross-user in shared conversations