### PR TITLE
Add session TTL to invalidate stale Claude sessions

### DIFF
--- a/main.py
+++ b/main.py
@@ -652,6 +652,7 @@ class AgentAwareMessageProcessor(MessageProcessor):
         # Workflow steps get a fresh runner session (no --resume) to avoid
         # contamination from previous conversations.
         _source = inter_agent_context.get("source", "") if inter_agent_context else ""
+        _session_ttl_expired = False
         if _source == "workflow":
             hook_data.session_id = None
         else:
@@ -659,7 +660,6 @@ class AgentAwareMessageProcessor(MessageProcessor):
 
             # Session TTL: invalidate runner session if too old
             session_ttl = ctx_opts.get("session_ttl_minutes")
-            _session_ttl_expired = False
             if session_ttl and session and session.runner_session_id:
                 try:
                     from datetime import datetime, timedelta, timezone

--- a/main.py
+++ b/main.py
@@ -657,6 +657,25 @@ class AgentAwareMessageProcessor(MessageProcessor):
         else:
             hook_data.session_id = session.runner_session_id if session else None
 
+            # Session TTL: invalidate runner session if too old
+            session_ttl = ctx_opts.get("session_ttl_minutes")
+            if session_ttl and session and session.runner_session_id:
+                try:
+                    from datetime import datetime, timedelta, timezone
+
+                    last_update = session.updated_at
+                    if last_update.tzinfo is None:
+                        last_update = last_update.replace(tzinfo=timezone.utc)
+                    age = datetime.now(timezone.utc) - last_update
+                    if age > timedelta(minutes=int(session_ttl)):
+                        logger.info(
+                            "Session TTL expired (%d min), starting fresh",
+                            session_ttl,
+                        )
+                        hook_data.session_id = None
+                except Exception as exc:
+                    logger.debug("Session TTL check failed: %s", exc)
+
         # HOOK: after_context_build
         hook_data = await self.hooks.execute(
             HookName.AFTER_CONTEXT_BUILD,

--- a/main.py
+++ b/main.py
@@ -659,6 +659,7 @@ class AgentAwareMessageProcessor(MessageProcessor):
 
             # Session TTL: invalidate runner session if too old
             session_ttl = ctx_opts.get("session_ttl_minutes")
+            _session_ttl_expired = False
             if session_ttl and session and session.runner_session_id:
                 try:
                     from datetime import datetime, timedelta, timezone
@@ -673,6 +674,7 @@ class AgentAwareMessageProcessor(MessageProcessor):
                             session_ttl,
                         )
                         hook_data.session_id = None
+                        _session_ttl_expired = True
                 except Exception as exc:
                     logger.debug("Session TTL check failed: %s", exc)
 
@@ -761,6 +763,14 @@ class AgentAwareMessageProcessor(MessageProcessor):
 
         hook_data.response_text = response.text
         hook_data.session_id = response.session_id
+
+        # Prefix response with TTL notice if session was reset
+        if _session_ttl_expired and not response.is_error and response.text:
+            ttl_msg = ctx_opts.get(
+                "session_ttl_message",
+                "_(Conversazione precedente chiusa per inattività)_",
+            )
+            hook_data.response_text = f"{ttl_msg}\n\n{response.text}"
 
         # Plan execution: mark task completed after runner response
         if _active_task and _conv_id and not response.is_error:


### PR DESCRIPTION
## Summary
Configurable per-agent session TTL via `context_options.session_ttl_minutes`. When the last message is older than the TTL, the runner starts a fresh Claude session (no `--resume`) instead of reusing the stale one. Solves the issue where public agents (Serena on WhatsApp) cache outdated tool responses for hours.

## Test plan
- [x] Unit tests pass (627)
- [x] Set Serena to 30min TTL, verify fresh session after timeout
- [ ] Verify normal conversations within TTL still resume correctly