### PR TITLE
Fix WhatsApp media sending + phone_number_id admin UI

### DIFF
--- a/core/agent.py
+++ b/core/agent.py
@@ -225,8 +225,17 @@ class Agent:
         self._channels[platform] = channel
 
     def get_channel(self, platform: str) -> "BaseChannel | None":
-        """Get channel by platform name."""
-        return self._channels.get(platform)
+        """Get channel by platform name or plugin name."""
+        # Direct lookup by plugin name (e.g. "whatsapp_api", "telegram")
+        ch = self._channels.get(platform)
+        if ch:
+            return ch
+        # Fallback: search by channel's platform attribute
+        # (e.g. whatsapp_api plugin declares platform = "whatsapp")
+        for channel in self._channels.values():
+            if getattr(channel, "platform", None) == platform:
+                return channel
+        return None
 
     def get_channel_names(self) -> list[str]:
         """Return list of available channel platform names."""

--- a/plugins/whatsapp_api/adapter.py
+++ b/plugins/whatsapp_api/adapter.py
@@ -314,8 +314,15 @@ class WhatsAppMetaChannel(BaseChannel):
         mime_type, _ = mimetypes.guess_type(file_path)
         mime_type = mime_type or "application/octet-stream"
 
+        logger.info(
+            "WhatsApp Meta: uploading file %s (%s) for %s",
+            path.name,
+            mime_type,
+            phone,
+        )
         try:
             media_id = await self._client.upload_media(file_path, mime_type)
+            logger.info("WhatsApp Meta: uploaded media_id=%s", media_id)
         except Exception as exc:
             logger.error(
                 "WhatsApp Meta: failed to upload media %s: %s",
@@ -331,6 +338,7 @@ class WhatsAppMetaChannel(BaseChannel):
                 await self._client.send_audio(phone, media_id)
             else:
                 await self._client.send_document(phone, media_id, caption, path.name)
+            logger.info("WhatsApp Meta: file sent to %s (%s)", phone, path.name)
             return True
         except Exception as exc:
             logger.error(

--- a/plugins/whatsapp_api/admin/routes.py
+++ b/plugins/whatsapp_api/admin/routes.py
@@ -33,14 +33,79 @@ async def whatsapp_api_dashboard(request: Request, _=Depends(require_login)):
     base_url = os.getenv("GRIDBEAR_BASE_URL", "").rstrip("/")
     webhook_url = f"{base_url}/api/whatsapp_api/webhook"
 
+    # Load agent channel configs for phone_number_id display
+    agent_channels = _get_agent_whatsapp_configs()
+
     return templates.TemplateResponse(
         "whatsapp_api.html",
         get_plugin_template_context(
             request,
             PLUGIN_DIR,
             webhook_url=webhook_url,
+            agent_channels=agent_channels,
         ),
     )
+
+
+def _get_agent_whatsapp_configs() -> list[dict]:
+    """Get all agents that have whatsapp_api configured."""
+    try:
+        from core.models.agent_config import AgentConfigRecord
+
+        records = AgentConfigRecord.search_sync(
+            [("is_active", "=", True)], order="name"
+        )
+        result = []
+        for r in records:
+            channels = r.get("channels") or {}
+            wa_config = channels.get("whatsapp_api")
+            if wa_config:
+                result.append(
+                    {
+                        "agent_id": r["id"],
+                        "agent_name": r["name"],
+                        "phone_number_id": wa_config.get("phone_number_id", ""),
+                    }
+                )
+        return result
+    except Exception:
+        return []
+
+
+@router.post("/agent-channel", response_class=JSONResponse)
+async def save_agent_channel(request: Request, _=Depends(require_login)):
+    """Save phone_number_id for an agent's whatsapp_api channel."""
+    from core.models.agent_config import AgentConfigRecord
+
+    body = await request.json()
+    agent_id = body.get("agent_id", "").strip()
+    phone_number_id = body.get("phone_number_id", "").strip()
+
+    if not agent_id:
+        return JSONResponse(
+            {"ok": False, "error": "agent_id is required"}, status_code=400
+        )
+
+    try:
+        record = AgentConfigRecord.get_sync(id=agent_id)
+        if not record:
+            return JSONResponse(
+                {"ok": False, "error": "Agent not found"}, status_code=404
+            )
+
+        channels = dict(record.get("channels") or {})
+        wa_config = dict(channels.get("whatsapp_api") or {})
+        wa_config["phone_number_id"] = phone_number_id
+        channels["whatsapp_api"] = wa_config
+
+        AgentConfigRecord.create_or_update_sync(
+            _conflict_fields=("id",),
+            id=agent_id,
+            channels=channels,
+        )
+        return JSONResponse({"ok": True})
+    except Exception as exc:
+        return JSONResponse({"ok": False, "error": str(exc)}, status_code=500)
 
 
 @router.get("/authorized", response_class=JSONResponse)

--- a/plugins/whatsapp_api/admin/templates/whatsapp_api.html
+++ b/plugins/whatsapp_api/admin/templates/whatsapp_api.html
@@ -1,6 +1,38 @@
 {% extends "plugins/plugin_base.html" %}
 
 {% block plugin_content_after %}
+<!-- Agent Phone Numbers -->
+<div class="rounded-2xl bg-white dark:bg-void-900/50 border border-void-200 dark:border-void-800 overflow-hidden">
+    <div class="p-5 border-b border-void-200 dark:border-void-800 bg-gradient-to-r from-green-500/5 to-transparent">
+        <h3 class="font-semibold text-void-900 dark:text-white flex items-center gap-2">
+            <i class="fas fa-robot text-green-500"></i>
+            Agent Phone Numbers
+        </h3>
+        <p class="text-sm text-void-500 dark:text-void-400 mt-1">
+            Configure the Meta Phone Number ID for each agent using WhatsApp.
+        </p>
+    </div>
+    <div class="p-5 space-y-3">
+        {% for ac in agent_channels %}
+        <div class="flex items-center gap-3" id="agent-ch-{{ ac.agent_id }}">
+            <span class="text-sm font-medium text-void-700 dark:text-void-300 w-32">{{ ac.agent_name }}</span>
+            <input type="text" value="{{ ac.phone_number_id }}"
+                   id="pnid-{{ ac.agent_id }}"
+                   placeholder="Phone Number ID"
+                   class="flex-1 bg-void-50 dark:bg-void-800/50 border border-void-200 dark:border-void-700 rounded-xl py-2 px-3 text-sm font-mono text-void-900 dark:text-white focus:outline-none focus:border-green-500/50">
+            <button onclick="savePhoneNumberId('{{ ac.agent_id }}')"
+                    class="px-3 py-2 rounded-xl bg-green-500 hover:bg-green-600 text-white text-sm font-medium transition-all">
+                <i class="fas fa-save"></i>
+            </button>
+            <span id="pnid-status-{{ ac.agent_id }}" class="text-xs"></span>
+        </div>
+        {% endfor %}
+        {% if not agent_channels %}
+        <p class="text-sm text-void-400">No agents have whatsapp_api configured in their channels.</p>
+        {% endif %}
+    </div>
+</div>
+
 <!-- Webhook URL -->
 <div class="rounded-2xl bg-white dark:bg-void-900/50 border border-void-200 dark:border-void-800 overflow-hidden">
     <div class="p-5 border-b border-void-200 dark:border-void-800 bg-gradient-to-r from-green-500/5 to-transparent">
@@ -120,6 +152,26 @@
 
 {% block plugin_extra_js %}
 <script>
+async function savePhoneNumberId(agentId) {
+    const input = document.getElementById('pnid-' + agentId);
+    const status = document.getElementById('pnid-status-' + agentId);
+    const csrfToken = document.querySelector('[name=csrf_token]')?.value || '';
+    try {
+        const resp = await fetch('agent-channel', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken},
+            body: JSON.stringify({agent_id: agentId, phone_number_id: input.value.trim()}),
+        });
+        const data = await resp.json();
+        status.textContent = data.ok ? 'Saved' : data.error;
+        status.className = 'text-xs ' + (data.ok ? 'text-green-500' : 'text-red-500');
+        setTimeout(function() { status.textContent = ''; }, 3000);
+    } catch (e) {
+        status.textContent = 'Error';
+        status.className = 'text-xs text-red-500';
+    }
+}
+
 function authorizedNumbers() {
     return {
         numbers: [],


### PR DESCRIPTION
## Summary
- **Media sending fix**: `Agent.get_channel()` now falls back to matching by channel's `platform` attribute. The whatsapp_api plugin declares `platform = "whatsapp"` but is registered under key `"whatsapp_api"` in agent channels — `send_file_to_chat` was looking up `"whatsapp"` and getting None.
- **Phone Number ID admin**: new section in plugin admin page to view/edit `phone_number_id` per agent, eliminating the need for SQL.

## Test plan
- [x] Unit tests pass (627)
- [ ] Send WhatsApp message asking for an image → verify media is sent
- [ ] Plugin admin page shows agents with phone_number_id field
- [ ] Edit phone_number_id from admin → reload agent → verify channel works