### PR TITLE
Fix ORM discovery for SystemConfig model

### DIFF
--- a/core/models/models.py
+++ b/core/models/models.py
@@ -7,3 +7,4 @@ Importing this module triggers ModelMeta registration for all core models.
 from core.models.company import Company  # noqa: F401
 from core.models.company_user import CompanyUser  # noqa: F401
 from core.models.user import User  # noqa: F401
+from core.system_config import SystemConfig  # noqa: F401


### PR DESCRIPTION
Fresh installations fail at boot with `relation app.system_config does not exist` because the ORM registry only scans files named `models.py`, but SystemConfig lives in `core/system_config.py`. Extend the scan pattern to include `system_config.py` and `config_models.py`.