### PR TITLE
Fix default company insert on fresh install

### DIFF
--- a/core/config_migration.py
+++ b/core/config_migration.py
@@ -439,9 +439,9 @@ async def migrate_create_default_company() -> bool:
         # 1. Create default company with OVERRIDING SYSTEM VALUE to force id=1
         await conn.execute(
             """
-            INSERT INTO app.companies (id, name, slug, active, locale, timezone, plan)
+            INSERT INTO app.companies (id, name, slug, active, locale, timezone)
             OVERRIDING SYSTEM VALUE
-            VALUES (1, 'Default', 'default', TRUE, 'en', 'UTC', 'free')
+            VALUES (1, 'Default', 'default', TRUE, 'en', 'UTC')
             ON CONFLICT (id) DO NOTHING
             """
         )


### PR DESCRIPTION
On fresh installs, `app.companies` table is created by the ORM without the `plan` column (removed from model previously). The migration INSERT still references `plan` → UndefinedColumn.

Remove `plan` from the INSERT. Model defaults handle locale/timezone.