### PR TITLE
Fix fresh install: entrypoint for bind-mount ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ffmpeg \
+    gosu \
     libnss3 \
     libnspr4 \
     libatk1.0-0 \
@@ -87,13 +88,15 @@ RUN npm install --save-dev tailwindcss @tailwindcss/forms daisyui \
     && rm -rf node_modules
 
 # Create directories and set ownership
-RUN mkdir -p /app/data/attachments /app/credentials /home/gridbear/.claude /home/gridbear/.codex && \
+RUN mkdir -p /app/data/attachments /app/data/models /app/data/avatars /app/credentials /home/gridbear/.claude /home/gridbear/.codex && \
     chown -R gridbear:gridbear /app /home/gridbear
+
+# Entrypoint fixes bind-mount ownership then drops to gridbear user
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/app
 
-# Switch to non-root user
-USER gridbear
-
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["python", "main.py"]

--- a/core/models/models.py
+++ b/core/models/models.py
@@ -4,6 +4,16 @@ Discovered by Registry._scan_directory() via rglob("models.py").
 Importing this module triggers ModelMeta registration for all core models.
 """
 
+from core.config_models import (  # noqa: F401
+    ChannelAuthorizedUser,
+    GroupMcpPermission,
+    MemoryGroup,
+    OAuthToken,
+    PasswordToken,
+    UserMcpPermission,
+    UserPlatform,
+    UserServiceAccount,
+)
 from core.models.company import Company  # noqa: F401
 from core.models.company_user import CompanyUser  # noqa: F401
 from core.models.user import User  # noqa: F401

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Fix ownership of bind-mounted volumes before dropping privileges.
+# Users bind ./data, ./config, ./credentials from their host filesystem;
+# those dirs are typically owned by a different uid than the gridbear user
+# inside the container.
+
+set -e
+
+for dir in /app/data /app/config /app/credentials; do
+    if [ -d "$dir" ]; then
+        chown -R gridbear:gridbear "$dir" 2>/dev/null || true
+    fi
+done
+
+# Ensure subdirs that plugins create on-demand exist with correct ownership
+mkdir -p /app/data/attachments /app/data/models /app/data/avatars
+chown -R gridbear:gridbear /app/data
+
+exec gosu gridbear "$@"

--- a/main.py
+++ b/main.py
@@ -1243,12 +1243,13 @@ async def main():
     set_plugin_manager(plugin_manager)
 
     if not plugin_manager.runners:
-        logger.error(
+        logger.warning(
             "No runner plugin enabled. "
-            "Enable at least one runner (e.g. claude) via the admin UI plugin manager."
+            "Enable at least one runner (e.g. claude) via the admin UI plugin manager. "
+            "Agents will not respond to messages until a runner is configured."
         )
-        sys.exit(1)
-    logger.info(f"Runners loaded: {list(plugin_manager.runners.keys())}")
+    else:
+        logger.info(f"Runners loaded: {list(plugin_manager.runners.keys())}")
 
     # Log MCP servers count (config is generated on-demand, never written to disk)
     mcp_servers = plugin_manager.get_all_mcp_server_names()

--- a/main.py
+++ b/main.py
@@ -1269,13 +1269,12 @@ async def main():
     agents_list = agent_manager.list_agents()
 
     if not agents_list:
-        logger.error(
+        logger.warning(
             "No agents configured. "
-            "Add a YAML file in config/agents/ or use the Admin UI at %s to create one. "
-            "See config/agents/ for .example files.",
+            "Use the Admin UI at %s to create one. "
+            "Messaging features are disabled until at least one agent exists.",
             os.environ.get("GRIDBEAR_BASE_URL", "http://localhost:8088"),
         )
-        sys.exit(1)
 
     logger.info(
         f"Loaded {len(agents_list)} agent(s): {[a['name'] for a in agents_list]}"


### PR DESCRIPTION
On fresh installs (or hosts where uid != 1000), bind-mounted `./data` is owned by the host user, not `gridbear` (uid 1000). This causes `PermissionError` when gridbear tries to create subdirs like `/app/data/models`.

Add an entrypoint script that runs as root, chowns the bind mounts, creates standard subdirs, then drops to `gridbear` via `gosu`.

Accumulates fixes for the fresh-install flow. More fixes may be added to this branch before merge.