### PR TITLE
Persist agent avatars via bind mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - .env
     volumes:
       - ./data:/app/data
+      - ./data/avatars:/app/ui/static/avatars
       - ./credentials:/app/credentials
       - ./config:/app/config
       - claude_state:/home/gridbear/.claude


### PR DESCRIPTION
Mount `./data/avatars` to `/app/ui/static/avatars` so avatars survive container rebuilds. Previously they were stored inside the image and got lost.