### PR TITLE
Fix Codex CLI MCP tool approval and virtual tool filtering

### DIFF
--- a/core/mcp_gateway/server.py
+++ b/core/mcp_gateway/server.py
@@ -2018,8 +2018,19 @@ async def _handle_message(msg: dict, session_id: str, request: Request) -> dict 
                 if matches_permission(_VAULT_SERVER_NAME, mcp_perms):
                     tools.extend(_VAULT_TOOLS)
 
-            # Add virtual tool provider tools (always available — they are local plugins)
+            # Add virtual tool provider tools (filtered by agent's enabled plugins)
+            agent_enabled_plugins = None
+            if agent_name:
+                acfg = _load_agent_config(agent_name)
+                if acfg:
+                    plugins_cfg = acfg.get("plugins", {})
+                    if isinstance(plugins_cfg, dict) and "enabled" in plugins_cfg:
+                        agent_enabled_plugins = set(plugins_cfg["enabled"])
             for provider in _local_tool_providers:
+                if agent_enabled_plugins is not None:
+                    server_name = provider.get_server_name()
+                    if server_name not in agent_enabled_plugins:
+                        continue
                 tools.extend(provider.get_tools())
 
             # Discover active platform names for enum injection

--- a/plugins/openai/cli_backend.py
+++ b/plugins/openai/cli_backend.py
@@ -232,7 +232,12 @@ class OpenAICliBackend:
         if model:
             cmd.extend(["--model", model])
 
-        cmd.extend(["--full-auto", "--skip-git-repo-check"])
+        cmd.extend(
+            [
+                "--dangerously-bypass-approvals-and-sandbox",
+                "--skip-git-repo-check",
+            ]
+        )
         cmd.append(prompt)
 
         return cmd

--- a/ui/templates/plugins/partials/config_fields.html
+++ b/ui/templates/plugins/partials/config_fields.html
@@ -30,7 +30,17 @@
                     {{ schema.get('description', key) }}
                 </label>
 
-                {% if schema.get('enum') %}
+                {% if key == 'model' and runner_model_info is defined and runner_model_info.models %}
+                <select id="{{ key }}" name="{{ key }}"
+                        class="w-full bg-void-50 dark:bg-void-800/50 border border-void-200 dark:border-void-700 rounded-xl py-2.5 px-4 text-void-900 dark:text-white focus:outline-none focus:border-nordic-500/50 transition-all">
+                    {% for m in runner_model_info.models %}
+                    <option value="{{ m.id }}" {% if current_value == m.id %}selected{% endif %}>
+                        {{ m.name or m.id }}
+                    </option>
+                    {% endfor %}
+                </select>
+
+                {% elif schema.get('enum') %}
                 <select id="{{ key }}" name="{{ key }}"
                         class="w-full bg-void-50 dark:bg-void-800/50 border border-void-200 dark:border-void-700 rounded-xl py-2.5 px-4 text-void-900 dark:text-white focus:outline-none focus:border-nordic-500/50 transition-all">
                     {% for option in schema.enum %}


### PR DESCRIPTION
## Summary
- **Codex CLI**: Switch from `--full-auto` to `--dangerously-bypass-approvals-and-sandbox` — `--full-auto` only approves shell commands, not MCP tool calls, causing "user cancelled MCP tool call" errors
- **Virtual tool filtering**: Filter virtual tool providers (hetzner, videomaker, etc.) by agent's `plugins.enabled` list — was including all globally-enabled plugins regardless of agent config, exceeding OpenAI's 128 tool limit
- **Model dropdown**: Plugin config page now uses models registry (76 models from API refresh) instead of hardcoded manifest enum (10 models)

## Test plan
- [ ] Codex CLI backend calls MCP tools successfully (no "user cancelled" errors)
- [ ] Agent with restricted `plugins.enabled` only gets tools from those plugins
- [ ] Plugin config model dropdown shows all models from registry