### PR TITLE
Agent service_account + fix agent save data loss

### DIFF
--- a/main.py
+++ b/main.py
@@ -500,14 +500,22 @@ class AgentAwareMessageProcessor(MessageProcessor):
         if not unified_id and username_lower:
             unified_id = get_unified_user_id(message.platform, username_lower)
 
+        # Service account override: use the agent's own identity for MCP
+        # permissions and gateway context (e.g. bot agents with their own
+        # Odoo credentials). The sender's unified_id is kept for memories.
+        ctx_opts = self.agent_context.get("context_options", {})
+        service_account = ctx_opts.get("service_account")
+        mcp_unified_id = service_account if service_account else unified_id
+
         extra_servers = []
         shared_accounts = {}
-        if unified_id:
-            shared_accounts = get_group_shared_accounts(unified_id)
+        if mcp_unified_id:
+            shared_accounts = get_group_shared_accounts(mcp_unified_id)
             for plugin_name, accounts in shared_accounts.items():
                 extra_servers.extend(
                     _expand_shared_accounts(self.plugin_manager, plugin_name, accounts)
                 )
+        if unified_id:
             # User locale can override agent locale if set
             user_locale = get_user_locale(unified_id) or user_locale
 
@@ -515,7 +523,7 @@ class AgentAwareMessageProcessor(MessageProcessor):
             username=username_lower,
             platform=message.platform,
             is_group_chat=message.is_group_chat,
-            unified_id=unified_id,
+            unified_id=mcp_unified_id,
             agent_mcp_permissions=agent_mcp_permissions or None,
             extra_servers=extra_servers,
         )
@@ -538,9 +546,6 @@ class AgentAwareMessageProcessor(MessageProcessor):
         builder.set_locale(user_locale)
         builder.set_voice_response(message.respond_with_voice)
         builder.set_allowed_mcp_servers(hook_data.mcp_permissions)
-
-        # Agent-level context_options for lightweight prompts (e.g. Ollama)
-        ctx_opts = self.agent_context.get("context_options", {})
 
         if not ctx_opts.get("skip_calendars"):
             builder.set_shared_accounts(shared_accounts)
@@ -596,8 +601,6 @@ class AgentAwareMessageProcessor(MessageProcessor):
         # was recycled — load more history so Claude can recover context
         is_cold_start = bool(session and not session.runner_session_id)
 
-        # Agent-level context_options for lightweight prompts (e.g. Ollama)
-        ctx_opts = self.agent_context.get("context_options", {})
         mem_limit = ctx_opts.get("memories", 5)
         hist_limit = ctx_opts.get("history_limit", 20 if is_cold_start else 10)
         hist_chars = ctx_opts.get("history_max_chars", 6000 if is_cold_start else 3000)
@@ -710,7 +713,7 @@ class AgentAwareMessageProcessor(MessageProcessor):
             agent_id=agent_id,
             model=agent_model or None,
             system_prompt=agent_system_prompt,
-            unified_id=unified_id,
+            unified_id=mcp_unified_id,
             max_tools=agent_max_tools,
             tool_loading=agent_tool_loading,
         )

--- a/ui/routes/agents.py
+++ b/ui/routes/agents.py
@@ -554,6 +554,8 @@ async def save_agent_config(
 
     if avatar_value:
         config["avatar"] = avatar_value
+    elif existing_config.get("avatar"):
+        config["avatar"] = existing_config["avatar"]
 
     # Channels - read dynamically from form data
     form_data = await request.form()
@@ -603,6 +605,11 @@ async def save_agent_config(
 
     # Plugins - always save what form sends
     config["plugins"] = {"enabled": plugins_enabled}
+
+    # Preserve fields not managed by the form
+    for preserve_key in ("context_options", "services"):
+        if preserve_key in existing_config and preserve_key not in config:
+            config[preserve_key] = existing_config[preserve_key]
 
     save_agent(agent_id, config)
 

--- a/ui/routes/agents.py
+++ b/ui/routes/agents.py
@@ -564,7 +564,10 @@ async def save_agent_config(
         users_key = f"{ch_name}_allowed_users"
         token_value = form_data.get(token_key, "")
         if token_value:
-            ch_config = {"token_secret": token_value}
+            # Preserve existing channel config (e.g. phone_number_id)
+            # and only update form-managed fields
+            ch_config = channels.get(ch_name, {}).copy()
+            ch_config["token_secret"] = token_value
             allowed = form_data.getlist(users_key)
             if allowed:
                 ch_config["allowed_users"] = [u.strip() for u in allowed if u.strip()]


### PR DESCRIPTION
## Summary
- **Service account**: agents can set `service_account` in `context_options` to use their own MCP credentials (e.g. Odoo OAuth2) instead of the message sender's identity. Sender identity preserved for memories.
- **Fix agent save**: the admin form was losing channel custom fields (e.g. `phone_number_id`), avatar, `context_options`, and `services` on every save. Now preserves existing values for fields not managed by the form.

## Test plan
- [x] Unit tests pass (627)
- [x] Serena agent uses her own Odoo credentials via service_account
- [x] Agent save preserves phone_number_id in channel config
- [ ] Agent save preserves avatar after editing other fields

## Known issues (not in scope)
- Agent reload from admin doesn't set message handler for whatsapp_api channel (requires full restart)
- phone_number_id has no UI field — must be set via SQL