### PR TITLE
Fix Vibe CLI model selection, auto-approve, and VTP filter

### DIFF
--- a/core/mcp_gateway/server.py
+++ b/core/mcp_gateway/server.py
@@ -1267,6 +1267,17 @@ async def _handle_search_tools(
     if unified_id:
         all_tools = _filter_by_user_prefs(all_tools, unified_id)
 
+    # Log post-filter breakdown
+    post_by_server = {}
+    for t in all_tools:
+        prefix = t["name"].split("__", 1)[0] if "__" in t["name"] else "builtin"
+        post_by_server[prefix] = post_by_server.get(prefix, 0) + 1
+    logger.info(
+        "search_tools: post-filter %d tools: %s",
+        len(all_tools),
+        ", ".join(f"{k}:{v}" for k, v in sorted(post_by_server.items())),
+    )
+
     # Score and rank tools
     keywords = query.split()
     scored: list[tuple[float, dict, str]] = []
@@ -2018,18 +2029,24 @@ async def _handle_message(msg: dict, session_id: str, request: Request) -> dict 
                 if matches_permission(_VAULT_SERVER_NAME, mcp_perms):
                     tools.extend(_VAULT_TOOLS)
 
-            # Add virtual tool provider tools (filtered by agent's enabled plugins)
-            agent_enabled_plugins = None
+            # Add virtual tool provider tools (filtered by agent config)
+            # Include if: in plugins.enabled OR in mcp_permissions
+            agent_allowed_vtp = None
             if agent_name:
                 acfg = _load_agent_config(agent_name)
                 if acfg:
+                    allowed = set()
                     plugins_cfg = acfg.get("plugins", {})
                     if isinstance(plugins_cfg, dict) and "enabled" in plugins_cfg:
-                        agent_enabled_plugins = set(plugins_cfg["enabled"])
+                        allowed.update(plugins_cfg["enabled"])
+                    agent_perms = acfg.get("mcp_permissions", [])
+                    if isinstance(agent_perms, list):
+                        allowed.update(agent_perms)
+                    agent_allowed_vtp = allowed
             for provider in _local_tool_providers:
-                if agent_enabled_plugins is not None:
+                if agent_allowed_vtp is not None:
                     server_name = provider.get_server_name()
-                    if server_name not in agent_enabled_plugins:
+                    if server_name not in agent_allowed_vtp:
                         continue
                 tools.extend(provider.get_tools())
 

--- a/plugins/mistral/cli_backend.py
+++ b/plugins/mistral/cli_backend.py
@@ -82,10 +82,10 @@ class MistralCliBackend:
         unified_id = kwargs.get("unified_id")
         if not no_tools and agent_id:
             self._prepare_mcp_token(agent_id, unified_id=unified_id)
-            # Ensure Vibe TOML has MCP server config pointing to gateway
+            # Ensure Vibe TOML has MCP server config + correct model
             from .config_generator import write_config
 
-            write_config(gateway_url=self._gateway_url)
+            write_config(gateway_url=self._gateway_url, model=effective_model)
 
         cmd = self._build_command(prompt=prompt)
         logger.debug("Running vibe: %d args, prompt_len=%d", len(cmd), len(prompt))

--- a/plugins/mistral/config_generator.py
+++ b/plugins/mistral/config_generator.py
@@ -44,13 +44,14 @@ api_key_format = "Bearer {{token}}"
 def write_config(
     gateway_url: str | None = None,
     mcp_token_env: str = "GRIDBEAR_MCP_TOKEN",
+    model: str | None = None,
 ) -> bool:
     """Ensure ~/.vibe/config.toml has the MCP gateway server configured.
 
     Uses text-level surgery to avoid corrupting Vibe's complex TOML
     (nested tables like [tools.bash] break with parse+reserialize).
-    Only touches the marked gridbear-gateway block — leaves everything
-    else (active_model, models, tools, providers) untouched.
+    Only touches the marked gridbear-gateway block and active_model —
+    leaves everything else (models, tools, providers) untouched.
 
     Returns True if the file was written successfully.
     """
@@ -80,8 +81,49 @@ def write_config(
         else:
             text = text.rstrip() + "\n\n" + gw_block + "\n"
 
+        # Ensure auto_approve is true for programmatic mode
+        if re.search(r"^auto_approve\s*=\s*false", text, re.MULTILINE):
+            text = re.sub(
+                r"^auto_approve\s*=\s*false",
+                "auto_approve = true",
+                text,
+                count=1,
+                flags=re.MULTILINE,
+            )
+
+        # Update active_model if specified
+        if model:
+            if re.search(r"^active_model\s*=", text, re.MULTILINE):
+                text = re.sub(
+                    r'^active_model\s*=\s*"[^"]*"',
+                    f'active_model = "{model}"',
+                    text,
+                    count=1,
+                    flags=re.MULTILINE,
+                )
+            else:
+                text = f'active_model = "{model}"\n' + text
+
+            # Ensure model is defined in [[models]] section
+            if f'name = "{model}"' not in text:
+                model_block = (
+                    f"\n[[models]]\n"
+                    f'name = "{model}"\n'
+                    f'provider = "mistral"\n'
+                    f"temperature = 0.2\n"
+                )
+                # Insert before the gateway block marker if present
+                if _GW_BLOCK_MARKER in text:
+                    text = text.replace(
+                        _GW_BLOCK_MARKER,
+                        model_block + "\n" + _GW_BLOCK_MARKER,
+                        1,
+                    )
+                else:
+                    text = text.rstrip() + "\n" + model_block
+
         VIBE_CONFIG_PATH.write_text(text)
-        logger.debug("Wrote Vibe MCP config: gateway=%s", gw_url)
+        logger.debug("Wrote Vibe MCP config: gateway=%s, model=%s", gw_url, model)
         return True
     except OSError as e:
         logger.warning("Could not write %s: %s", VIBE_CONFIG_PATH, e)


### PR DESCRIPTION
## Summary
- **Vibe CLI model**: Write `active_model` + model definition to config.toml before each invocation so the agent's configured model is actually used (was always using `devstral-2`)
- **Auto-approve**: Set `auto_approve = true` in Vibe config for programmatic mode — MCP tool calls were silently rejected without approval
- **VTP filter**: Virtual tool providers now included if server_name is in `mcp_permissions` OR `plugins.enabled` — no need to duplicate config in both places

## Test plan
- [ ] Vibe CLI uses the model configured in agent YAML (not config.toml default)
- [ ] MCP tool calls work through Vibe CLI (no silent rejection)
- [ ] Virtual tool provider plugins listed in mcp_permissions appear in agent's tool list