### PR TITLE
[FIX] webchat: cross-conversation messages, plan UX, smart scroll

### DIFF
--- a/plugins/planning/skills/planning_instructions.md
+++ b/plugins/planning/skills/planning_instructions.md
@@ -2,21 +2,39 @@
 
 You have access to planning tools for managing task plans.
 
+## Creating a plan
+
 When the user asks you to plan or organize a complex task:
 1. Break it into discrete, actionable steps
-2. Call plan_create with a title, task list, and the conversation_id from your [Message Source] context
+2. Call `plan_create` with a title, task list, and the conversation_id from your [Message Source] context
 3. Wait for user approval before starting
-4. When told to proceed, call plan_update(action: "start") with the plan_id
-5. Execute tasks one by one:
-   - Call plan_task_update(status: "in_progress") before starting each task
-   - Do the work (use other tools as needed)
-   - Call plan_task_update(status: "completed", result: "...") when done
-   - If a task fails, call plan_task_update(status: "failed", result: "error description"). The plan will pause automatically.
-6. Continue to the next task
+4. When told to proceed, call `plan_update(action: "start")` with the plan_id
 
-If the user asks to modify the plan, use plan_update:
-- To edit an existing task: use update_tasks with the task_id and new title/description
-- To add new tasks: use add_tasks
-- To remove tasks: use remove_tasks with task IDs
+## Executing tasks — STRICT WORKFLOW
+
+**You MUST follow this exact sequence for every task. No exceptions.**
+
+For each task, in order:
+
+1. **BEFORE starting work**: Call `plan_task_update(task_id: "...", status: "in_progress")`
+2. **Do the actual work** using other tools (MCP, search, etc.)
+3. **IMMEDIATELY after the work is done**: Call `plan_task_update(task_id: "...", status: "completed", result: "brief summary of what you did")`
+4. **Only then** move to the next task
+
+**Critical rules:**
+- NEVER skip the `in_progress` call. The user needs to see which task is running.
+- NEVER skip the `completed` call. Without it, the task stays as pending forever and the plan never advances.
+- The `result` field is REQUIRED on completed — even if it's just one sentence ("Verified config OK" or "Created 3 records").
+- If a task fails, call `plan_task_update(status: "failed", result: "error description")` — the plan will auto-pause.
+- If you're asked to continue but no task is `in_progress`, find the first `pending` task and start from there.
+- When you receive a `[SYSTEM] Continue with the next task` message, do NOT just acknowledge it — actually execute the next pending task following the workflow above.
+
+## Modifying a plan
+
+If the user asks to modify the plan, use `plan_update`:
+- To edit an existing task: use `update_tasks` with the task_id and new title/description
+- To add new tasks: use `add_tasks`
+- To remove tasks: use `remove_tasks` with task IDs
 Prefer editing existing tasks over removing and re-adding them.
-Keep task titles short and actionable. Include a brief result for each completed task.
+
+Keep task titles short and actionable.

--- a/ui/routes/chat_api.py
+++ b/ui/routes/chat_api.py
@@ -449,23 +449,20 @@ async def get_messages(
 ):
     _ensure_db()
     uid = _uid(user)
+    if not validate_conversation_access(conv_id, uid):
+        return api_error(403, "Access denied", "forbidden")
+
+    limit = int(request.query_params.get("limit", "200"))
+    offset = int(request.query_params.get("offset", "0"))
+
     with _db.acquire_sync() as conn:
-        # Ownership check
-        row = conn.execute(
-            "SELECT 1 FROM chat.webchat_conversations WHERE id = %s AND unified_id = %s",
-            (conv_id, uid),
-        ).fetchone()
-        if not row:
-            return api_error(404, "Not found", "not_found")
-
-        limit = int(request.query_params.get("limit", "200"))
-        offset = int(request.query_params.get("offset", "0"))
-
         cur = conn.execute(
-            """SELECT id, role, content, metadata_json, created_at
-               FROM chat.webchat_messages
-               WHERE conversation_id = %s
-               ORDER BY created_at ASC
+            """SELECT m.id, m.role, m.content, m.metadata_json, m.created_at,
+                      m.sender_id, u.display_name as sender_display_name
+               FROM chat.webchat_messages m
+               LEFT JOIN app.users u ON u.username = m.sender_id
+               WHERE m.conversation_id = %s
+               ORDER BY m.created_at ASC
                LIMIT %s OFFSET %s""",
             (conv_id, limit, offset),
         )

--- a/ui/routes/ws_chat.py
+++ b/ui/routes/ws_chat.py
@@ -482,39 +482,6 @@ async def ws_chat(websocket: WebSocket):
                 if not text and not attachments:
                     continue
 
-                # Pause active plan when user sends a message
-                if conversation_id:
-                    try:
-                        from ui.routes.chat_api import get_active_plan
-
-                        plan = get_active_plan(conversation_id)
-                        if plan and plan["status"] == "active":
-                            from core.registry import get_database
-
-                            db = get_database()
-                            with db.acquire_sync() as conn:
-                                conn.execute(
-                                    "UPDATE chat.webchat_plans "
-                                    "SET status = 'paused', "
-                                    "updated_at = CURRENT_TIMESTAMP "
-                                    "WHERE id = %s",
-                                    (plan["id"],),
-                                )
-                                conn.commit()
-                            await broadcast_to_conversation(
-                                conversation_id,
-                                {
-                                    "type": "plan_updated",
-                                    "plan_id": plan["id"],
-                                    "changes": {"status": "paused"},
-                                },
-                            )
-                            logger.info(
-                                f"WebChat: paused plan {plan['id'][:8]} on user message"
-                            )
-                    except Exception:
-                        pass
-
                 # Persist user message
                 save_text = text
                 if attachments and not text:
@@ -528,6 +495,7 @@ async def ws_chat(websocket: WebSocket):
                 if conversation_id:
                     user_msg_event = {
                         "type": "user_message",
+                        "conversation_id": conversation_id,
                         "sender": uid,
                         "display_name": user.get("display_name", uid),
                         "text": text,
@@ -539,7 +507,7 @@ async def ws_chat(websocket: WebSocket):
                         user_msg_event,
                         exclude_uid=uid,
                     )
-                    # Notify participants not currently viewing
+                    # Notify participants not currently viewing (unread only)
                     try:
                         from ui.routes.chat_api import list_conversation_participants
 
@@ -547,8 +515,6 @@ async def ws_chat(websocket: WebSocket):
                         viewers = _conversation_viewers.get(conversation_id, set())
                         for p_uid in all_parts:
                             if p_uid != uid and p_uid not in viewers:
-                                # Send the message itself + unread indicator
-                                await push_to_webchat(p_uid, user_msg_event)
                                 await push_to_webchat(
                                     p_uid,
                                     {

--- a/ui/templates/me/chat.html
+++ b/ui/templates/me/chat.html
@@ -568,6 +568,14 @@
                             </button>
                         </div>
                     </template>
+                    <!-- New message indicator (sticky at bottom) -->
+                    <button x-show="hasNewMessages"
+                            x-transition
+                            @click="jumpToBottom()"
+                            class="sticky bottom-0 left-1/2 -translate-x-1/2 mx-auto px-3 py-1.5 rounded-full bg-nordic-500 hover:bg-nordic-600 text-white text-xs font-medium shadow-lg flex items-center gap-1.5 transition-all z-10">
+                        <i class="fas fa-arrow-down"></i>
+                        {{ _("New messages") }}
+                    </button>
                 </div>
 
                 <!-- Attachment preview strip -->
@@ -696,6 +704,7 @@ function chatApp() {
         wsConnected: false,
         ws: null,
         msgCounter: 0,
+        hasNewMessages: false,
 
         // Mobile view toggle: 'conversations' or 'chat'
         mobileView: 'conversations',
@@ -771,6 +780,19 @@ function chatApp() {
                 Notification.requestPermission();
             }
             this.loadConversations();
+
+            // Reset hasNewMessages when user manually scrolls to bottom
+            setTimeout(function() {
+                var msgEl = document.getElementById('chat-messages');
+                if (msgEl) {
+                    msgEl.addEventListener('scroll', function() {
+                        var nearBottom = (msgEl.scrollHeight - msgEl.scrollTop - msgEl.clientHeight) < 50;
+                        if (nearBottom && self.hasNewMessages) {
+                            self.hasNewMessages = false;
+                        }
+                    });
+                }
+            }, 500);
 
             // Wire up the global file input
             var fileInput = document.getElementById('file-input');
@@ -1001,17 +1023,26 @@ function chatApp() {
                 .then(function(r) { return r.json(); })
                 .then(function(data) {
                     var msgs = (data.data && data.data.messages) || [];
+                    var currentUid = '{{ user.username }}';
                     self.messages = msgs.map(function(m) {
+                        var role = m.role;
+                        if (role === 'assistant') {
+                            role = 'agent';
+                        } else if (role === 'user' && m.sender_id && m.sender_id !== currentUid && m.sender_id !== 'system') {
+                            role = 'other_user';
+                        }
                         return {
                             id: ++self.msgCounter,
-                            role: m.role === 'assistant' ? 'agent' : m.role,
+                            role: role,
+                            sender: m.sender_id,
+                            display_name: m.sender_display_name || m.sender_id,
                             text: m.content,
                             time: self._formatTime(m.created_at),
                             agent: self.selectedAgent,
                         };
                     });
                     self.messagesLoading = false;
-                    self.$nextTick(function() { self.scrollToBottom(); });
+                    self.$nextTick(function() { self.scrollToBottom(true); });
                 })
                 .catch(function() {
                     self.messagesLoading = false;
@@ -1184,17 +1215,30 @@ function chatApp() {
                     self.$nextTick(function() { self.scrollToBottom(); });
                 } else if (data.type === 'user_message') {
                     // Message from another user in shared conversation
-                    var mentioned = (data.text || '').toLowerCase().indexOf('@{{ user.username }}') !== -1;
-                    self._notify(data.display_name || data.sender, (data.text || '').substring(0, 100), mentioned);
-                    self.messages.push({
-                        id: ++self.msgCounter,
-                        role: 'other_user',
-                        sender: data.sender,
-                        display_name: data.display_name || data.sender,
-                        text: data.text,
-                        time: data.time || new Date().toLocaleTimeString('it-IT', {hour: '2-digit', minute: '2-digit'}),
-                    });
-                    self.$nextTick(function() { self.scrollToBottom(); });
+                    // Only render if it belongs to the currently active conversation
+                    if (data.conversation_id && data.conversation_id !== self.activeConversationId) {
+                        // Mark the other conversation as unread and notify
+                        var mentioned = (data.text || '').toLowerCase().indexOf('@{{ user.username }}') !== -1;
+                        self._notify(data.display_name || data.sender, (data.text || '').substring(0, 100), mentioned);
+                        for (var i = 0; i < self.conversations.length; i++) {
+                            if (self.conversations[i].id === data.conversation_id) {
+                                self.conversations[i].unread = true;
+                                break;
+                            }
+                        }
+                    } else {
+                        var mentioned = (data.text || '').toLowerCase().indexOf('@{{ user.username }}') !== -1;
+                        self._notify(data.display_name || data.sender, (data.text || '').substring(0, 100), mentioned);
+                        self.messages.push({
+                            id: ++self.msgCounter,
+                            role: 'other_user',
+                            sender: data.sender,
+                            display_name: data.display_name || data.sender,
+                            text: data.text,
+                            time: data.time || new Date().toLocaleTimeString('it-IT', {hour: '2-digit', minute: '2-digit'}),
+                        });
+                        self.$nextTick(function() { self.scrollToBottom(); });
+                    }
                 } else if (data.type === 'participant_joined') {
                     self.messages.push({
                         id: ++self.msgCounter,
@@ -1346,7 +1390,7 @@ function chatApp() {
             this.ws.send(JSON.stringify(payload));
 
             var self = this;
-            this.$nextTick(function() { self.scrollToBottom(); });
+            this.$nextTick(function() { self.scrollToBottom(true); });
         },
 
         stopAgent() {
@@ -1819,7 +1863,8 @@ function chatApp() {
 
         executePlan() {
             if (!this.activeConversationId) return;
-            this.sendMessage('Proceed with the plan.');
+            this.inputText = 'Proceed with the plan.';
+            this.sendMessage();
         },
 
         resumePlan() {
@@ -1832,7 +1877,8 @@ function chatApp() {
             .then(function(data) {
                 if (data.ok) {
                     self._planResuming = true;
-                    self.sendMessage('Continue with the plan.');
+                    self.inputText = 'Continue with the plan.';
+                    self.sendMessage();
                     setTimeout(function() { self._planResuming = false; }, 2000);
                 }
             });
@@ -2085,9 +2131,24 @@ function chatApp() {
             }
         },
 
-        scrollToBottom() {
+        scrollToBottom(force) {
             var el = document.getElementById('chat-messages');
-            if (el) el.scrollTop = el.scrollHeight;
+            if (!el) return;
+            var nearBottom = (el.scrollHeight - el.scrollTop - el.clientHeight) < 100;
+            if (force || nearBottom) {
+                el.scrollTop = el.scrollHeight;
+                this.hasNewMessages = false;
+            } else {
+                // User is reading older messages — show "new message" indicator
+                this.hasNewMessages = true;
+            }
+        },
+
+        jumpToBottom() {
+            var el = document.getElementById('chat-messages');
+            if (!el) return;
+            el.scrollTop = el.scrollHeight;
+            this.hasNewMessages = false;
         }
     };
 }


### PR DESCRIPTION
## Summary

Multiple webchat bug fixes and UX improvements.

### Cross-conversation message bug

Messages sent in one conversation were appearing in the currently active conversation if it was different. Root cause: `user_message` events lacked `conversation_id` and the frontend pushed them blindly.

- Backend includes `conversation_id` in `user_message` event
- Frontend filters by `conversation_id`, only renders if matches active conversation; otherwise marks the source conversation as unread + notification
- Removed pushing `user_message` text to non-viewing participants (only unread badge needed)

### Message history showing wrong sender

In shared conversations, messages from other users were attributed to the current user after page reload. Root cause: `get_messages` didn't SELECT `sender_id`.

- `get_messages` SELECTs `sender_id` and JOINs `app.users` for `display_name`
- Frontend marks messages as `other_user` when `sender_id != current user`
- Bonus: `get_messages` now uses `validate_conversation_access` instead of strict ownership, so invited users can load shared conversation history

### Plan execution UX

- `Execute` and `Resume` buttons did nothing because they passed an argument to `sendMessage()` which is ignored (it reads `inputText`). Fixed by setting `inputText` before calling.
- Removed `pause-on-user-message`: too aggressive, prevented users from answering agent questions during a task without pausing the plan
- Stricter `planning_instructions` skill: explicit workflow rules requiring `in_progress -> completed` transitions per task, no skipping

### Smart scroll + new messages bubble

Auto-scroll to bottom was annoying when reading older messages. Now:

- Auto-scroll only triggers if user is already within 100px of bottom
- New `force` parameter for explicit scrolls (sendMessage, conversation load)
- Floating "New messages ↓" bubble appears when a message arrives while reading older content
- Click bubble or scroll manually to bottom → bubble disappears

## Test plan

- [ ] Open shared conversation, switch to another, have someone write — first conversation gets unread badge, current conversation does NOT receive the message
- [ ] Reload shared conversation page — other users' messages show with correct names and amber background
- [ ] Click `Execute` on a draft plan — sends "Proceed with the plan" to agent
- [ ] Reply to agent question during active plan — plan does NOT pause
- [ ] Scroll up in chat history, send a new message from another tab — chat does NOT auto-scroll, "New messages" bubble appears