### PR TITLE
Backup plugin + prompt/planning improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,9 +75,9 @@ RUN ARCH=$(dpkg --print-architecture) \
     | tar xz -C /usr/local/bin github-mcp-server \
     && chmod +x /usr/local/bin/github-mcp-server
 
-# Install Google Sheets MCP server
+# Install Google Sheets MCP server + boto3 for S3 backup uploads
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system mcp-google-sheets
+    uv pip install --system mcp-google-sheets boto3
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libasound2 \
     libpango-1.0-0 \
     libcairo2 \
+    postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js for Claude CLI

--- a/core/mcp_gateway/server.py
+++ b/core/mcp_gateway/server.py
@@ -369,6 +369,7 @@ _BUILTIN_PREFIXES = (
     "ask_agent",
     "async_",
     "chat_history__",
+    "conversation_docs__",
     "credential_vault__",
     "search_tools",
     "execute_discovered_tool",
@@ -873,6 +874,90 @@ _CHAT_HISTORY_TOOLS = [
         },
     },
 ]
+
+
+# --- Conversation Documents tools ---
+
+_CONVERSATION_DOCS_TOOLS = [
+    {
+        "name": "conversation_docs__read",
+        "description": (
+            "Read the full text content of a document uploaded to the current "
+            "conversation. The list of available documents is shown in the system "
+            "prompt under [Conversation Documents]."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "conversation_id": {
+                    "type": "string",
+                    "description": "Conversation ID from channel_metadata",
+                },
+                "filename": {
+                    "type": "string",
+                    "description": "Original filename of the document to read",
+                },
+            },
+            "required": ["conversation_id", "filename"],
+        },
+    },
+]
+
+
+async def _handle_conversation_docs_call(
+    tool_name: str,
+    arguments: dict,
+) -> list[dict]:
+    """Handle conversation_docs__* virtual tool calls."""
+    from core.registry import get_database
+
+    db = get_database()
+    if db is None:
+        return [{"type": "text", "text": "Database not available."}]
+
+    short = tool_name.split("__", 1)[-1]
+
+    if short == "read":
+        conv_id = arguments.get("conversation_id", "").strip()
+        filename = arguments.get("filename", "").strip()
+        if not conv_id or not filename:
+            return [
+                {
+                    "type": "text",
+                    "text": "Error: conversation_id and filename are required.",
+                }
+            ]
+
+        try:
+            async with db.acquire() as conn:
+                row = await (
+                    await conn.execute(
+                        "SELECT original_filename, content_text "
+                        "FROM chat.webchat_documents "
+                        "WHERE conversation_id = %s "
+                        "AND original_filename = %s",
+                        (conv_id, filename),
+                    )
+                ).fetchone()
+                if not row:
+                    return [
+                        {
+                            "type": "text",
+                            "text": f"Document '{filename}' not found in this conversation.",
+                        }
+                    ]
+                text = row["content_text"] or "(no text content extracted)"
+                return [
+                    {
+                        "type": "text",
+                        "text": f"--- {row['original_filename']} ---\n{text}\n--- end ---",
+                    }
+                ]
+        except Exception as e:
+            logger.error("conversation_docs tool error: %s", e)
+            return [{"type": "text", "text": f"Error: {e}"}]
+
+    return [{"type": "text", "text": f"Unknown tool: {tool_name}"}]
 
 
 async def _handle_send_file(
@@ -1537,6 +1622,9 @@ async def _dispatch_tool_call(
     if tool_name.startswith("chat_history__"):
         return await _handle_chat_history_call(tool_name, arguments)
 
+    if tool_name.startswith("conversation_docs__"):
+        return await _handle_conversation_docs_call(tool_name, arguments)
+
     if tool_name.startswith("credential_vault__"):
         return await _handle_vault_call(tool_name, arguments)
 
@@ -2072,6 +2160,9 @@ async def _handle_message(msg: dict, session_id: str, request: Request) -> dict 
 
             # Add chat history tools (always available)
             tools.extend(_CHAT_HISTORY_TOOLS)
+
+            # Add conversation document tools (always available)
+            tools.extend(_CONVERSATION_DOCS_TOOLS)
 
             # Add search_tools + execute_discovered_tool (always available)
             tools.append(_SEARCH_TOOLS_TOOL)

--- a/main.py
+++ b/main.py
@@ -623,6 +623,28 @@ class AgentAwareMessageProcessor(MessageProcessor):
 
         full_prompt = builder.build()
 
+        # Plan execution: inject active task into prompt
+        _active_task = None
+        _conv_id = (
+            message.channel_metadata.get("conversation_id")
+            if message.channel_metadata
+            else None
+        )
+        if _conv_id:
+            try:
+                from plugins.planning.plan_executor import (
+                    build_task_prompt_injection,
+                    get_active_plan_task,
+                    mark_task_in_progress,
+                )
+
+                _active_task = get_active_plan_task(_conv_id)
+                if _active_task:
+                    full_prompt += build_task_prompt_injection(_active_task)
+                    await mark_task_in_progress(_active_task["task_id"], _conv_id)
+            except Exception as exc:
+                logger.debug("Plan executor pre-run failed: %s", exc)
+
         hook_data.prompt = full_prompt
         # Workflow steps get a fresh runner session (no --resume) to avoid
         # contamination from previous conversations.
@@ -717,6 +739,23 @@ class AgentAwareMessageProcessor(MessageProcessor):
 
         hook_data.response_text = response.text
         hook_data.session_id = response.session_id
+
+        # Plan execution: mark task completed after runner response
+        if _active_task and _conv_id and not response.is_error:
+            try:
+                from plugins.planning.plan_executor import (
+                    mark_task_completed,
+                    truncate_result,
+                )
+
+                await mark_task_completed(
+                    task_id=_active_task["task_id"],
+                    conversation_id=_conv_id,
+                    result=truncate_result(response.text),
+                    plan_id=_active_task["plan_id"],
+                )
+            except Exception as exc:
+                logger.debug("Plan executor post-run failed: %s", exc)
 
         # HOOK: after_runner_call
         hook_data = await self.hooks.execute(

--- a/plugins/claude/runner.py
+++ b/plugins/claude/runner.py
@@ -393,6 +393,31 @@ class ClaudeRunner(BaseRunner):
             )
             logger.debug(f"Running command: {' '.join(cmd)}")
 
+            # Always log prompt size for diagnostics
+            prompt_bytes = len(prompt.encode("utf-8"))
+            logger.info(
+                f"Prompt size: {prompt_bytes} bytes "
+                f"({prompt_bytes / 1024:.1f} KB, "
+                f"{prompt.count(chr(10))} lines)"
+            )
+
+            # Dump prompt to file for inspection (toggle via system_config)
+            try:
+                from core.system_config import SystemConfig
+
+                if SystemConfig.get_param_sync("dump_prompts"):
+                    dump_dir = Path("/app/data/prompt_dumps")
+                    dump_dir.mkdir(exist_ok=True)
+                    from datetime import datetime
+
+                    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+                    agent_label = agent_id or "unknown"
+                    dump_path = dump_dir / f"{agent_label}_{ts}.txt"
+                    dump_path.write_text(prompt, encoding="utf-8")
+                    logger.info(f"Prompt dumped to {dump_path}")
+            except Exception:
+                pass
+
             # Verbose logging: log full prompt
             if self.verbose:
                 logger.info("=" * 60)
@@ -415,7 +440,7 @@ class ClaudeRunner(BaseRunner):
                     )
 
                 try:
-                    result = await self._run_subprocess(cmd)
+                    result = await self._run_subprocess(cmd, stdin_data=prompt)
 
                     # Cancel feedback task if still pending
                     if feedback_task and not feedback_task.done():
@@ -547,11 +572,15 @@ class ClaudeRunner(BaseRunner):
         model: str | None = None,
         no_tools: bool = False,
     ) -> list[str]:
-        """Build Claude CLI command."""
+        """Build Claude CLI command.
+
+        The prompt is passed via stdin (not as a CLI argument) to avoid
+        OS ARG_MAX limits (~2MB) when the prompt grows large.
+        """
         cmd = [
             "claude",
             "-p",
-            prompt,
+            "-",  # Read prompt from stdin
             "--output-format",
             "json",
             "--model",
@@ -589,11 +618,21 @@ class ClaudeRunner(BaseRunner):
         return cmd
 
     async def _run_subprocess(
-        self, cmd: list[str], retry_without_resume: bool = True
+        self,
+        cmd: list[str],
+        retry_without_resume: bool = True,
+        stdin_data: str | None = None,
     ) -> str:
-        """Run subprocess and return stdout."""
+        """Run subprocess and return stdout.
+
+        Args:
+            cmd: Command to execute.
+            retry_without_resume: Retry without --resume on session expiry.
+            stdin_data: Data to pass via stdin (used for prompt).
+        """
         process = await asyncio.create_subprocess_exec(
             *cmd,
+            stdin=asyncio.subprocess.PIPE if stdin_data else None,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=self.working_dir,
@@ -601,8 +640,9 @@ class ClaudeRunner(BaseRunner):
         )
 
         try:
+            stdin_bytes = stdin_data.encode("utf-8") if stdin_data else None
             stdout, stderr = await asyncio.wait_for(
-                process.communicate(), timeout=self.timeout
+                process.communicate(input=stdin_bytes), timeout=self.timeout
             )
         except asyncio.TimeoutError:
             process.kill()
@@ -633,7 +673,11 @@ class ClaudeRunner(BaseRunner):
                         skip_next = True
                         continue
                     new_cmd.append(c)
-                return await self._run_subprocess(new_cmd, retry_without_resume=False)
+                return await self._run_subprocess(
+                    new_cmd,
+                    retry_without_resume=False,
+                    stdin_data=stdin_data,
+                )
 
         if not stdout_str and stderr_str:
             logger.warning(f"No stdout, stderr: {stderr_str[:1000]}")

--- a/plugins/planning/plan_executor.py
+++ b/plugins/planning/plan_executor.py
@@ -1,0 +1,208 @@
+"""Plan execution helper — auto-advance tasks without model cooperation.
+
+Called by the message processor before/after runner invocation
+to manage plan task lifecycle. The model doesn't need to call
+planning tools — the code handles status transitions.
+"""
+
+from __future__ import annotations
+
+from config.logging_config import logger
+
+
+def get_active_plan_task(conversation_id: str) -> dict | None:
+    """Find the active plan's next actionable task.
+
+    Returns dict with plan + task info, or None if no active plan.
+    """
+    try:
+        from core.registry import get_database
+
+        db = get_database()
+        if not db:
+            return None
+
+        with db.acquire_sync() as conn:
+            plan = conn.execute(
+                "SELECT id, title, status FROM chat.webchat_plans "
+                "WHERE conversation_id = %s AND status = 'active' "
+                "LIMIT 1",
+                (conversation_id,),
+            ).fetchone()
+            if not plan:
+                return None
+
+            # Check for a task already in_progress (resume after timeout/crash)
+            current = conn.execute(
+                "SELECT id, title, description, position FROM chat.webchat_plan_tasks "
+                "WHERE plan_id = %s AND status = 'in_progress' "
+                "ORDER BY position LIMIT 1",
+                (plan["id"],),
+            ).fetchone()
+
+            if not current:
+                # Find next pending task
+                current = conn.execute(
+                    "SELECT id, title, description, position FROM chat.webchat_plan_tasks "
+                    "WHERE plan_id = %s AND status = 'pending' "
+                    "ORDER BY position LIMIT 1",
+                    (plan["id"],),
+                ).fetchone()
+
+            if not current:
+                return None
+
+            total = conn.execute(
+                "SELECT count(*) as cnt FROM chat.webchat_plan_tasks "
+                "WHERE plan_id = %s",
+                (plan["id"],),
+            ).fetchone()["cnt"]
+
+            return {
+                "plan_id": plan["id"],
+                "plan_title": plan["title"],
+                "task_id": current["id"],
+                "task_title": current["title"],
+                "task_description": current["description"] or "",
+                "task_position": current["position"] + 1,  # 1-based
+                "total_tasks": total,
+            }
+    except Exception as exc:
+        logger.debug("get_active_plan_task failed: %s", exc)
+        return None
+
+
+async def mark_task_in_progress(task_id: str, conversation_id: str) -> None:
+    """Set task to in_progress and broadcast to webchat."""
+    try:
+        from core.registry import get_database
+
+        db = get_database()
+        if not db:
+            return
+
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc)
+
+        async with db.acquire() as conn:
+            await conn.execute(
+                "UPDATE chat.webchat_plan_tasks "
+                "SET status = 'in_progress', started_at = %s "
+                "WHERE id = %s AND status IN ('pending', 'in_progress')",
+                (now, task_id),
+            )
+            await conn.execute("COMMIT")
+
+        await _broadcast(
+            conversation_id,
+            {
+                "type": "plan_task_update",
+                "task_id": task_id,
+                "status": "in_progress",
+            },
+        )
+    except Exception as exc:
+        logger.debug("mark_task_in_progress failed: %s", exc)
+
+
+async def mark_task_completed(
+    task_id: str,
+    conversation_id: str,
+    result: str,
+    plan_id: str,
+) -> None:
+    """Set task to completed, check if plan is done, broadcast."""
+    try:
+        from core.registry import get_database
+
+        db = get_database()
+        if not db:
+            return
+
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc)
+
+        async with db.acquire() as conn:
+            await conn.execute(
+                "UPDATE chat.webchat_plan_tasks "
+                "SET status = 'completed', completed_at = %s, result = %s "
+                "WHERE id = %s AND status = 'in_progress'",
+                (now, result, task_id),
+            )
+            await conn.execute(
+                "UPDATE chat.webchat_plans SET updated_at = %s WHERE id = %s",
+                (now, plan_id),
+            )
+
+            # Check if all tasks are done
+            pending = await (
+                await conn.execute(
+                    "SELECT count(*) as cnt FROM chat.webchat_plan_tasks "
+                    "WHERE plan_id = %s AND status IN ('pending', 'in_progress')",
+                    (plan_id,),
+                )
+            ).fetchone()
+
+            plan_status_change = None
+            if pending and pending["cnt"] == 0:
+                await conn.execute(
+                    "UPDATE chat.webchat_plans SET status = 'completed', "
+                    "updated_at = %s WHERE id = %s",
+                    (now, plan_id),
+                )
+                plan_status_change = "completed"
+
+            await conn.execute("COMMIT")
+
+        event = {
+            "type": "plan_task_update",
+            "task_id": task_id,
+            "status": "completed",
+            "result": result,
+        }
+        if plan_status_change:
+            event["plan_status"] = plan_status_change
+        await _broadcast(conversation_id, event)
+
+        if plan_status_change:
+            logger.info("Plan %s completed (all tasks done)", plan_id)
+    except Exception as exc:
+        logger.debug("mark_task_completed failed: %s", exc)
+
+
+def build_task_prompt_injection(task_info: dict) -> str:
+    """Build prompt text to inject for the active task."""
+    desc = task_info["task_description"]
+    desc_block = f"\nDescription: {desc}" if desc else ""
+
+    return (
+        f'\n\n[Active Plan: "{task_info["plan_title"]}"]\n'
+        f"You are currently working on task {task_info['task_position']} "
+        f"of {task_info['total_tasks']}:\n"
+        f"Title: {task_info['task_title']}{desc_block}\n\n"
+        f"Focus ONLY on this task. When done, report what you did.\n"
+        f"Do NOT proceed to the next task — stop and wait for instructions."
+    )
+
+
+def truncate_result(text: str, max_len: int = 200) -> str:
+    """Truncate response text for task result summary."""
+    if not text:
+        return "Completed"
+    # Take first line or first max_len chars
+    first_line = text.strip().split("\n")[0]
+    if len(first_line) <= max_len:
+        return first_line
+    return first_line[:max_len] + "..."
+
+
+async def _broadcast(conversation_id: str, event: dict) -> None:
+    """Broadcast event to webchat viewers."""
+    try:
+        from ui.routes.ws_chat import broadcast_to_conversation
+
+        await broadcast_to_conversation(conversation_id, event)
+    except Exception as exc:
+        logger.debug("Plan executor broadcast failed: %s", exc)

--- a/sessions/context_builder.py
+++ b/sessions/context_builder.py
@@ -742,40 +742,24 @@ When sending emails as {self._agent_display_name or "yourself"}, ALWAYS append t
                 f"if they are in the right conversation."
             )
 
-        # Include conversation documents (per-conversation knowledge base)
+        # Include conversation documents (metadata only — content via tool)
         if self._conversation_documents:
-            doc_parts = []
-            total_chars = 0
-            max_chars = 100_000  # 100KB total cap for all documents
+            doc_lines = []
             for doc in self._conversation_documents:
-                text = doc.get("content_text", "")
                 fname = doc.get("original_filename", "document")
-                if not text:
-                    doc_parts.append(
-                        f"--- document: {fname} ---\n"
-                        f"(no text content extracted)\n"
-                        f"--- end document ---"
-                    )
-                    continue
-                remaining = max_chars - total_chars
-                if remaining <= 0:
-                    doc_parts.append(
-                        f"--- document: {fname} ---\n"
-                        f"(skipped — context size limit reached)\n"
-                        f"--- end document ---"
-                    )
-                    continue
-                if len(text) > remaining:
-                    text = text[:remaining] + "\n... (truncated)"
-                total_chars += len(text)
-                doc_parts.append(
-                    f"--- document: {fname} ---\n{text}\n--- end document ---"
-                )
+                text = doc.get("content_text", "")
+                size_kb = len(text) / 1024 if text else 0
+                status = f"{size_kb:.0f}KB" if text else "no text"
+                doc_lines.append(f"- {fname} ({status})")
+            conv_id = ""
+            if self._channel_metadata:
+                conv_id = self._channel_metadata.get("conversation_id", "")
             parts.append(
                 "[Conversation Documents]\n"
-                "The user has uploaded the following documents to this "
-                "conversation. Reference them when answering questions.\n\n"
-                + "\n\n".join(doc_parts)
+                "The user has uploaded documents to this conversation. "
+                "To read their content, use the conversation_docs__read tool "
+                f'with conversation_id="{conv_id}" and the filename.\n\n'
+                + "\n".join(doc_lines)
             )
 
         # Include recent chat history for conversational context

--- a/ui/routes/settings.py
+++ b/ui/routes/settings.py
@@ -40,6 +40,7 @@ def get_template_context(request: Request, **kwargs) -> dict:
 @router.get("", response_class=HTMLResponse)
 async def settings_page(request: Request, _=Depends(require_login)):
     """General settings page."""
+    from core.system_config import SystemConfig
     from ui import tts_service
 
     encryption_available = secrets_manager.is_available()
@@ -53,6 +54,8 @@ async def settings_page(request: Request, _=Depends(require_login)):
     tts_providers = tts_service.get_available_providers()
     current_tts_provider = config.get_webchat_tts_provider()
 
+    dump_prompts = bool(SystemConfig.get_param_sync("dump_prompts"))
+
     return templates.TemplateResponse(
         "settings.html",
         get_template_context(
@@ -64,6 +67,7 @@ async def settings_page(request: Request, _=Depends(require_login)):
             bot_email_settings=bot_email_settings,
             tts_providers=tts_providers,
             current_tts_provider=current_tts_provider,
+            dump_prompts=dump_prompts,
         ),
     )
 
@@ -115,6 +119,19 @@ async def save_bot_settings(
     )
 
     return RedirectResponse("/settings?saved=bot", status_code=303)
+
+
+@router.post("/debug")
+async def save_debug_settings(
+    request: Request,
+    dump_prompts: str = Form(""),
+    _=Depends(require_login),
+):
+    """Save debug/diagnostics settings."""
+    from core.system_config import SystemConfig
+
+    SystemConfig.set_param_sync("dump_prompts", dump_prompts == "on")
+    return RedirectResponse("/settings?saved=debug", status_code=303)
 
 
 @router.post("/tts")

--- a/ui/templates/me/chat.html
+++ b/ui/templates/me/chat.html
@@ -1982,7 +1982,8 @@ function chatApp() {
 
         executePlan() {
             if (!this.activeConversationId) return;
-            this.inputText = 'Proceed with the plan.';
+            var mention = this.selectedAgent ? '@' + this.selectedAgent + ' ' : '';
+            this.inputText = mention + 'Proceed with the plan.';
             this.sendMessage();
         },
 

--- a/ui/templates/settings.html
+++ b/ui/templates/settings.html
@@ -195,6 +195,33 @@
             </div>
         </div>
 
+        <!-- Debug / Diagnostics -->
+        <div class="rounded-2xl bg-white dark:bg-void-900/50 border border-void-200 dark:border-void-800 overflow-hidden">
+            <div class="p-5 border-b border-void-200 dark:border-void-800 bg-gradient-to-r from-frost-500/5 to-transparent">
+                <h3 class="font-semibold text-void-900 dark:text-white flex items-center gap-2">
+                    <i class="fas fa-bug text-frost-500"></i>
+                    Diagnostics
+                </h3>
+            </div>
+            <div class="p-5">
+                <form method="POST" action="/settings/debug">
+                    {% include "partials/csrf_field.html" %}
+                    <label class="flex items-center gap-3 cursor-pointer">
+                        <input type="checkbox" name="dump_prompts" {{ 'checked' if dump_prompts else '' }}
+                               class="rounded text-nordic-500 focus:ring-nordic-500/40">
+                        <div>
+                            <span class="text-sm font-medium text-void-900 dark:text-white">Dump prompts to file</span>
+                            <p class="text-xs text-void-500 dark:text-void-400">Save full prompts to <code class="text-xs">/data/prompt_dumps/</code> for inspection</p>
+                        </div>
+                    </label>
+                    <button type="submit" class="mt-4 inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-nordic-500 hover:bg-nordic-600 text-white font-medium transition-all shadow-lg shadow-nordic-500/20">
+                        <i class="fas fa-save"></i>
+                        Save
+                    </button>
+                </form>
+            </div>
+        </div>
+
         <!-- Quick Commands -->
         <div class="rounded-2xl bg-void-900 dark:bg-void-800/50 border border-void-800 overflow-hidden text-white">
             <div class="p-5 border-b border-void-800">


### PR DESCRIPTION
## Summary
- **Backup infrastructure**: install boto3 and postgresql-client in Docker for S3 backup uploads and pg_dump
- **Prompt stdin**: pass prompts via stdin instead of CLI arg to avoid OS ARG_MAX limit on large prompts
- **Conversation documents via tool**: documents no longer injected inline in prompt (was ~100KB), now accessible via `conversation_docs__read` tool on demand
- **Diagnostics toggle**: dump_prompts setting in admin UI (Settings > Diagnostics), no restart needed
- **Plan auto-advance**: plan task lifecycle managed by code (in_progress/completed), no model cooperation needed
- **Webchat plan fix**: Execute button mentions @agent in shared conversations

## Test plan
- [x] Prompt stdin: tested with large prompt, no ARG_MAX error
- [x] Document tool: prompt reduced from 134KB to 32KB, tool returns content correctly
- [x] Diagnostics toggle: verified dump files created in /data/prompt_dumps/
- [ ] Plan auto-advance: needs end-to-end test with active plan
- [ ] Backup: needs S3 integration test