### PR TITLE
Artifacts plugin: standalone HTML with share-token capability URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ config/executor.json
 # Agent configs (contain tokens and authorized users)
 config/agents/*.yaml
 config/agents/*.yml
+config/agents/*.migrated
 !config/agents/*.example
 
 # Gmail MCP credentials and tokens
@@ -125,3 +126,6 @@ node_modules/
 package-lock.json
 ui/static/css/output.css
 config/monitoring/
+
+# Claude Code Playwright MCP session artifacts (host-side, not container)
+.playwright-mcp/

--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -51,6 +51,15 @@ The hook system uses a different architecture and API design.
 
 Cheshire Cat AI is licensed under GPLv3.
 
+### Anthropic Claude Artifacts
+
+The single-file HTML artifact pattern — self-contained HTML/CSS/JS with
+embedded data, rendered in a sandboxed iframe — is modelled after the
+[Artifacts feature](https://www.anthropic.com/news/artifacts) in Anthropic's
+Claude consumer UI. GridBear's implementation is entirely original code;
+the pattern is architectural inspiration. Anthropic's product is
+proprietary; no code was copied.
+
 ### Memory System Terminology
 
 The memory system uses standard cognitive science terminology:

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN npm install --save-dev tailwindcss @tailwindcss/forms daisyui \
     && rm -rf node_modules
 
 # Create directories and set ownership
-RUN mkdir -p /app/data/attachments /app/data/models /app/data/avatars /app/credentials /home/gridbear/.claude /home/gridbear/.codex && \
+RUN mkdir -p /app/data/attachments /app/data/models /app/data/avatars /app/data/artifacts /app/credentials /home/gridbear/.claude /home/gridbear/.codex && \
     chown -R gridbear:gridbear /app /home/gridbear
 
 # Entrypoint fixes bind-mount ownership then drops to gridbear user

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -34,11 +34,6 @@ services:
       - WEBAUTHN_RP_ID=${WEBAUTHN_RP_ID:-localhost}
       - WEBAUTHN_RP_NAME=GridBear
       - WEBAUTHN_ORIGIN=${WEBAUTHN_ORIGIN:-http://localhost:8088}
-      # Container role. In a split bot/ui deployment set this to "bot" on
-      # the bot container and "ui" on the UI container so background
-      # workers (e.g. artifacts cleanup) only run on the UI side. Leave
-      # unset for single-process deployments (bot + UI in one container).
-      # - GRIDBEAR_ROLE=bot
     expose:
       - "8000"
     ports:

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -34,6 +34,11 @@ services:
       - WEBAUTHN_RP_ID=${WEBAUTHN_RP_ID:-localhost}
       - WEBAUTHN_RP_NAME=GridBear
       - WEBAUTHN_ORIGIN=${WEBAUTHN_ORIGIN:-http://localhost:8088}
+      # Container role. In a split bot/ui deployment set this to "bot" on
+      # the bot container and "ui" on the UI container so background
+      # workers (e.g. artifacts cleanup) only run on the UI side. Leave
+      # unset for single-process deployments (bot + UI in one container).
+      # - GRIDBEAR_ROLE=bot
     expose:
       - "8000"
     ports:

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -12,7 +12,6 @@ services:
     volumes:
       - ./data:/app/data
       - ./data/avatars:/app/ui/static/avatars
-      - ./data/artifacts:/app/data/artifacts
       - ./credentials:/app/credentials
       - ./config:/app/config
       - claude_state:/home/gridbear/.claude

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -12,6 +12,7 @@ services:
     volumes:
       - ./data:/app/data
       - ./data/avatars:/app/ui/static/avatars
+      - ./data/artifacts:/app/data/artifacts
       - ./credentials:/app/credentials
       - ./config:/app/config
       - claude_state:/home/gridbear/.claude

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ for dir in /app/data /app/config /app/credentials; do
 done
 
 # Ensure subdirs that plugins create on-demand exist with correct ownership
-mkdir -p /app/data/attachments /app/data/models /app/data/avatars
+mkdir -p /app/data/attachments /app/data/models /app/data/avatars /app/data/artifacts
 chown -R gridbear:gridbear /app/data
 
 exec gosu gridbear "$@"

--- a/plugins/artifacts/__init__.py
+++ b/plugins/artifacts/__init__.py
@@ -1,0 +1,1 @@
+"""Artifacts plugin — standalone HTML artifacts with capability URLs."""

--- a/plugins/artifacts/__init__.py
+++ b/plugins/artifacts/__init__.py
@@ -1,1 +1,3 @@
 """Artifacts plugin — standalone HTML artifacts with capability URLs."""
+
+from plugins.artifacts import models  # noqa: F401  — register ORM model

--- a/plugins/artifacts/admin/menu.json
+++ b/plugins/artifacts/admin/menu.json
@@ -1,0 +1,11 @@
+{
+  "items": [
+    {
+      "label": "Artifacts",
+      "url": "/plugin/artifacts",
+      "icon": "fa-solid fa-cubes",
+      "section": "services",
+      "priority": 20
+    }
+  ]
+}

--- a/plugins/artifacts/admin/routes.py
+++ b/plugins/artifacts/admin/routes.py
@@ -1,0 +1,120 @@
+"""Admin routes for the artifacts plugin."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from ui.jinja_env import templates
+from ui.plugin_helpers import get_plugin_template_context
+from ui.routes.auth import require_login
+
+router = APIRouter()
+
+PLUGIN_DIR = Path(__file__).resolve().parent.parent
+
+
+def _get_plugin_metadata() -> dict:
+    return {
+        "name": "artifacts",
+        "display_name": "Artifacts",
+        "icon": "fa-solid fa-cubes",
+    }
+
+
+@router.get("/", response_class=HTMLResponse)
+@router.get("", response_class=HTMLResponse)
+async def list_artifacts(
+    request: Request,
+    _=Depends(require_login),
+    agent: str | None = None,
+    owner: str | None = None,
+    status: str | None = None,
+):
+    from plugins.artifacts.models import Artifact
+
+    domain: list = []
+    if agent:
+        domain.append(("agent_id", "=", agent))
+    if owner:
+        domain.append(("owner_user_id", "=", owner))
+    rows = await Artifact.search(domain, order="created_at DESC", limit=200)
+
+    now = datetime.now(UTC)
+    enriched = []
+    for r in rows:
+        if r["revoked_at"]:
+            s = "revoked"
+        elif r["expires_at"] < now and not r["pinned"]:
+            s = "expired"
+        else:
+            s = "active"
+        if status and status != s:
+            continue
+        r = dict(r)
+        r["_status"] = s
+        enriched.append(r)
+
+    return templates.TemplateResponse(
+        "list.html",
+        get_plugin_template_context(
+            request,
+            PLUGIN_DIR,
+            artifacts=enriched,
+            filter_agent=agent or "",
+            filter_owner=owner or "",
+            filter_status=status or "",
+        ),
+    )
+
+
+@router.get("/{uuid}", response_class=HTMLResponse)
+async def artifact_detail(request: Request, uuid: str, _=Depends(require_login)):
+    from plugins.artifacts.models import Artifact
+    from plugins.artifacts.signing import build_capability_url
+
+    rows = await Artifact.search([("id", "=", uuid)])
+    if not rows:
+        return HTMLResponse("Not Found", status_code=404)
+    row = dict(rows[0])
+    row["capability_url"] = build_capability_url(uuid)
+    return templates.TemplateResponse(
+        "detail.html",
+        get_plugin_template_context(request, PLUGIN_DIR, artifact=row),
+    )
+
+
+@router.post("/{uuid}/pin")
+async def admin_pin(uuid: str, pinned: str = Form(...), _=Depends(require_login)):
+    from plugins.artifacts.service import ArtifactsService
+
+    # HTML checkbox sends "true"/"false" as string
+    await ArtifactsService().pin(uuid, pinned=pinned.lower() == "true")
+    return RedirectResponse(f"/plugin/artifacts/{uuid}", status_code=303)
+
+
+@router.post("/{uuid}/revoke")
+async def admin_revoke(uuid: str, _=Depends(require_login)):
+    from plugins.artifacts.service import ArtifactsService
+
+    await ArtifactsService().revoke(uuid)
+    return RedirectResponse(f"/plugin/artifacts/{uuid}", status_code=303)
+
+
+@router.post("/{uuid}/unrevoke")
+async def admin_unrevoke(uuid: str, _=Depends(require_login)):
+    from plugins.artifacts.service import ArtifactsService
+
+    await ArtifactsService().unrevoke(uuid)
+    return RedirectResponse(f"/plugin/artifacts/{uuid}", status_code=303)
+
+
+@router.post("/{uuid}/delete")
+async def admin_delete(uuid: str, _=Depends(require_login)):
+    from plugins.artifacts.service import ArtifactsService
+
+    await ArtifactsService().hard_delete(uuid)
+    return RedirectResponse("/plugin/artifacts/", status_code=303)

--- a/plugins/artifacts/admin/routes.py
+++ b/plugins/artifacts/admin/routes.py
@@ -30,9 +30,11 @@ def _get_plugin_metadata() -> dict:
 async def list_artifacts(
     request: Request,
     _=Depends(require_login),
+    q: str | None = None,
     agent: str | None = None,
     owner: str | None = None,
     status: str | None = None,
+    share: str | None = None,
 ):
     from plugins.artifacts.models import Artifact
 
@@ -41,6 +43,12 @@ async def list_artifacts(
         domain.append(("agent_id", "=", agent))
     if owner:
         domain.append(("owner_user_id", "=", owner))
+    if share == "active":
+        domain.append(("share_token", "!=", None))
+    elif share == "revoked":
+        domain.append(("share_token", "=", None))
+    if q:
+        domain.append(("title", "ilike", f"%{q}%"))
     rows = await Artifact.search(domain, order="created_at DESC", limit=200)
 
     now = datetime.now(UTC)
@@ -64,9 +72,11 @@ async def list_artifacts(
             request,
             PLUGIN_DIR,
             artifacts=enriched,
+            filter_q=q or "",
             filter_agent=agent or "",
             filter_owner=owner or "",
             filter_status=status or "",
+            filter_share=share or "",
         ),
     )
 
@@ -80,7 +90,9 @@ async def artifact_detail(request: Request, uuid: str, _=Depends(require_login))
     if not rows:
         return HTMLResponse("Not Found", status_code=404)
     row = dict(rows[0])
-    row["capability_url"] = build_capability_url(uuid)
+    row["capability_url"] = build_capability_url(
+        uuid, share_token=row.get("share_token")
+    )
     return templates.TemplateResponse(
         "detail.html",
         get_plugin_template_context(request, PLUGIN_DIR, artifact=row),
@@ -118,3 +130,19 @@ async def admin_delete(uuid: str, _=Depends(require_login)):
 
     await ArtifactsService().hard_delete(uuid)
     return RedirectResponse("/plugin/artifacts/", status_code=303)
+
+
+@router.post("/{uuid}/share/regenerate")
+async def admin_regenerate_share(uuid: str, _=Depends(require_login)):
+    from plugins.artifacts.service import ArtifactsService
+
+    await ArtifactsService().regenerate_share_token(uuid)
+    return RedirectResponse(f"/plugin/artifacts/{uuid}", status_code=303)
+
+
+@router.post("/{uuid}/share/revoke")
+async def admin_revoke_share(uuid: str, _=Depends(require_login)):
+    from plugins.artifacts.service import ArtifactsService
+
+    await ArtifactsService().revoke_share_token(uuid)
+    return RedirectResponse(f"/plugin/artifacts/{uuid}", status_code=303)

--- a/plugins/artifacts/admin/templates/artifact_modal.html
+++ b/plugins/artifacts/admin/templates/artifact_modal.html
@@ -1,0 +1,177 @@
+{# Artifact preview modal - included from the webchat main template via Jinja ChoiceLoader.
+
+   Although conceptually this is a "webchat" partial, it lives under the
+   plugin's admin/templates/ directory because that path is already registered
+   with the Jinja ChoiceLoader in ui/jinja_env.py::rebuild_template_loader().
+   Keeping the file here avoids any loader changes and preserves the
+   core/ui -> plugin dependency isolation (ui never imports from plugins;
+   this is a pure template inclusion resolved at render time).
+
+   Behavior:
+   1) Scans assistant messages for /artifacts/<uuid>?t=<hex> URLs
+   2) Appends a preview card below the message with Preview + New-tab buttons
+   3) Opens the iframe (sandboxed) in the modal when Preview is clicked
+#}
+<div x-data="artifactModal()" x-show="open" x-cloak
+     @keydown.escape.window="open = false"
+     @artifact-open.window="openModal($event.detail.url, $event.detail.title)"
+     class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+  <div class="bg-white dark:bg-void-900 rounded-2xl shadow-2xl w-full max-w-5xl max-h-[90vh] flex flex-col"
+       @click.stop>
+    <div class="flex items-center justify-between px-4 py-3 border-b border-void-200 dark:border-void-800">
+      <h2 class="font-semibold truncate" x-text="title"></h2>
+      <div class="flex gap-2 flex-shrink-0">
+        <a :href="url" target="_blank" rel="noopener noreferrer"
+           class="px-3 py-1 rounded bg-nordic-500 hover:bg-nordic-600 text-white text-sm">
+          <i class="fas fa-arrow-up-right-from-square mr-1"></i> Open in new tab
+        </a>
+        <button @click="open = false"
+                class="px-3 py-1 rounded bg-void-200 dark:bg-void-700 hover:bg-void-300 dark:hover:bg-void-600 text-sm">
+          <i class="fas fa-xmark"></i>
+        </button>
+      </div>
+    </div>
+    <iframe x-show="embedUrl" :src="embedUrl"
+            sandbox="allow-scripts allow-forms allow-popups"
+            referrerpolicy="no-referrer"
+            class="w-full h-[80vh] border-0 rounded-b-2xl bg-white"></iframe>
+  </div>
+</div>
+
+<script>
+function artifactModal() {
+  return {
+    open: false,
+    title: "",
+    url: "",
+    embedUrl: "",
+    openModal(url, title) {
+      this.url = url;
+      this.embedUrl = url + (url.includes('?') ? '&' : '?') + 'mode=embed';
+      this.title = title || "Artifact";
+      this.open = true;
+    }
+  };
+}
+</script>
+
+<script>
+(function() {
+  // Matches an absolute or relative artifact URL with a uuid and hex token.
+  const ARTIFACT_RE = /(https?:\/\/[^\s<"'()]+\/artifacts\/[0-9a-f-]{36}\?t=[0-9a-f]{32}|\/artifacts\/[0-9a-f-]{36}\?t=[0-9a-f]{32})/gi;
+
+  function extractUrls(text) {
+    if (!text) return [];
+    const out = new Set();
+    let match;
+    ARTIFACT_RE.lastIndex = 0;
+    while ((match = ARTIFACT_RE.exec(text)) !== null) {
+      out.add(match[1]);
+    }
+    return Array.from(out);
+  }
+
+  function buildCard(url) {
+    const card = document.createElement('div');
+    card.setAttribute('data-artifact-card', url);
+    card.className = 'mt-3 p-3 border border-void-200 dark:border-void-700 rounded-lg bg-void-50 dark:bg-void-800/40 flex justify-between items-center gap-3';
+
+    const label = document.createElement('div');
+    label.className = 'min-w-0 flex-1';
+
+    const title = document.createElement('div');
+    title.className = 'text-sm font-semibold flex items-center gap-2';
+    const icon = document.createElement('i');
+    icon.className = 'fas fa-cube text-nordic-500';
+    const titleText = document.createElement('span');
+    titleText.textContent = 'Artifact';
+    title.appendChild(icon);
+    title.appendChild(titleText);
+
+    const subtitle = document.createElement('div');
+    subtitle.className = 'text-xs text-void-500 truncate';
+    subtitle.textContent = url;
+
+    label.appendChild(title);
+    label.appendChild(subtitle);
+
+    const actions = document.createElement('div');
+    actions.className = 'flex gap-2 flex-shrink-0';
+
+    const previewBtn = document.createElement('button');
+    previewBtn.type = 'button';
+    previewBtn.className = 'px-3 py-1.5 rounded-lg bg-nordic-500 hover:bg-nordic-600 text-white text-xs font-medium';
+    previewBtn.textContent = 'Preview';
+    previewBtn.addEventListener('click', function() {
+      window.dispatchEvent(new CustomEvent('artifact-open', {
+        detail: { url: url, title: 'Artifact' }
+      }));
+    });
+
+    const newTab = document.createElement('a');
+    newTab.className = 'px-3 py-1.5 rounded-lg bg-void-200 dark:bg-void-700 hover:bg-void-300 dark:hover:bg-void-600 text-xs font-medium';
+    newTab.textContent = 'New tab';
+    newTab.href = url;
+    newTab.target = '_blank';
+    newTab.rel = 'noopener noreferrer';
+
+    actions.appendChild(previewBtn);
+    actions.appendChild(newTab);
+    card.appendChild(label);
+    card.appendChild(actions);
+    return card;
+  }
+
+  // Given a message container (.msg-agent), find the .prose content,
+  // extract artifact URLs, and append one card per unique URL (dedup).
+  function decorate(container) {
+    if (!container || container.nodeType !== 1) return;
+    const prose = container.querySelector ? container.querySelector('.prose') : null;
+    if (!prose) return;
+    const text = prose.textContent || '';
+    const urls = extractUrls(text);
+    if (!urls.length) return;
+    for (const url of urls) {
+      const existing = container.querySelector('[data-artifact-card="' + CSS.escape(url) + '"]');
+      if (existing) continue;
+      container.appendChild(buildCard(url));
+    }
+  }
+
+  function scanAll(root) {
+    const scope = root && root.querySelectorAll ? root : document;
+    const nodes = scope.querySelectorAll ? scope.querySelectorAll('.msg-agent') : [];
+    nodes.forEach(decorate);
+    if (root && root.nodeType === 1 && root.classList && root.classList.contains('msg-agent')) {
+      decorate(root);
+    }
+  }
+
+  function observe() {
+    scanAll(document);
+    const observer = new MutationObserver(function(mutations) {
+      for (const m of mutations) {
+        m.addedNodes.forEach(function(node) {
+          if (node.nodeType !== 1) return;
+          scanAll(node);
+        });
+        if (m.type === 'characterData' || m.type === 'childList') {
+          const target = m.target && m.target.closest ? m.target.closest('.msg-agent') : null;
+          if (target) decorate(target);
+        }
+      }
+    });
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      characterData: true
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', observe);
+  } else {
+    observe();
+  }
+})();
+</script>

--- a/plugins/artifacts/admin/templates/detail.html
+++ b/plugins/artifacts/admin/templates/detail.html
@@ -1,0 +1,58 @@
+{% extends "plugins/plugin_subpage.html" %}
+
+{% block subpage_content %}
+<div class="space-y-4">
+  <div class="flex items-center gap-3">
+    <h2 class="text-xl font-semibold">{{ artifact.title }}</h2>
+    {% if artifact.revoked_at %}
+      <span class="px-2 py-0.5 rounded text-xs bg-red-100 text-red-800">revoked</span>
+    {% elif artifact.pinned %}
+      <span class="px-2 py-0.5 rounded text-xs bg-blue-100 text-blue-800">pinned</span>
+    {% endif %}
+  </div>
+
+  <div class="text-sm text-void-500 space-y-1">
+    <div>Agent: <span class="font-mono">{{ artifact.agent_id }}</span></div>
+    <div>Owner: <span class="font-mono">{{ artifact.owner_user_id }}</span></div>
+    <div>Size: {{ (artifact.size_bytes // 1024) }} KB</div>
+    <div>Created: {{ artifact.created_at }}</div>
+    <div>Expires: {% if artifact.pinned %}∞{% else %}{{ artifact.expires_at }}{% endif %}</div>
+  </div>
+
+  <div class="bg-void-50 dark:bg-void-800/50 p-3 rounded">
+    <label class="text-xs text-void-500">Capability URL</label>
+    <input type="text" readonly value="{{ artifact.capability_url }}"
+           class="w-full bg-white dark:bg-void-900 border rounded px-3 py-1 font-mono text-xs">
+  </div>
+
+  <iframe src="{{ artifact.capability_url }}&amp;mode=embed"
+          sandbox="allow-scripts"
+          class="w-full h-96 border rounded"></iframe>
+
+  <div class="flex gap-2">
+    <form method="post" action="/plugin/artifacts/{{ artifact.id }}/pin">
+      {% include "partials/csrf_field.html" %}
+      <input type="hidden" name="pinned" value="{{ 'false' if artifact.pinned else 'true' }}">
+      <button class="px-3 py-1 rounded bg-blue-500 text-white text-sm">
+        {{ 'Unpin' if artifact.pinned else 'Pin' }}
+      </button>
+    </form>
+    {% if artifact.revoked_at %}
+    <form method="post" action="/plugin/artifacts/{{ artifact.id }}/unrevoke">
+      {% include "partials/csrf_field.html" %}
+      <button class="px-3 py-1 rounded bg-yellow-500 text-white text-sm">Unrevoke</button>
+    </form>
+    {% else %}
+    <form method="post" action="/plugin/artifacts/{{ artifact.id }}/revoke">
+      {% include "partials/csrf_field.html" %}
+      <button class="px-3 py-1 rounded bg-yellow-500 text-white text-sm">Revoke</button>
+    </form>
+    {% endif %}
+    <form method="post" action="/plugin/artifacts/{{ artifact.id }}/delete"
+          onsubmit="return confirm('Delete this artifact permanently?')">
+      {% include "partials/csrf_field.html" %}
+      <button class="px-3 py-1 rounded bg-red-500 text-white text-sm">Delete</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/plugins/artifacts/admin/templates/detail.html
+++ b/plugins/artifacts/admin/templates/detail.html
@@ -1,9 +1,23 @@
-{% extends "plugins/plugin_subpage.html" %}
+{% extends "base.html" %}
 
-{% block subpage_content %}
-<div class="space-y-4">
-  <div class="flex items-center gap-3">
-    <h2 class="text-xl font-semibold">{{ artifact.title }}</h2>
+{% block title %}{{ artifact.title }} - Artifacts - GridBear Admin{% endblock %}
+{% block page_title %}Artifact Detail{% endblock %}
+
+{% block content %}
+<div class="mb-4">
+  <a href="/plugin/artifacts/" class="text-sm text-blue-600 hover:underline">
+    <i class="fa-solid fa-arrow-left"></i> Back to list
+  </a>
+</div>
+
+<div class="rounded-2xl bg-white dark:bg-void-900/50 border border-void-200 dark:border-void-800 p-5 space-y-4">
+  <div class="flex items-center gap-3 flex-wrap">
+    <h2 class="text-xl font-semibold text-void-900 dark:text-white">{{ artifact.title }}</h2>
+    {% if artifact.share_token %}
+      <span class="px-2 py-0.5 rounded text-xs bg-orange-100 text-orange-800"><i class="fa-solid fa-link"></i> share active</span>
+    {% else %}
+      <span class="px-2 py-0.5 rounded text-xs bg-void-200 text-void-800"><i class="fa-solid fa-link-slash"></i> share revoked</span>
+    {% endif %}
     {% if artifact.revoked_at %}
       <span class="px-2 py-0.5 rounded text-xs bg-red-100 text-red-800">revoked</span>
     {% elif artifact.pinned %}
@@ -11,7 +25,7 @@
     {% endif %}
   </div>
 
-  <div class="text-sm text-void-500 space-y-1">
+  <div class="text-sm text-void-600 dark:text-void-400 space-y-1">
     <div>Agent: <span class="font-mono">{{ artifact.agent_id }}</span></div>
     <div>Owner: <span class="font-mono">{{ artifact.owner_user_id }}</span></div>
     <div>Size: {{ (artifact.size_bytes // 1024) }} KB</div>
@@ -20,16 +34,67 @@
   </div>
 
   <div class="bg-void-50 dark:bg-void-800/50 p-3 rounded">
-    <label class="text-xs text-void-500">Capability URL</label>
-    <input type="text" readonly value="{{ artifact.capability_url }}"
-           class="w-full bg-white dark:bg-void-900 border rounded px-3 py-1 font-mono text-xs">
+    <label class="text-xs text-void-500">
+      {% if artifact.share_token %}Shareable URL (anyone with this link can view){% else %}URL (owner/admin only — share token revoked){% endif %}
+    </label>
+    <div class="flex gap-2 items-center">
+      <input type="text" readonly value="{{ artifact.capability_url }}"
+             id="share-url-input"
+             class="flex-1 bg-white dark:bg-void-900 border rounded px-3 py-1 font-mono text-xs">
+      <button type="button"
+              onclick="copyShareUrl(this)"
+              class="px-3 py-1 rounded border text-sm whitespace-nowrap hover:bg-void-100 dark:hover:bg-void-700">
+        <i class="fa-regular fa-copy"></i>
+        <span data-label>Copy</span>
+      </button>
+    </div>
   </div>
+  <script>
+    function copyShareUrl(btn) {
+      const input = document.getElementById('share-url-input');
+      const label = btn.querySelector('[data-label]');
+      navigator.clipboard.writeText(input.value).then(() => {
+        const orig = label.textContent;
+        label.textContent = 'Copied';
+        setTimeout(() => { label.textContent = orig; }, 1500);
+      }).catch(() => {
+        // Fallback for older browsers / non-HTTPS contexts
+        input.select();
+        document.execCommand('copy');
+        label.textContent = 'Copied';
+        setTimeout(() => { label.textContent = 'Copy'; }, 1500);
+      });
+    }
+  </script>
 
   <iframe src="{{ artifact.capability_url }}&amp;mode=embed"
           sandbox="allow-scripts"
           class="w-full h-96 border rounded"></iframe>
 
-  <div class="flex gap-2">
+  <div class="flex flex-wrap gap-2 pt-2 border-t border-void-200 dark:border-void-800">
+    {% if artifact.share_token %}
+    <form method="post" action="/plugin/artifacts/{{ artifact.id }}/share/regenerate"
+          onsubmit="return confirm('Regenerate share link? The previous link will stop working.')">
+      {% include "partials/csrf_field.html" %}
+      <button class="px-3 py-1 rounded bg-orange-500 text-white text-sm">
+        <i class="fa-solid fa-rotate"></i> Regenerate share link
+      </button>
+    </form>
+    <form method="post" action="/plugin/artifacts/{{ artifact.id }}/share/revoke"
+          onsubmit="return confirm('Revoke share link? External users will lose access.')">
+      {% include "partials/csrf_field.html" %}
+      <button class="px-3 py-1 rounded bg-void-600 text-white text-sm">
+        <i class="fa-solid fa-link-slash"></i> Revoke share link
+      </button>
+    </form>
+    {% else %}
+    <form method="post" action="/plugin/artifacts/{{ artifact.id }}/share/regenerate">
+      {% include "partials/csrf_field.html" %}
+      <button class="px-3 py-1 rounded bg-orange-500 text-white text-sm">
+        <i class="fa-solid fa-link"></i> Generate share link
+      </button>
+    </form>
+    {% endif %}
     <form method="post" action="/plugin/artifacts/{{ artifact.id }}/pin">
       {% include "partials/csrf_field.html" %}
       <input type="hidden" name="pinned" value="{{ 'false' if artifact.pinned else 'true' }}">

--- a/plugins/artifacts/admin/templates/list.html
+++ b/plugins/artifacts/admin/templates/list.html
@@ -1,23 +1,36 @@
-{% extends "plugins/plugin_base.html" %}
+{% extends "base.html" %}
 
-{% block plugin_content_after %}
+{% block title %}Artifacts - GridBear Admin{% endblock %}
+{% block page_title %}Artifacts{% endblock %}
+
+{% block content %}
 <div class="rounded-2xl bg-white dark:bg-void-900/50 border border-void-200 dark:border-void-800 overflow-hidden">
   <div class="p-5 border-b border-void-200 dark:border-void-800">
-    <h3 class="font-semibold text-void-900 dark:text-white">Artifacts</h3>
+    <h3 class="font-semibold text-void-900 dark:text-white flex items-center gap-2">
+      <i class="fa-solid fa-cubes"></i> Artifacts
+    </h3>
     <p class="text-sm text-void-500 dark:text-void-400">{{ artifacts|length }} records</p>
   </div>
-  <form method="get" class="p-4 flex gap-2 border-b border-void-200 dark:border-void-800">
+  <form method="get" class="p-4 flex flex-wrap gap-2 border-b border-void-200 dark:border-void-800">
+    <input name="q" placeholder="search title…" value="{{ filter_q }}"
+           class="border rounded px-3 py-1 text-sm flex-1 min-w-[160px] bg-white dark:bg-void-800">
     <input name="agent" placeholder="agent" value="{{ filter_agent }}"
-           class="border rounded px-3 py-1 text-sm">
+           class="border rounded px-3 py-1 text-sm w-32 bg-white dark:bg-void-800">
     <input name="owner" placeholder="owner" value="{{ filter_owner }}"
-           class="border rounded px-3 py-1 text-sm">
-    <select name="status" class="border rounded px-3 py-1 text-sm">
-      <option value="">any</option>
+           class="border rounded px-3 py-1 text-sm w-32 bg-white dark:bg-void-800">
+    <select name="status" class="border rounded px-3 py-1 text-sm bg-white dark:bg-void-800">
+      <option value="">any status</option>
       <option value="active" {% if filter_status == "active" %}selected{% endif %}>active</option>
       <option value="expired" {% if filter_status == "expired" %}selected{% endif %}>expired</option>
       <option value="revoked" {% if filter_status == "revoked" %}selected{% endif %}>revoked</option>
     </select>
+    <select name="share" class="border rounded px-3 py-1 text-sm bg-white dark:bg-void-800">
+      <option value="">any share</option>
+      <option value="active" {% if filter_share == "active" %}selected{% endif %}>share active</option>
+      <option value="revoked" {% if filter_share == "revoked" %}selected{% endif %}>share revoked</option>
+    </select>
     <button type="submit" class="px-3 py-1 rounded bg-blue-500 text-white text-sm">Filter</button>
+    <a href="/plugin/artifacts/" class="px-3 py-1 rounded border text-sm">Reset</a>
   </form>
   <table class="w-full text-sm">
     <thead class="bg-void-100 dark:bg-void-800/50">
@@ -25,6 +38,7 @@
         <th class="text-left px-4 py-2">Title</th>
         <th class="text-left px-4 py-2">Agent</th>
         <th class="text-left px-4 py-2">Owner</th>
+        <th class="text-left px-4 py-2">Share</th>
         <th class="text-left px-4 py-2">Size</th>
         <th class="text-left px-4 py-2">Status</th>
         <th class="text-left px-4 py-2">Expires</th>
@@ -38,9 +52,16 @@
         </td>
         <td class="px-4 py-2 font-mono text-xs">{{ a.agent_id }}</td>
         <td class="px-4 py-2 font-mono text-xs">{{ a.owner_user_id }}</td>
-        <td class="px-4 py-2">{{ (a.size_bytes // 1024) }} KB</td>
         <td class="px-4 py-2">
-          <span class="px-2 py-0.5 rounded text-xs
+          {% if a.share_token %}
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-orange-100 text-orange-800 whitespace-nowrap"><i class="fa-solid fa-link"></i> active</span>
+          {% else %}
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-void-200 text-void-800 whitespace-nowrap"><i class="fa-solid fa-link-slash"></i> revoked</span>
+          {% endif %}
+        </td>
+        <td class="px-4 py-2 whitespace-nowrap">{{ (a.size_bytes // 1024) }} KB</td>
+        <td class="px-4 py-2">
+          <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs whitespace-nowrap
             {% if a._status == 'active' %}bg-green-100 text-green-800
             {% elif a._status == 'expired' %}bg-yellow-100 text-yellow-800
             {% else %}bg-red-100 text-red-800{% endif %}">
@@ -54,7 +75,7 @@
       </tr>
       {% endfor %}
       {% if not artifacts %}
-      <tr><td colspan="6" class="px-4 py-8 text-center text-void-400">No artifacts.</td></tr>
+      <tr><td colspan="7" class="px-4 py-8 text-center text-void-400">No artifacts.</td></tr>
       {% endif %}
     </tbody>
   </table>

--- a/plugins/artifacts/admin/templates/list.html
+++ b/plugins/artifacts/admin/templates/list.html
@@ -1,0 +1,62 @@
+{% extends "plugins/plugin_base.html" %}
+
+{% block plugin_content_after %}
+<div class="rounded-2xl bg-white dark:bg-void-900/50 border border-void-200 dark:border-void-800 overflow-hidden">
+  <div class="p-5 border-b border-void-200 dark:border-void-800">
+    <h3 class="font-semibold text-void-900 dark:text-white">Artifacts</h3>
+    <p class="text-sm text-void-500 dark:text-void-400">{{ artifacts|length }} records</p>
+  </div>
+  <form method="get" class="p-4 flex gap-2 border-b border-void-200 dark:border-void-800">
+    <input name="agent" placeholder="agent" value="{{ filter_agent }}"
+           class="border rounded px-3 py-1 text-sm">
+    <input name="owner" placeholder="owner" value="{{ filter_owner }}"
+           class="border rounded px-3 py-1 text-sm">
+    <select name="status" class="border rounded px-3 py-1 text-sm">
+      <option value="">any</option>
+      <option value="active" {% if filter_status == "active" %}selected{% endif %}>active</option>
+      <option value="expired" {% if filter_status == "expired" %}selected{% endif %}>expired</option>
+      <option value="revoked" {% if filter_status == "revoked" %}selected{% endif %}>revoked</option>
+    </select>
+    <button type="submit" class="px-3 py-1 rounded bg-blue-500 text-white text-sm">Filter</button>
+  </form>
+  <table class="w-full text-sm">
+    <thead class="bg-void-100 dark:bg-void-800/50">
+      <tr>
+        <th class="text-left px-4 py-2">Title</th>
+        <th class="text-left px-4 py-2">Agent</th>
+        <th class="text-left px-4 py-2">Owner</th>
+        <th class="text-left px-4 py-2">Size</th>
+        <th class="text-left px-4 py-2">Status</th>
+        <th class="text-left px-4 py-2">Expires</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for a in artifacts %}
+      <tr class="border-b border-void-100 dark:border-void-800/50 hover:bg-void-50 dark:hover:bg-void-800/30">
+        <td class="px-4 py-2">
+          <a href="/plugin/artifacts/{{ a.id }}" class="text-blue-600 hover:underline">{{ a.title }}</a>
+        </td>
+        <td class="px-4 py-2 font-mono text-xs">{{ a.agent_id }}</td>
+        <td class="px-4 py-2 font-mono text-xs">{{ a.owner_user_id }}</td>
+        <td class="px-4 py-2">{{ (a.size_bytes // 1024) }} KB</td>
+        <td class="px-4 py-2">
+          <span class="px-2 py-0.5 rounded text-xs
+            {% if a._status == 'active' %}bg-green-100 text-green-800
+            {% elif a._status == 'expired' %}bg-yellow-100 text-yellow-800
+            {% else %}bg-red-100 text-red-800{% endif %}">
+            {{ a._status }}
+          </span>
+          {% if a.pinned %}<i class="fa-solid fa-thumbtack text-xs text-void-500 ml-1"></i>{% endif %}
+        </td>
+        <td class="px-4 py-2 text-xs text-void-500">
+          {% if a.pinned %}∞{% else %}{{ a.expires_at.strftime('%Y-%m-%d') }}{% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+      {% if not artifacts %}
+      <tr><td colspan="6" class="px-4 py-8 text-center text-void-400">No artifacts.</td></tr>
+      {% endif %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/plugins/artifacts/admin/templates/me_artifacts.html
+++ b/plugins/artifacts/admin/templates/me_artifacts.html
@@ -1,0 +1,28 @@
+{% extends "me/base.html" %}
+
+{% block title %}Your artifacts - GridBear{% endblock %}
+
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">Your artifacts</h1>
+<div class="space-y-3">
+  {% for a in artifacts %}
+  <div class="p-4 border rounded-lg flex justify-between items-center">
+    <div>
+      <div class="font-semibold">{{ a.title }}</div>
+      <div class="text-xs text-void-500">
+        Created by {{ a.agent_id }}
+        {% if a.size_bytes is not none %} &middot; {{ (a.size_bytes // 1024) }} KB{% endif %}
+      </div>
+      {% if a.revoked_at %}<span class="text-xs text-red-600">revoked</span>{% endif %}
+    </div>
+    {% if not a.revoked_at %}
+    <a href="/artifacts/{{ a.id }}?t={{ a.id | hmac_token }}" target="_blank"
+       class="px-3 py-1 rounded bg-blue-500 text-white text-sm">Open</a>
+    {% endif %}
+  </div>
+  {% endfor %}
+  {% if not artifacts %}
+  <p class="text-void-400">No artifacts yet.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/plugins/artifacts/api/routes.py
+++ b/plugins/artifacts/api/routes.py
@@ -1,0 +1,178 @@
+"""Public routes for the artifacts plugin.
+
+Mounted on the UI FastAPI app at prefix /artifacts. These endpoints do not
+require admin login — access is gated by the HMAC token (capability model).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Query, Request
+from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
+from pydantic import BaseModel
+
+from plugins.artifacts import storage
+from plugins.artifacts.models import Artifact
+from plugins.artifacts.signing import verify_signature
+
+_logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_CDNS = ["https://esm.sh", "https://unpkg.com", "https://cdn.jsdelivr.net"]
+
+
+def _embed_csp() -> str:
+    cdns = " ".join(_CDNS)
+    return (
+        "default-src 'self' 'unsafe-inline'; "
+        f"script-src 'self' 'unsafe-inline' {cdns}; "
+        f"style-src 'self' 'unsafe-inline' {cdns}; "
+        "img-src 'self' data: https:; "
+        "font-src 'self' data: https:; "
+        "connect-src 'none'; "
+        "frame-ancestors 'self'; "
+        "form-action 'none'; "
+        "base-uri 'self'"
+    )
+
+
+def _wrapper_csp() -> str:
+    return (
+        "default-src 'self'; "
+        "style-src 'self' 'unsafe-inline'; "
+        "frame-src 'self'; "
+        "frame-ancestors 'self'"
+    )
+
+
+def _html_escape(s: str) -> str:
+    return (
+        s.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+def _wrapper_html(*, title: str, uid: str, token: str, size_bytes: int) -> str:
+    size_kb = size_bytes // 1024 or 1
+    safe_title = _html_escape(title)
+    return f"""<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>{safe_title}</title>
+  <meta property="og:title" content="{safe_title}">
+  <meta property="og:description" content="GridBear artifact — {size_kb}KB">
+  <meta property="og:type" content="website">
+  <style>
+    body {{ margin: 0; font-family: system-ui, sans-serif; }}
+    .top-bar {{ display: flex; justify-content: space-between; align-items: center;
+               padding: 12px 16px; background: #1a1a1a; color: #fff; height: 48px; }}
+    iframe {{ width: 100%; height: calc(100vh - 48px); border: 0; display: block; }}
+  </style>
+</head>
+<body>
+  <header class="top-bar"><h1>{safe_title}</h1></header>
+  <iframe src="/artifacts/{uid}?t={token}&amp;mode=embed"
+          sandbox="allow-scripts" allow="clipboard-write"></iframe>
+</body>
+</html>"""
+
+
+@router.get("/{uuid}")
+async def serve_artifact(
+    request: Request,
+    uuid: str,
+    t: str = Query(..., min_length=32, max_length=64),
+    mode: str | None = Query(None),
+):
+    if not verify_signature(uuid, t):
+        return PlainTextResponse("Forbidden", status_code=403)
+
+    rows = await Artifact.search([("id", "=", uuid)])
+    if not rows:
+        return PlainTextResponse("Not Found", status_code=404)
+
+    row = rows[0]
+    if row.get("revoked_at") is not None:
+        return PlainTextResponse("This artifact has been revoked.", status_code=410)
+
+    expires_at = row["expires_at"]
+    if expires_at and expires_at < datetime.now(UTC) and not row["pinned"]:
+        return PlainTextResponse("This artifact has expired.", status_code=410)
+
+    if mode == "embed":
+        if not storage.exists(uuid):
+            _logger.warning("Artifact row %s exists but file missing", uuid)
+            return PlainTextResponse("Not Found", status_code=404)
+        html = storage.read_artifact(uuid)
+        return HTMLResponse(
+            content=html,
+            headers={
+                "Content-Security-Policy": _embed_csp(),
+                "X-Frame-Options": "SAMEORIGIN",
+                "X-Content-Type-Options": "nosniff",
+                "Referrer-Policy": "no-referrer",
+            },
+        )
+
+    return HTMLResponse(
+        content=_wrapper_html(
+            title=row["title"],
+            uid=uuid,
+            token=t,
+            size_bytes=row["size_bytes"],
+        ),
+        headers={
+            "Content-Security-Policy": _wrapper_csp(),
+            "X-Frame-Options": "SAMEORIGIN",
+        },
+    )
+
+
+@router.get("/{uuid}/meta")
+async def artifact_meta(uuid: str):
+    rows = await Artifact.search([("id", "=", uuid)])
+    if not rows:
+        return JSONResponse({"error": "not_found"}, status_code=404)
+    row = rows[0]
+    return JSONResponse(
+        {
+            "title": row["title"],
+            "size_bytes": row["size_bytes"],
+            "created_at": row["created_at"].isoformat() if row["created_at"] else None,
+            "agent_id": row["agent_id"],
+        }
+    )
+
+
+class PinBody(BaseModel):
+    pinned: bool
+
+
+@router.post("/{uuid}/pin")
+async def action_pin(uuid: str, body: PinBody):
+    from plugins.artifacts.service import ArtifactsService
+
+    await ArtifactsService().pin(uuid, pinned=body.pinned)
+    return {"ok": True}
+
+
+@router.post("/{uuid}/revoke")
+async def action_revoke(uuid: str):
+    from plugins.artifacts.service import ArtifactsService
+
+    await ArtifactsService().revoke(uuid)
+    return {"ok": True}
+
+
+@router.post("/{uuid}/unrevoke")
+async def action_unrevoke(uuid: str):
+    from plugins.artifacts.service import ArtifactsService
+
+    await ArtifactsService().unrevoke(uuid)
+    return {"ok": True}

--- a/plugins/artifacts/api/routes.py
+++ b/plugins/artifacts/api/routes.py
@@ -16,12 +16,51 @@ import logging
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Query, Request
-from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
+from fastapi.responses import (
+    HTMLResponse,
+    JSONResponse,
+    PlainTextResponse,
+    RedirectResponse,
+    Response,
+)
 from pydantic import BaseModel
 
 from plugins.artifacts import storage
 from plugins.artifacts.models import Artifact
 from plugins.artifacts.signing import verify_signature
+from ui.auth.session import get_current_user
+
+_NOINDEX_HEADERS = {"X-Robots-Tag": "noindex, nofollow, noarchive"}
+
+
+def _check_access(row: dict, request: Request, share: str | None) -> Response | None:
+    """Gate artifact access.
+
+    Allow if: valid ``?s=<token>`` matches share_token, OR authenticated
+    user is the owner / superadmin. Otherwise redirect to login (so external
+    clickers who lost the share token are prompted to log in).
+    Returns an error/redirect response if denied, None if allowed.
+    """
+    stored_token = row.get("share_token")
+    if share and stored_token and _hmac_compare(share, stored_token):
+        return None
+    user = get_current_user(request)
+    if not user:
+        request.session["post_login_redirect"] = str(request.url)
+        return RedirectResponse(url="/auth/login", status_code=303)
+    if user.get("is_superadmin"):
+        return None
+    if user.get("username") != row.get("owner_user_id"):
+        return PlainTextResponse("Forbidden", status_code=403, headers=_NOINDEX_HEADERS)
+    return None
+
+
+def _hmac_compare(a: str, b: str) -> bool:
+    """Constant-time comparison to avoid timing oracles on share tokens."""
+    import hmac as _h
+
+    return _h.compare_digest(a.encode(), b.encode())
+
 
 _logger = logging.getLogger(__name__)
 
@@ -63,13 +102,17 @@ def _html_escape(s: str) -> str:
     )
 
 
-def _wrapper_html(*, title: str, uid: str, token: str, size_bytes: int) -> str:
+def _wrapper_html(
+    *, title: str, uid: str, token: str, size_bytes: int, share: str | None
+) -> str:
     size_kb = size_bytes // 1024 or 1
     safe_title = _html_escape(title)
+    share_qs = f"&amp;s={share}" if share else ""
     return f"""<!doctype html>
 <html>
 <head>
   <meta charset="utf-8">
+  <meta name="robots" content="noindex, nofollow, noarchive">
   <title>{safe_title}</title>
   <meta property="og:title" content="{safe_title}">
   <meta property="og:description" content="GridBear artifact — {size_kb}KB">
@@ -83,7 +126,7 @@ def _wrapper_html(*, title: str, uid: str, token: str, size_bytes: int) -> str:
 </head>
 <body>
   <header class="top-bar"><h1>{safe_title}</h1></header>
-  <iframe src="/artifacts/{uid}?t={token}&amp;mode=embed"
+  <iframe src="/artifacts/{uid}?t={token}{share_qs}&amp;mode=embed"
           sandbox="allow-scripts" allow="clipboard-write"></iframe>
 </body>
 </html>"""
@@ -94,27 +137,42 @@ async def serve_artifact(
     request: Request,
     uuid: str,
     t: str = Query(..., min_length=32, max_length=64),
+    s: str | None = Query(None, min_length=16, max_length=64),
     mode: str | None = Query(None),
 ):
     if not verify_signature(uuid, t):
-        return PlainTextResponse("Forbidden", status_code=403)
+        return PlainTextResponse("Forbidden", status_code=403, headers=_NOINDEX_HEADERS)
 
     rows = await Artifact.search([("id", "=", uuid)])
     if not rows:
-        return PlainTextResponse("Not Found", status_code=404)
+        return PlainTextResponse("Not Found", status_code=404, headers=_NOINDEX_HEADERS)
 
     row = rows[0]
     if row.get("revoked_at") is not None:
-        return PlainTextResponse("This artifact has been revoked.", status_code=410)
+        return PlainTextResponse(
+            "This artifact has been revoked.",
+            status_code=410,
+            headers=_NOINDEX_HEADERS,
+        )
 
     expires_at = row["expires_at"]
     if expires_at and expires_at < datetime.now(UTC) and not row["pinned"]:
-        return PlainTextResponse("This artifact has expired.", status_code=410)
+        return PlainTextResponse(
+            "This artifact has expired.",
+            status_code=410,
+            headers=_NOINDEX_HEADERS,
+        )
+
+    denied = _check_access(row, request, s)
+    if denied is not None:
+        return denied
 
     if mode == "embed":
         if not storage.exists(uuid):
             _logger.warning("Artifact row %s exists but file missing", uuid)
-            return PlainTextResponse("Not Found", status_code=404)
+            return PlainTextResponse(
+                "Not Found", status_code=404, headers=_NOINDEX_HEADERS
+            )
         html = storage.read_artifact(uuid)
         return HTMLResponse(
             content=html,
@@ -123,6 +181,8 @@ async def serve_artifact(
                 "X-Frame-Options": "SAMEORIGIN",
                 "X-Content-Type-Options": "nosniff",
                 "Referrer-Policy": "no-referrer",
+                "Cache-Control": "private, no-store, max-age=0",
+                **_NOINDEX_HEADERS,
             },
         )
 
@@ -132,10 +192,13 @@ async def serve_artifact(
             uid=uuid,
             token=t,
             size_bytes=row["size_bytes"],
+            share=s,
         ),
         headers={
             "Content-Security-Policy": _wrapper_csp(),
             "X-Frame-Options": "SAMEORIGIN",
+            "Cache-Control": "private, no-store, max-age=0",
+            **_NOINDEX_HEADERS,
         },
     )
 

--- a/plugins/artifacts/api/routes.py
+++ b/plugins/artifacts/api/routes.py
@@ -2,6 +2,12 @@
 
 Mounted on the UI FastAPI app at prefix /artifacts. These endpoints do not
 require admin login — access is gated by the HMAC token (capability model).
+
+Action endpoints (pin/revoke/unrevoke) live on the public router because the
+plugin manifest sets `public_api: true`. They therefore share the capability
+URL gating model: the client must supply `t=<hmac>` as a query parameter.
+The admin UI's Task 9 routes remain authed via `require_login` and are not
+affected by this module.
 """
 
 from __future__ import annotations
@@ -140,6 +146,8 @@ async def artifact_meta(uuid: str):
     if not rows:
         return JSONResponse({"error": "not_found"}, status_code=404)
     row = rows[0]
+    if row.get("revoked_at") is not None:
+        return JSONResponse({"error": "revoked"}, status_code=410)
     return JSONResponse(
         {
             "title": row["title"],
@@ -155,7 +163,13 @@ class PinBody(BaseModel):
 
 
 @router.post("/{uuid}/pin")
-async def action_pin(uuid: str, body: PinBody):
+async def action_pin(
+    uuid: str,
+    body: PinBody,
+    t: str = Query(..., min_length=32, max_length=64),
+):
+    if not verify_signature(uuid, t):
+        return JSONResponse({"error": "forbidden"}, status_code=403)
     from plugins.artifacts.service import ArtifactsService
 
     await ArtifactsService().pin(uuid, pinned=body.pinned)
@@ -163,7 +177,12 @@ async def action_pin(uuid: str, body: PinBody):
 
 
 @router.post("/{uuid}/revoke")
-async def action_revoke(uuid: str):
+async def action_revoke(
+    uuid: str,
+    t: str = Query(..., min_length=32, max_length=64),
+):
+    if not verify_signature(uuid, t):
+        return JSONResponse({"error": "forbidden"}, status_code=403)
     from plugins.artifacts.service import ArtifactsService
 
     await ArtifactsService().revoke(uuid)
@@ -171,7 +190,12 @@ async def action_revoke(uuid: str):
 
 
 @router.post("/{uuid}/unrevoke")
-async def action_unrevoke(uuid: str):
+async def action_unrevoke(
+    uuid: str,
+    t: str = Query(..., min_length=32, max_length=64),
+):
+    if not verify_signature(uuid, t):
+        return JSONResponse({"error": "forbidden"}, status_code=403)
     from plugins.artifacts.service import ArtifactsService
 
     await ArtifactsService().unrevoke(uuid)

--- a/plugins/artifacts/cleanup.py
+++ b/plugins/artifacts/cleanup.py
@@ -1,0 +1,60 @@
+"""Background worker: prune expired non-pinned artifacts."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+
+from plugins.artifacts import storage
+from plugins.artifacts.models import Artifact
+
+_logger = logging.getLogger(__name__)
+
+_DEFAULT_INTERVAL_HOURS = 6
+
+
+def _load_interval_hours() -> int:
+    try:
+        from core.plugin_registry.models import PluginRegistryEntry
+
+        entry = PluginRegistryEntry.get_sync(name="artifacts")
+        cfg = (entry or {}).get("config") or {}
+        return int(cfg.get("cleanup_interval_hours", _DEFAULT_INTERVAL_HOURS))
+    except Exception as err:
+        _logger.debug("Failed to load cleanup_interval_hours from DB: %s", err)
+        return _DEFAULT_INTERVAL_HOURS
+
+
+async def run_cleanup_once() -> int:
+    """Execute one cleanup sweep. Returns the number of artifacts removed."""
+    now = datetime.now(UTC)
+    to_delete = await Artifact.search(
+        [("expires_at", "<", now), ("pinned", "=", False)]
+    )
+    count = 0
+    for row in to_delete:
+        uid = row["id"]
+        try:
+            storage.delete_artifact(uid)
+            await Artifact.delete(uid)
+            count += 1
+            _logger.info("Cleaned up expired artifact %s", uid)
+        except Exception as err:
+            _logger.exception("Failed to clean up artifact %s: %s", uid, err)
+    return count
+
+
+async def cleanup_loop() -> None:
+    """Long-running task invoking run_cleanup_once at a fixed interval."""
+    interval = _load_interval_hours() * 3600
+    try:
+        await run_cleanup_once()
+    except Exception as err:
+        _logger.exception("Initial cleanup failed: %s", err)
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            await run_cleanup_once()
+        except Exception as err:
+            _logger.exception("Cleanup iteration failed: %s", err)

--- a/plugins/artifacts/errors.py
+++ b/plugins/artifacts/errors.py
@@ -1,0 +1,25 @@
+"""Domain-specific exceptions for the artifacts plugin."""
+
+
+class ArtifactError(Exception):
+    """Base class."""
+
+
+class InvalidHtmlError(ArtifactError):
+    """HTML failed validation (e.g. missing doctype)."""
+
+
+class HtmlTooLargeError(ArtifactError):
+    """HTML exceeds configured size cap."""
+
+
+class ArtifactNotFoundError(ArtifactError):
+    """No artifact row for the given id."""
+
+
+class ArtifactRevokedError(ArtifactError):
+    """Artifact has been revoked."""
+
+
+class ArtifactExpiredError(ArtifactError):
+    """Artifact passed its TTL and is not pinned."""

--- a/plugins/artifacts/hooks.py
+++ b/plugins/artifacts/hooks.py
@@ -1,36 +1,25 @@
 """Startup hook: launch the artifacts cleanup worker.
 
-The cleanup loop runs on the UI container only to avoid a double-sweep
-when both bot and UI processes load the plugin. ``GRIDBEAR_ROLE=bot``
-disables the worker; any other value (``ui``, unset for single-process
-dev) enables it.
+Runs whenever `HookName.ON_STARTUP` is emitted, which in GridBear happens
+on the bot entry-point (main.py) and in single-process deployments. The UI
+container uses FastAPI's own `on_event("startup")` and does not emit
+GridBear's ON_STARTUP, so in split-container deployments cleanup runs on
+the bot side only — never double-executes.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-import os
 
 from core.hooks import hook
 
 _logger = logging.getLogger(__name__)
 
-_BOT_ROLE = "bot"
-
 
 @hook("on_startup", priority=50)
-async def start_cleanup_worker(data, **_kwargs):
-    """Launch the cleanup loop as a background task (non-bot roles only)."""
-    role = os.environ.get("GRIDBEAR_ROLE")
-    if role == _BOT_ROLE:
-        _logger.debug(
-            "Artifacts cleanup worker not started on bot container (role=%s)", role
-        )
-        return data
-
+async def start_cleanup_worker(*_args, **_kwargs) -> None:
     from plugins.artifacts.cleanup import cleanup_loop
 
-    _logger.info("Starting artifacts cleanup worker (role=%s)", role or "unset")
+    _logger.info("Starting artifacts cleanup worker")
     asyncio.create_task(cleanup_loop())
-    return data

--- a/plugins/artifacts/hooks.py
+++ b/plugins/artifacts/hooks.py
@@ -1,0 +1,36 @@
+"""Startup hook: launch the artifacts cleanup worker.
+
+The cleanup loop runs on the UI container only to avoid a double-sweep
+when both bot and UI processes load the plugin. ``GRIDBEAR_ROLE=bot``
+disables the worker; any other value (``ui``, unset for single-process
+dev) enables it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from core.hooks import hook
+
+_logger = logging.getLogger(__name__)
+
+_BOT_ROLE = "bot"
+
+
+@hook("on_startup", priority=50)
+async def start_cleanup_worker(data, **_kwargs):
+    """Launch the cleanup loop as a background task (non-bot roles only)."""
+    role = os.environ.get("GRIDBEAR_ROLE")
+    if role == _BOT_ROLE:
+        _logger.debug(
+            "Artifacts cleanup worker not started on bot container (role=%s)", role
+        )
+        return data
+
+    from plugins.artifacts.cleanup import cleanup_loop
+
+    _logger.info("Starting artifacts cleanup worker (role=%s)", role or "unset")
+    asyncio.create_task(cleanup_loop())
+    return data

--- a/plugins/artifacts/manifest.json
+++ b/plugins/artifacts/manifest.json
@@ -1,0 +1,41 @@
+{
+  "name": "artifacts",
+  "version": "0.1.0",
+  "description": "Standalone HTML artifacts produced by agents, served via signed capability URLs.",
+  "type": "service",
+  "entry_point": "service.py",
+  "class_name": "ArtifactsService",
+  "provides": "artifacts",
+  "public_api": true,
+  "public_api_prefix": "/artifacts",
+  "dependencies": {
+    "required": [],
+    "optional": []
+  },
+  "config_schema": {
+    "default_ttl_days": {
+      "type": "integer",
+      "default": 30,
+      "description": "Default TTL in days applied to new artifacts when ttl_days not specified"
+    },
+    "max_html_bytes": {
+      "type": "integer",
+      "default": 2097152,
+      "description": "Hard cap on artifact HTML size (2 MB)"
+    },
+    "cleanup_interval_hours": {
+      "type": "integer",
+      "default": 6,
+      "description": "How often the cleanup worker prunes expired non-pinned artifacts"
+    },
+    "csp_cdns": {
+      "type": "array",
+      "default": ["https://esm.sh", "https://unpkg.com", "https://cdn.jsdelivr.net"],
+      "description": "CDNs whitelisted in the artifact CSP"
+    }
+  },
+  "ui": {
+    "display_name": "Artifacts",
+    "icon": "fa-solid fa-cubes"
+  }
+}

--- a/plugins/artifacts/manifest.json
+++ b/plugins/artifacts/manifest.json
@@ -8,6 +8,14 @@
   "provides": "artifacts",
   "public_api": true,
   "public_api_prefix": "/artifacts",
+  "virtual_tools": "virtual_tools.py",
+  "context_skills": [
+    {
+      "name": "artifacts-usage",
+      "title": "Using artifacts",
+      "file": "skills/using-artifacts.md"
+    }
+  ],
   "dependencies": {
     "required": [],
     "optional": []

--- a/plugins/artifacts/models.py
+++ b/plugins/artifacts/models.py
@@ -1,0 +1,41 @@
+"""ORM model for Artifact records."""
+
+from core.orm import Model, fields
+
+
+class Artifact(Model):
+    """Standalone HTML artifact produced by an agent.
+
+    The ``id`` is declared as a Text field (UUID string) rather than a SERIAL
+    — the ORM's migrate step detects the explicit id and applies PRIMARY KEY
+    to it instead of adding a SERIAL. The UUID is the value embedded in
+    capability URLs.
+
+    Note on indexes: the ORM migrate engine supports simple single-column
+    ``index=True`` declarations and multi-column ``_indexes`` via the
+    ``(name, column, method)`` tuple format. Partial indexes (e.g.
+    ``WHERE pinned = false``) and composite-column expressions are not
+    supported by the migrator and would be a schema-only concern; we rely
+    on single-column btree indexes for now.
+    """
+
+    _schema = "app"
+    _name = "artifacts"
+
+    id = fields.Text(required=True)
+    title = fields.Text(required=True)
+    agent_id = fields.Text(required=True, index=True)
+    owner_user_id = fields.Text(required=True, index=True)
+    conversation_id = fields.Text()
+    file_path = fields.Text(required=True)
+    size_bytes = fields.Integer(required=True)
+    content_hash = fields.Text(required=True)
+    pinned = fields.Boolean(default=False)
+    expires_at = fields.DateTime(required=True, index=True)
+    revoked_at = fields.DateTime()
+    created_at = fields.DateTime(auto_now_add=True)
+    updated_at = fields.DateTime(auto_now_add=True, auto_now=True)
+
+    _constraints = [
+        ("chk_artifact_size", "CHECK (size_bytes <= 10485760)"),
+    ]

--- a/plugins/artifacts/models.py
+++ b/plugins/artifacts/models.py
@@ -31,6 +31,7 @@ class Artifact(Model):
     size_bytes = fields.Integer(required=True)
     content_hash = fields.Text(required=True)
     pinned = fields.Boolean(default=False)
+    share_token = fields.Text()
     expires_at = fields.DateTime(required=True, index=True)
     revoked_at = fields.DateTime()
     created_at = fields.DateTime(auto_now_add=True)

--- a/plugins/artifacts/portal/routes.py
+++ b/plugins/artifacts/portal/routes.py
@@ -1,0 +1,57 @@
+"""User portal routes for the artifacts plugin.
+
+Registered by ui.plugin_admin.PluginAdminRegistry.register_portal_routes on
+startup (ui/app.py).  Also registers the `hmac_token` Jinja filter so the
+template can build signed capability URLs without leaking signing internals
+into the core UI.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse
+
+from plugins.artifacts.models import Artifact
+from plugins.artifacts.signing import sign_uuid
+from ui.jinja_env import templates
+from ui.routes.auth import require_user
+
+_logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/me", tags=["user-portal"])
+
+
+# Register the `hmac_token` Jinja filter at module import time.
+# This module is imported during UI startup via register_portal_routes,
+# which keeps the plugin→core→plugin dependency direction clean (core
+# does not import from plugins; the plugin wires itself into core).
+def _hmac_token_filter(uuid_str: str) -> str:
+    try:
+        return sign_uuid(uuid_str)
+    except Exception:
+        return ""
+
+
+templates.env.filters["hmac_token"] = _hmac_token_filter
+
+
+@router.get("/artifacts", response_class=HTMLResponse)
+async def me_artifacts(request: Request, user: dict = Depends(require_user)):
+    """Show the signed-in user's own artifacts with capability links."""
+    username = user["username"]
+    try:
+        rows = await Artifact.search(
+            [("owner_user_id", "=", username)],
+            order="created_at DESC",
+            limit=100,
+        )
+    except Exception as exc:
+        _logger.warning("Failed to load artifacts for %s: %s", username, exc)
+        rows = []
+
+    return templates.TemplateResponse(
+        "me_artifacts.html",
+        {"request": request, "user": user, "artifacts": rows},
+    )

--- a/plugins/artifacts/service.py
+++ b/plugins/artifacts/service.py
@@ -1,4 +1,15 @@
-"""Artifacts plugin service + MCP LocalToolProvider."""
+"""Artifacts plugin service + MCP LocalToolProvider.
+
+Known v1 limitations
+--------------------
+The MCP tool handler (``ArtifactsToolProvider.handle_tool_call``) does not
+currently receive ``conversation_id`` from the MCP gateway / runner context,
+so artifacts created via the ``artifacts__create_artifact`` tool are persisted
+with ``conversation_id=NULL``. This is intentional for v1: threading the
+conversation id through the gateway kwargs is a v2 task (see TODO in
+``handle_tool_call``), and until then ``/me/artifacts`` cannot filter
+tool-created artifacts by thread.
+"""
 
 from __future__ import annotations
 
@@ -146,12 +157,35 @@ class ArtifactsToolProvider(LocalToolProvider):
     ) -> list[dict]:
         if tool_name != "artifacts__create_artifact":
             return [{"type": "text", "text": f"Unknown artifacts tool: {tool_name}"}]
+
+        # TODO(v2): thread conversation_id through from the MCP gateway
+        # (kwargs.get("conversation_id")) so /me/artifacts can filter by thread.
+        # Current v1 leaves the field NULL for tool-created artifacts.
+        agent_name = kwargs.get("agent_name")
+        oauth2_user = kwargs.get("oauth2_user")
+        if not agent_name or not oauth2_user:
+            _logger.error(
+                "artifacts__create_artifact invoked without agent/user context "
+                "(agent=%r, user=%r) — refusing",
+                agent_name,
+                oauth2_user,
+            )
+            return [
+                {
+                    "type": "text",
+                    "text": (
+                        "Error: artifact creation requires authenticated "
+                        "agent and user context."
+                    ),
+                }
+            ]
+
         try:
             result = await self._service.create(
                 title=arguments["title"],
                 html=arguments["html"],
-                agent_id=kwargs.get("agent_name") or "unknown",
-                owner_user_id=kwargs.get("oauth2_user") or "unknown",
+                agent_id=agent_name,
+                owner_user_id=oauth2_user,
                 pin=bool(arguments.get("pin", False)),
                 ttl_days=arguments.get("ttl_days"),
             )

--- a/plugins/artifacts/service.py
+++ b/plugins/artifacts/service.py
@@ -19,6 +19,9 @@ from uuid import uuid4
 
 from core.interfaces.local_tools import LocalToolProvider
 from plugins.artifacts import storage
+from plugins.artifacts.hooks import (
+    start_cleanup_worker,  # noqa: F401 — hook registration
+)
 from plugins.artifacts.models import Artifact
 from plugins.artifacts.signing import build_capability_url
 

--- a/plugins/artifacts/service.py
+++ b/plugins/artifacts/service.py
@@ -1,14 +1,14 @@
-"""Artifacts plugin service + MCP LocalToolProvider.
+"""Artifacts plugin service.
 
 Known v1 limitations
 --------------------
-The MCP tool handler (``ArtifactsToolProvider.handle_tool_call``) does not
-currently receive ``conversation_id`` from the MCP gateway / runner context,
-so artifacts created via the ``artifacts__create_artifact`` tool are persisted
-with ``conversation_id=NULL``. This is intentional for v1: threading the
-conversation id through the gateway kwargs is a v2 task (see TODO in
-``handle_tool_call``), and until then ``/me/artifacts`` cannot filter
-tool-created artifacts by thread.
+The MCP tool handler (``ArtifactsToolProvider.handle_tool_call``, defined in
+``virtual_tools.py``) does not currently receive ``conversation_id`` from the
+MCP gateway / runner context, so artifacts created via the
+``artifacts__create_artifact`` tool are persisted with ``conversation_id=NULL``.
+This is intentional for v1: threading the conversation id through the gateway
+kwargs is a v2 task (see TODO in ``handle_tool_call``), and until then
+``/me/artifacts`` cannot filter tool-created artifacts by thread.
 """
 
 from __future__ import annotations
@@ -17,7 +17,6 @@ import logging
 from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
-from core.interfaces.local_tools import LocalToolProvider
 from plugins.artifacts import storage
 from plugins.artifacts.hooks import (
     start_cleanup_worker,  # noqa: F401 — hook registration
@@ -27,7 +26,6 @@ from plugins.artifacts.signing import build_capability_url
 
 _logger = logging.getLogger(__name__)
 
-_SERVER_NAME = "artifacts"
 _DEFAULT_TTL_DAYS = 30
 _DEFAULT_MAX_HTML = 2_097_152
 
@@ -117,91 +115,3 @@ class ArtifactsService:
     async def hard_delete(self, artifact_id: str) -> None:
         storage.delete_artifact(artifact_id)
         await Artifact.delete(artifact_id)
-
-
-_TOOLS = [
-    {
-        "name": "artifacts__create_artifact",
-        "description": (
-            "Create a standalone HTML artifact (dashboard, chart, data viewer). "
-            "Returns a public URL the user can click. Keep HTML self-contained: "
-            "inline CSS and JS. External libraries only from esm.sh / unpkg / "
-            "cdn.jsdelivr.net. Embed data directly; the CSP blocks runtime fetch. "
-            "Pass pin=true to exempt the 30-day TTL."
-        ),
-        "inputSchema": {
-            "type": "object",
-            "required": ["title", "html"],
-            "properties": {
-                "title": {"type": "string", "maxLength": 200},
-                "html": {"type": "string"},
-                "pin": {"type": "boolean"},
-                "ttl_days": {"type": "integer", "minimum": 1, "maximum": 365},
-            },
-        },
-    }
-]
-
-
-class ArtifactsToolProvider(LocalToolProvider):
-    """Expose the create_artifact MCP tool to agents."""
-
-    def __init__(self) -> None:
-        self._service = ArtifactsService()
-
-    def get_server_name(self) -> str:
-        return _SERVER_NAME
-
-    def get_tools(self) -> list[dict]:
-        return list(_TOOLS)
-
-    async def handle_tool_call(
-        self, tool_name: str, arguments: dict, **kwargs
-    ) -> list[dict]:
-        if tool_name != "artifacts__create_artifact":
-            return [{"type": "text", "text": f"Unknown artifacts tool: {tool_name}"}]
-
-        # TODO(v2): thread conversation_id through from the MCP gateway
-        # (kwargs.get("conversation_id")) so /me/artifacts can filter by thread.
-        # Current v1 leaves the field NULL for tool-created artifacts.
-        agent_name = kwargs.get("agent_name")
-        oauth2_user = kwargs.get("oauth2_user")
-        if not agent_name or not oauth2_user:
-            _logger.error(
-                "artifacts__create_artifact invoked without agent/user context "
-                "(agent=%r, user=%r) — refusing",
-                agent_name,
-                oauth2_user,
-            )
-            return [
-                {
-                    "type": "text",
-                    "text": (
-                        "Error: artifact creation requires authenticated "
-                        "agent and user context."
-                    ),
-                }
-            ]
-
-        try:
-            result = await self._service.create(
-                title=arguments["title"],
-                html=arguments["html"],
-                agent_id=agent_name,
-                owner_user_id=oauth2_user,
-                pin=bool(arguments.get("pin", False)),
-                ttl_days=arguments.get("ttl_days"),
-            )
-            return [
-                {
-                    "type": "text",
-                    "text": (
-                        f"Artifact created: {result['title']}\n"
-                        f"URL: {result['url']}\n"
-                        f"Expires: {result['expires_at']}"
-                    ),
-                }
-            ]
-        except Exception as err:
-            _logger.exception("Failed to create artifact: %s", err)
-            return [{"type": "text", "text": f"Error creating artifact: {err}"}]

--- a/plugins/artifacts/service.py
+++ b/plugins/artifacts/service.py
@@ -1,0 +1,170 @@
+"""Artifacts plugin service + MCP LocalToolProvider."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+from core.interfaces.local_tools import LocalToolProvider
+from plugins.artifacts import storage
+from plugins.artifacts.models import Artifact
+from plugins.artifacts.signing import build_capability_url
+
+_logger = logging.getLogger(__name__)
+
+_SERVER_NAME = "artifacts"
+_DEFAULT_TTL_DAYS = 30
+_DEFAULT_MAX_HTML = 2_097_152
+
+
+def _load_config() -> dict:
+    try:
+        from core.plugin_registry.models import PluginRegistryEntry
+
+        entry = PluginRegistryEntry.get_sync(name="artifacts")
+        return (entry or {}).get("config") or {}
+    except Exception:
+        return {}
+
+
+class ArtifactsService:
+    """Facade for artifact creation, retrieval, and lifecycle actions."""
+
+    async def create(
+        self,
+        *,
+        title: str,
+        html: str,
+        agent_id: str,
+        owner_user_id: str,
+        conversation_id: str | None = None,
+        pin: bool = False,
+        ttl_days: int | None = None,
+    ) -> dict:
+        title = (title or "").strip()
+        if not title:
+            raise ValueError("title is required")
+        cfg = _load_config()
+        max_bytes = int(cfg.get("max_html_bytes", _DEFAULT_MAX_HTML))
+        default_ttl = int(cfg.get("default_ttl_days", _DEFAULT_TTL_DAYS))
+        ttl = ttl_days if ttl_days is not None else default_ttl
+
+        storage.validate_html(html, max_bytes=max_bytes)
+        content_hash, size_bytes = storage.compute_hash_and_size(html)
+
+        artifact_id = str(uuid4())
+        now = datetime.now(UTC)
+        expires_at = now + timedelta(days=ttl)
+
+        file_path = storage.write_artifact(artifact_id, html)
+        try:
+            await Artifact.create(
+                id=artifact_id,
+                title=title,
+                agent_id=agent_id,
+                owner_user_id=owner_user_id,
+                conversation_id=conversation_id,
+                file_path=file_path,
+                size_bytes=size_bytes,
+                content_hash=content_hash,
+                pinned=pin,
+                expires_at=expires_at,
+            )
+        except Exception:
+            storage.delete_artifact(artifact_id)
+            raise
+
+        return {
+            "artifact_id": artifact_id,
+            "url": build_capability_url(artifact_id),
+            "expires_at": expires_at.isoformat(),
+            "title": title,
+        }
+
+    async def pin(self, artifact_id: str, *, pinned: bool) -> None:
+        if pinned:
+            await Artifact.write(artifact_id, pinned=True)
+        else:
+            cfg = _load_config()
+            ttl = int(cfg.get("default_ttl_days", _DEFAULT_TTL_DAYS))
+            await Artifact.write(
+                artifact_id,
+                pinned=False,
+                expires_at=datetime.now(UTC) + timedelta(days=ttl),
+            )
+
+    async def revoke(self, artifact_id: str) -> None:
+        await Artifact.write(artifact_id, revoked_at=datetime.now(UTC))
+
+    async def unrevoke(self, artifact_id: str) -> None:
+        await Artifact.write(artifact_id, revoked_at=None)
+
+    async def hard_delete(self, artifact_id: str) -> None:
+        storage.delete_artifact(artifact_id)
+        await Artifact.delete(artifact_id)
+
+
+_TOOLS = [
+    {
+        "name": "artifacts__create_artifact",
+        "description": (
+            "Create a standalone HTML artifact (dashboard, chart, data viewer). "
+            "Returns a public URL the user can click. Keep HTML self-contained: "
+            "inline CSS and JS. External libraries only from esm.sh / unpkg / "
+            "cdn.jsdelivr.net. Embed data directly; the CSP blocks runtime fetch. "
+            "Pass pin=true to exempt the 30-day TTL."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "required": ["title", "html"],
+            "properties": {
+                "title": {"type": "string", "maxLength": 200},
+                "html": {"type": "string"},
+                "pin": {"type": "boolean"},
+                "ttl_days": {"type": "integer", "minimum": 1, "maximum": 365},
+            },
+        },
+    }
+]
+
+
+class ArtifactsToolProvider(LocalToolProvider):
+    """Expose the create_artifact MCP tool to agents."""
+
+    def __init__(self) -> None:
+        self._service = ArtifactsService()
+
+    def get_server_name(self) -> str:
+        return _SERVER_NAME
+
+    def get_tools(self) -> list[dict]:
+        return list(_TOOLS)
+
+    async def handle_tool_call(
+        self, tool_name: str, arguments: dict, **kwargs
+    ) -> list[dict]:
+        if tool_name != "artifacts__create_artifact":
+            return [{"type": "text", "text": f"Unknown artifacts tool: {tool_name}"}]
+        try:
+            result = await self._service.create(
+                title=arguments["title"],
+                html=arguments["html"],
+                agent_id=kwargs.get("agent_name") or "unknown",
+                owner_user_id=kwargs.get("oauth2_user") or "unknown",
+                pin=bool(arguments.get("pin", False)),
+                ttl_days=arguments.get("ttl_days"),
+            )
+            return [
+                {
+                    "type": "text",
+                    "text": (
+                        f"Artifact created: {result['title']}\n"
+                        f"URL: {result['url']}\n"
+                        f"Expires: {result['expires_at']}"
+                    ),
+                }
+            ]
+        except Exception as err:
+            _logger.exception("Failed to create artifact: %s", err)
+            return [{"type": "text", "text": f"Error creating artifact: {err}"}]

--- a/plugins/artifacts/service.py
+++ b/plugins/artifacts/service.py
@@ -14,6 +14,7 @@ kwargs is a v2 task (see TODO in ``handle_tool_call``), and until then
 from __future__ import annotations
 
 import logging
+import secrets
 from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
@@ -43,6 +44,13 @@ def _load_config() -> dict:
 class ArtifactsService:
     """Facade for artifact creation, retrieval, and lifecycle actions."""
 
+    def __init__(self, config: dict | None = None) -> None:
+        self.config = config or {}
+
+    async def initialize(self) -> None:
+        """No-op initializer — service is stateless."""
+        return None
+
     async def create(
         self,
         *,
@@ -66,6 +74,7 @@ class ArtifactsService:
         content_hash, size_bytes = storage.compute_hash_and_size(html)
 
         artifact_id = str(uuid4())
+        share_token = secrets.token_urlsafe(24)
         now = datetime.now(UTC)
         expires_at = now + timedelta(days=ttl)
 
@@ -81,6 +90,7 @@ class ArtifactsService:
                 size_bytes=size_bytes,
                 content_hash=content_hash,
                 pinned=pin,
+                share_token=share_token,
                 expires_at=expires_at,
             )
         except Exception:
@@ -89,10 +99,20 @@ class ArtifactsService:
 
         return {
             "artifact_id": artifact_id,
-            "url": build_capability_url(artifact_id),
+            "url": build_capability_url(artifact_id, share_token=share_token),
             "expires_at": expires_at.isoformat(),
             "title": title,
         }
+
+    async def regenerate_share_token(self, artifact_id: str) -> str:
+        """Generate a new share token; old share links stop working."""
+        new_token = secrets.token_urlsafe(24)
+        await Artifact.write(artifact_id, share_token=new_token)
+        return new_token
+
+    async def revoke_share_token(self, artifact_id: str) -> None:
+        """Clear share token — only owner/admin can view after this."""
+        await Artifact.write(artifact_id, share_token=None)
 
     async def pin(self, artifact_id: str, *, pinned: bool) -> None:
         if pinned:

--- a/plugins/artifacts/signing.py
+++ b/plugins/artifacts/signing.py
@@ -35,8 +35,16 @@ def verify_signature(uuid_str: str, token: str) -> bool:
     return _hmac.compare_digest(expected, token)
 
 
-def build_capability_url(uuid_str: str) -> str:
-    """Build a full /artifacts/<uuid>?t=<token> URL using GRIDBEAR_BASE_URL."""
+def build_capability_url(uuid_str: str, share_token: str | None = None) -> str:
+    """Build a full /artifacts/<uuid>?t=<hmac>[&s=<share>] URL.
+
+    ``share_token`` is the per-artifact random token stored in the DB — when
+    included, anyone with this URL can view without logging in. Revoking the
+    column on the row kills the link.
+    """
     base = os.environ.get("GRIDBEAR_BASE_URL", "").rstrip("/")
     token = sign_uuid(uuid_str)
-    return f"{base}/artifacts/{uuid_str}?t={token}"
+    url = f"{base}/artifacts/{uuid_str}?t={token}"
+    if share_token:
+        url += f"&s={share_token}"
+    return url

--- a/plugins/artifacts/signing.py
+++ b/plugins/artifacts/signing.py
@@ -1,0 +1,42 @@
+"""HMAC-SHA256 signing for capability URLs.
+
+Uses the shared INTERNAL_API_SECRET env var so either container can sign
+and verify. Token is the first 32 hex chars of HMAC-SHA256(secret, uuid).
+Deterministic: same uuid -> same token. Revocation via revoked_at column.
+"""
+
+from __future__ import annotations
+
+import hmac as _hmac
+import os
+from hashlib import sha256
+
+
+def _get_secret() -> bytes:
+    secret = os.environ.get("INTERNAL_API_SECRET")
+    if not secret:
+        raise RuntimeError(
+            "INTERNAL_API_SECRET is not set — cannot sign or verify artifact tokens"
+        )
+    return secret.encode()
+
+
+def sign_uuid(uuid_str: str) -> str:
+    """Return 32-hex-char HMAC token for the given UUID string."""
+    return _hmac.new(_get_secret(), uuid_str.encode(), sha256).hexdigest()[:32]
+
+
+def verify_signature(uuid_str: str, token: str) -> bool:
+    """Verify a capability token in constant time."""
+    try:
+        expected = sign_uuid(uuid_str)
+    except RuntimeError:
+        return False
+    return _hmac.compare_digest(expected, token)
+
+
+def build_capability_url(uuid_str: str) -> str:
+    """Build a full /artifacts/<uuid>?t=<token> URL using GRIDBEAR_BASE_URL."""
+    base = os.environ.get("GRIDBEAR_BASE_URL", "").rstrip("/")
+    token = sign_uuid(uuid_str)
+    return f"{base}/artifacts/{uuid_str}?t={token}"

--- a/plugins/artifacts/skills/using-artifacts.md
+++ b/plugins/artifacts/skills/using-artifacts.md
@@ -4,12 +4,71 @@ When the user would benefit from a visual representation of data beyond chat
 text (charts, tables with many rows, comparison matrices, interactive
 viewers), create an artifact using the `artifacts__create_artifact` tool.
 
-- Keep HTML self-contained. Inline CSS and JS.
-- External libraries: only from esm.sh, unpkg.com, cdn.jsdelivr.net.
-- Embed data directly as JSON literals in <script> tags. No runtime fetch.
-- Size budget: keep under 500KB for responsiveness.
-- Use the returned URL in your reply — the user will click to view.
-- If the user wants to keep the artifact beyond 30 days, pass pin=true.
+## Sharing model
+
+The URL returned by the tool includes a random share token (`?s=<token>`) so
+the link works on any channel — webchat, WhatsApp, Telegram, Discord, SMS,
+email. Just include the URL in your reply.
+
+The admin can revoke or regenerate the share token at any time from the
+artifacts admin page. The artifact itself remains in storage (owner/admin can
+still view it via the portal) but the shareable link stops working.
+
+You don't need to manage this — just create the artifact and return the URL.
+
+## Hard constraints (CSP-enforced)
+
+The artifact is served inside an iframe with a strict Content-Security-Policy:
+
+- **`connect-src 'none'`** — no `fetch()`, no `XMLHttpRequest`, no WebSocket at
+  runtime. All data MUST be embedded in the HTML as a JSON literal inside a
+  `<script>` tag.
+- **`script-src`** allows only: `esm.sh`, `unpkg.com`, `cdn.jsdelivr.net` (plus
+  inline). Any other origin is blocked.
+- **`img-src`** allows `data:` URIs and `https:` (images from anywhere work).
+
+## Recommended pattern
+
+Use ESM modules from **`esm.sh`**. This avoids UMD-global timing bugs and is
+the most reliable path through the CSP:
+
+```html
+<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>...</title></head>
+<body>
+  <canvas id="chart"></canvas>
+  <script id="data" type="application/json">
+    {"labels": [...], "values": [...]}
+  </script>
+  <script type="module">
+    import Chart from "https://esm.sh/chart.js@4";
+    const data = JSON.parse(document.getElementById("data").textContent);
+    new Chart(document.getElementById("chart"), { type: "bar", data: ... });
+  </script>
+</body>
+</html>
+```
+
+## Library picks
+
+- Charts: `chart.js`, `echarts`, `plotly.js-dist-min` — via `esm.sh`
+- Tables (sort/filter): `@tanstack/table-core` or plain DOM — via `esm.sh`
+- Styling: inline CSS, or Tailwind Play CDN from `cdn.jsdelivr.net`
+- Icons: inline SVG or data-URI (never `<link>` to external icon font)
+
+## Other rules
+
+- Keep HTML self-contained. Inline CSS and JS beyond imports.
+- Size budget: under 500 KB total.
+- Pass `pin=true` if the artifact should outlive the 30-day default TTL.
+
+## Bad patterns (will break in production)
+
+- `fetch("https://api.example.com/data")` — blocked by `connect-src 'none'`
+- `<script src="https://cdnjs.cloudflare.com/...">` — cloudflare not whitelisted
+- Loading data from a query parameter via JS fetch — same block
+- Relying on UMD globals set by unpkg `<script src>` without checking load order
 
 Good candidates: dashboards, sales reports, timeline visualizations,
 filterable tables.

--- a/plugins/artifacts/skills/using-artifacts.md
+++ b/plugins/artifacts/skills/using-artifacts.md
@@ -1,0 +1,16 @@
+# Using artifacts
+
+When the user would benefit from a visual representation of data beyond chat
+text (charts, tables with many rows, comparison matrices, interactive
+viewers), create an artifact using the `artifacts__create_artifact` tool.
+
+- Keep HTML self-contained. Inline CSS and JS.
+- External libraries: only from esm.sh, unpkg.com, cdn.jsdelivr.net.
+- Embed data directly as JSON literals in <script> tags. No runtime fetch.
+- Size budget: keep under 500KB for responsiveness.
+- Use the returned URL in your reply — the user will click to view.
+- If the user wants to keep the artifact beyond 30 days, pass pin=true.
+
+Good candidates: dashboards, sales reports, timeline visualizations,
+filterable tables.
+Bad candidates: one-line answers, simple markdown that renders in chat.

--- a/plugins/artifacts/storage.py
+++ b/plugins/artifacts/storage.py
@@ -1,0 +1,59 @@
+"""Filesystem storage helpers for artifact HTML files.
+
+Files live at {DATA_DIR}/artifacts/<uuid>.html. DATA_DIR defaults to
+/app/data inside the container; tests override via GRIDBEAR_DATA_DIR.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+from plugins.artifacts.errors import HtmlTooLargeError, InvalidHtmlError
+
+_SUBDIR = "artifacts"
+
+
+def _base_dir() -> Path:
+    data = os.environ.get("GRIDBEAR_DATA_DIR", "/app/data")
+    p = Path(data) / _SUBDIR
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _absolute_path(uuid_str: str) -> Path:
+    return _base_dir() / f"{uuid_str}.html"
+
+
+def validate_html(html: str, *, max_bytes: int) -> None:
+    stripped = html.lstrip()
+    if not stripped.lower().startswith("<!doctype html"):
+        raise InvalidHtmlError("HTML must start with <!doctype html>")
+    size = len(html.encode())
+    if size > max_bytes:
+        raise HtmlTooLargeError(f"HTML is {size} bytes; max allowed is {max_bytes}")
+
+
+def compute_hash_and_size(html: str) -> tuple[str, int]:
+    encoded = html.encode()
+    return hashlib.sha256(encoded).hexdigest(), len(encoded)
+
+
+def write_artifact(uuid_str: str, html: str) -> str:
+    _absolute_path(uuid_str).write_text(html, encoding="utf-8")
+    return f"{_SUBDIR}/{uuid_str}.html"
+
+
+def read_artifact(uuid_str: str) -> str:
+    return _absolute_path(uuid_str).read_text(encoding="utf-8")
+
+
+def delete_artifact(uuid_str: str) -> None:
+    p = _absolute_path(uuid_str)
+    if p.exists():
+        p.unlink()
+
+
+def exists(uuid_str: str) -> bool:
+    return _absolute_path(uuid_str).exists()

--- a/plugins/artifacts/virtual_tools.py
+++ b/plugins/artifacts/virtual_tools.py
@@ -1,0 +1,106 @@
+"""LocalToolProvider exposing the artifacts__create_artifact MCP tool.
+
+Lives in a dedicated file (per the discover_local_tool_providers convention:
+the manifest's `virtual_tools` key points to a module that contains a
+LocalToolProvider subclass; the discoverer imports the file and instantiates
+the class).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from core.interfaces.local_tools import LocalToolProvider
+from plugins.artifacts.service import ArtifactsService
+
+_logger = logging.getLogger(__name__)
+
+_SERVER_NAME = "artifacts"
+
+_TOOLS = [
+    {
+        "name": "artifacts__create_artifact",
+        "description": (
+            "Create a standalone HTML artifact (dashboard, chart, data viewer). "
+            "Returns a public URL the user can click. Keep HTML self-contained: "
+            "inline CSS and JS. External libraries only from esm.sh / unpkg / "
+            "cdn.jsdelivr.net. Embed data directly; the CSP blocks runtime fetch. "
+            "Pass pin=true to exempt the 30-day TTL."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "required": ["title", "html"],
+            "properties": {
+                "title": {"type": "string", "maxLength": 200},
+                "html": {"type": "string"},
+                "pin": {"type": "boolean"},
+                "ttl_days": {"type": "integer", "minimum": 1, "maximum": 365},
+            },
+        },
+    }
+]
+
+
+class ArtifactsToolProvider(LocalToolProvider):
+    """Expose the create_artifact MCP tool to agents."""
+
+    def __init__(self) -> None:
+        self._service = ArtifactsService()
+
+    def get_server_name(self) -> str:
+        return _SERVER_NAME
+
+    def get_tools(self) -> list[dict]:
+        return list(_TOOLS)
+
+    async def handle_tool_call(
+        self, tool_name: str, arguments: dict, **kwargs
+    ) -> list[dict]:
+        if tool_name != "artifacts__create_artifact":
+            return [{"type": "text", "text": f"Unknown artifacts tool: {tool_name}"}]
+
+        agent_name = kwargs.get("agent_name")
+        oauth2_user = kwargs.get("oauth2_user")
+        if not agent_name or not oauth2_user:
+            _logger.error(
+                "artifacts__create_artifact invoked without agent/user context "
+                "(agent=%r, user=%r) — refusing",
+                agent_name,
+                oauth2_user,
+            )
+            return [
+                {
+                    "type": "text",
+                    "text": (
+                        "Error: artifact creation requires authenticated "
+                        "agent and user context."
+                    ),
+                }
+            ]
+
+        # TODO(v2): thread conversation_id through from the MCP gateway
+        # (kwargs.get("conversation_id")) so /me/artifacts can filter by thread.
+        # Current v1 leaves the field NULL for tool-created artifacts.
+
+        try:
+            result = await self._service.create(
+                title=arguments["title"],
+                html=arguments["html"],
+                agent_id=agent_name,
+                owner_user_id=oauth2_user,
+                pin=bool(arguments.get("pin", False)),
+                ttl_days=arguments.get("ttl_days"),
+            )
+            return [
+                {
+                    "type": "text",
+                    "text": (
+                        f"Artifact created: {result['title']}\n"
+                        f"URL: {result['url']}\n"
+                        f"Expires: {result['expires_at']}"
+                    ),
+                }
+            ]
+        except Exception as err:
+            _logger.exception("Failed to create artifact: %s", err)
+            return [{"type": "text", "text": f"Error creating artifact: {err}"}]

--- a/plugins/artifacts/virtual_tools.py
+++ b/plugins/artifacts/virtual_tools.py
@@ -22,10 +22,11 @@ _TOOLS = [
         "name": "artifacts__create_artifact",
         "description": (
             "Create a standalone HTML artifact (dashboard, chart, data viewer). "
-            "Returns a public URL the user can click. Keep HTML self-contained: "
-            "inline CSS and JS. External libraries only from esm.sh / unpkg / "
-            "cdn.jsdelivr.net. Embed data directly; the CSP blocks runtime fetch. "
-            "Pass pin=true to exempt the 30-day TTL."
+            "Returns a shareable URL — anyone with the link can view. The admin "
+            "can revoke or regenerate the share link later if needed. Keep HTML "
+            "self-contained: inline CSS and JS. External libraries only from "
+            "esm.sh / unpkg / cdn.jsdelivr.net. Embed data directly; the CSP "
+            "blocks runtime fetch. Pass pin=true to exempt the 30-day TTL."
         ),
         "inputSchema": {
             "type": "object",

--- a/plugins/claude/process_pool.py
+++ b/plugins/claude/process_pool.py
@@ -247,7 +247,7 @@ class ClaudeProcessPool:
         ]
 
         if mcp_config_path:
-            cmd.extend(["--mcp-config", mcp_config_path])
+            cmd.extend(["--mcp-config", mcp_config_path, "--strict-mcp-config"])
 
         # Add permissions from settings (includes MCP gateway wildcard)
         all_perms = []

--- a/plugins/claude/runner.py
+++ b/plugins/claude/runner.py
@@ -594,7 +594,7 @@ class ClaudeRunner(BaseRunner):
         cmd.extend(["--tools", "default"])
 
         if mcp_config and mcp_config.exists():
-            cmd.extend(["--mcp-config", str(mcp_config)])
+            cmd.extend(["--mcp-config", str(mcp_config), "--strict-mcp-config"])
 
         # Add file operation permissions
         # Permissions: file ops + MCP gateway wildcard from claude_settings.json

--- a/tests/unit/plugins/artifacts/conftest.py
+++ b/tests/unit/plugins/artifacts/conftest.py
@@ -1,0 +1,110 @@
+"""Shared fixtures for artifacts plugin unit tests.
+
+Tests requiring a live database are gated on ``TEST_DATABASE_URL``.
+Run with::
+
+    TEST_DATABASE_URL="postgresql://user:pass@host:5432/testdb" \\
+        pytest tests/unit/plugins/artifacts -v
+"""
+
+import os
+from uuid import uuid4
+
+import pytest
+
+DATABASE_URL = os.environ.get("TEST_DATABASE_URL", "")
+
+
+@pytest.fixture
+def fake_uuid() -> str:
+    return str(uuid4())
+
+
+@pytest.fixture
+def hmac_secret(monkeypatch) -> str:
+    secret = "test-secret-do-not-use-in-prod"
+    monkeypatch.setenv("INTERNAL_API_SECRET", secret)
+    return secret
+
+
+@pytest.fixture
+def tmp_data_dir(monkeypatch, tmp_path):
+    """Redirect artifacts storage to a temp dir."""
+    d = tmp_path / "artifacts"
+    d.mkdir()
+    monkeypatch.setenv("GRIDBEAR_DATA_DIR", str(tmp_path))
+    return d
+
+
+@pytest.fixture(scope="module")
+def _pg_sync_bootstrap():
+    """Run table migration once per module via a short-lived sync pool.
+
+    Module-scoped so auto-migration (CREATE TABLE / ADD COLUMN) only runs once.
+    Skips when TEST_DATABASE_URL is not set.
+    """
+    if not DATABASE_URL:
+        pytest.skip("TEST_DATABASE_URL not set — skipping live-DB tests")
+
+    from psycopg.rows import dict_row
+    from psycopg_pool import ConnectionPool
+
+    from core.database import DatabaseManager
+    from core.orm.migrate import migrate_all
+    from plugins.artifacts.models import Artifact
+
+    dm = DatabaseManager(DATABASE_URL)
+    dm._sync_pool = ConnectionPool(
+        DATABASE_URL,
+        min_size=1,
+        max_size=2,
+        open=False,
+        kwargs={"row_factory": dict_row},
+    )
+    dm._sync_pool.open()
+
+    # Run migration for Artifact model only
+    migrate_all([Artifact], dm)
+
+    yield dm
+
+    dm._sync_pool.close()
+
+
+@pytest.fixture
+async def db_initialised(_pg_sync_bootstrap):
+    """Wire the ORM against the current test event loop's async pool.
+
+    psycopg_pool.AsyncConnectionPool binds to the loop that opens it, so we
+    create a fresh pool per test (function scope) to match pytest-asyncio's
+    default loop policy.
+    """
+    from psycopg.rows import dict_row
+    from psycopg_pool import AsyncConnectionPool
+
+    from core.database import DatabaseManager
+    from core.orm.model import set_database
+
+    dm = DatabaseManager(DATABASE_URL)
+    # Reuse the module-scoped sync pool (for ORM sync paths, if any)
+    dm._sync_pool = _pg_sync_bootstrap._sync_pool
+    dm._async_pool = AsyncConnectionPool(
+        DATABASE_URL,
+        min_size=1,
+        max_size=2,
+        open=False,
+        kwargs={"row_factory": dict_row},
+    )
+    await dm._async_pool.open()
+
+    set_database(dm)
+
+    # Clean state for this test
+    with dm.acquire_sync() as conn:
+        conn.execute("TRUNCATE TABLE app.artifacts")
+        conn.commit()
+
+    try:
+        yield dm
+    finally:
+        await dm._async_pool.close()

--- a/tests/unit/plugins/artifacts/test_actions.py
+++ b/tests/unit/plugins/artifacts/test_actions.py
@@ -1,0 +1,91 @@
+"""Tests for pin/unpin/revoke/unrevoke/hard_delete via the service layer."""
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("TEST_DATABASE_URL"),
+        reason="TEST_DATABASE_URL not set",
+    ),
+]
+
+
+async def test_pin_sets_flag(db_initialised, tmp_data_dir, hmac_secret):
+    from plugins.artifacts.models import Artifact
+    from plugins.artifacts.service import ArtifactsService
+
+    svc = ArtifactsService()
+    r = await svc.create(
+        title="x",
+        html="<!doctype html><html></html>",
+        agent_id="a",
+        owner_user_id="u",
+    )
+    await svc.pin(r["artifact_id"], pinned=True)
+    row = (await Artifact.search([("id", "=", r["artifact_id"])]))[0]
+    assert row["pinned"] is True
+
+
+async def test_unpin_resets_expires_at(db_initialised, tmp_data_dir, hmac_secret):
+    from plugins.artifacts.models import Artifact
+    from plugins.artifacts.service import ArtifactsService
+
+    svc = ArtifactsService()
+    r = await svc.create(
+        title="x",
+        html="<!doctype html><html></html>",
+        agent_id="a",
+        owner_user_id="u",
+        pin=True,
+    )
+    uid = r["artifact_id"]
+    # Force expires_at into the distant past
+    await Artifact.write(uid, expires_at=datetime.now(UTC) - timedelta(days=365))
+    await svc.pin(uid, pinned=False)
+    row = (await Artifact.search([("id", "=", uid)]))[0]
+    assert row["pinned"] is False
+    assert row["expires_at"] > datetime.now(UTC) + timedelta(days=20)
+
+
+async def test_revoke_and_unrevoke(db_initialised, tmp_data_dir, hmac_secret):
+    from plugins.artifacts.models import Artifact
+    from plugins.artifacts.service import ArtifactsService
+
+    svc = ArtifactsService()
+    r = await svc.create(
+        title="x",
+        html="<!doctype html><html></html>",
+        agent_id="a",
+        owner_user_id="u",
+    )
+    uid = r["artifact_id"]
+    await svc.revoke(uid)
+    assert (await Artifact.search([("id", "=", uid)]))[0]["revoked_at"] is not None
+
+    await svc.unrevoke(uid)
+    assert (await Artifact.search([("id", "=", uid)]))[0]["revoked_at"] is None
+
+
+async def test_hard_delete_removes_row_and_file(
+    db_initialised, tmp_data_dir, hmac_secret
+):
+    from plugins.artifacts.models import Artifact
+    from plugins.artifacts.service import ArtifactsService
+    from plugins.artifacts.storage import exists
+
+    svc = ArtifactsService()
+    r = await svc.create(
+        title="x",
+        html="<!doctype html><html></html>",
+        agent_id="a",
+        owner_user_id="u",
+    )
+    uid = r["artifact_id"]
+    assert exists(uid)
+    await svc.hard_delete(uid)
+    assert not exists(uid)
+    assert len(await Artifact.search([("id", "=", uid)])) == 0

--- a/tests/unit/plugins/artifacts/test_cleanup.py
+++ b/tests/unit/plugins/artifacts/test_cleanup.py
@@ -1,0 +1,76 @@
+"""Tests for the cleanup worker."""
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("TEST_DATABASE_URL"),
+        reason="TEST_DATABASE_URL not set",
+    ),
+]
+
+
+async def test_cleanup_removes_expired_not_pinned(
+    db_initialised, tmp_data_dir, hmac_secret
+):
+    from plugins.artifacts.cleanup import run_cleanup_once
+    from plugins.artifacts.models import Artifact
+    from plugins.artifacts.service import ArtifactsService
+    from plugins.artifacts.storage import exists
+
+    r = await ArtifactsService().create(
+        title="x",
+        html="<!doctype html><html></html>",
+        agent_id="a",
+        owner_user_id="u",
+    )
+    uid = r["artifact_id"]
+    await Artifact.write(uid, expires_at=datetime.now(UTC) - timedelta(days=1))
+    await run_cleanup_once()
+    assert not exists(uid)
+    assert len(await Artifact.search([("id", "=", uid)])) == 0
+
+
+async def test_cleanup_keeps_pinned_expired(db_initialised, tmp_data_dir, hmac_secret):
+    from plugins.artifacts.cleanup import run_cleanup_once
+    from plugins.artifacts.models import Artifact
+    from plugins.artifacts.service import ArtifactsService
+    from plugins.artifacts.storage import exists
+
+    r = await ArtifactsService().create(
+        title="x",
+        html="<!doctype html><html></html>",
+        agent_id="a",
+        owner_user_id="u",
+        pin=True,
+    )
+    uid = r["artifact_id"]
+    await Artifact.write(uid, expires_at=datetime.now(UTC) - timedelta(days=1))
+    await run_cleanup_once()
+    assert exists(uid)
+    assert len(await Artifact.search([("id", "=", uid)])) == 1
+
+
+async def test_cleanup_missing_file_is_graceful(
+    db_initialised, tmp_data_dir, hmac_secret
+):
+    from plugins.artifacts.cleanup import run_cleanup_once
+    from plugins.artifacts.models import Artifact
+    from plugins.artifacts.service import ArtifactsService
+    from plugins.artifacts.storage import delete_artifact
+
+    r = await ArtifactsService().create(
+        title="x",
+        html="<!doctype html><html></html>",
+        agent_id="a",
+        owner_user_id="u",
+    )
+    uid = r["artifact_id"]
+    delete_artifact(uid)
+    await Artifact.write(uid, expires_at=datetime.now(UTC) - timedelta(days=1))
+    await run_cleanup_once()
+    assert len(await Artifact.search([("id", "=", uid)])) == 0

--- a/tests/unit/plugins/artifacts/test_cleanup.py
+++ b/tests/unit/plugins/artifacts/test_cleanup.py
@@ -5,15 +5,12 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-pytestmark = [
-    pytest.mark.integration,
-    pytest.mark.skipif(
-        not os.environ.get("TEST_DATABASE_URL"),
-        reason="TEST_DATABASE_URL not set",
-    ),
-]
 
-
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("TEST_DATABASE_URL"),
+    reason="TEST_DATABASE_URL not set",
+)
 async def test_cleanup_removes_expired_not_pinned(
     db_initialised, tmp_data_dir, hmac_secret
 ):
@@ -35,6 +32,11 @@ async def test_cleanup_removes_expired_not_pinned(
     assert len(await Artifact.search([("id", "=", uid)])) == 0
 
 
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("TEST_DATABASE_URL"),
+    reason="TEST_DATABASE_URL not set",
+)
 async def test_cleanup_keeps_pinned_expired(db_initialised, tmp_data_dir, hmac_secret):
     from plugins.artifacts.cleanup import run_cleanup_once
     from plugins.artifacts.models import Artifact
@@ -55,6 +57,11 @@ async def test_cleanup_keeps_pinned_expired(db_initialised, tmp_data_dir, hmac_s
     assert len(await Artifact.search([("id", "=", uid)])) == 1
 
 
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("TEST_DATABASE_URL"),
+    reason="TEST_DATABASE_URL not set",
+)
 async def test_cleanup_missing_file_is_graceful(
     db_initialised, tmp_data_dir, hmac_secret
 ):
@@ -74,3 +81,13 @@ async def test_cleanup_missing_file_is_graceful(
     await Artifact.write(uid, expires_at=datetime.now(UTC) - timedelta(days=1))
     await run_cleanup_once()
     assert len(await Artifact.search([("id", "=", uid)])) == 0
+
+
+def test_hook_is_registered_on_startup():
+    """The cleanup worker is wired to the on_startup hook with priority 50."""
+    from plugins.artifacts.hooks import start_cleanup_worker
+
+    hooks = getattr(start_cleanup_worker, "_gridbear_hooks", None)
+    assert hooks is not None
+    # _gridbear_hooks is a list of dicts {"hook_name": ..., "priority": ...}
+    assert any("on_startup" in str(h) for h in hooks)

--- a/tests/unit/plugins/artifacts/test_meta_endpoint.py
+++ b/tests/unit/plugins/artifacts/test_meta_endpoint.py
@@ -1,0 +1,57 @@
+"""Tests for the public meta endpoint."""
+
+import os
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("TEST_DATABASE_URL"),
+        reason="TEST_DATABASE_URL not set",
+    ),
+]
+
+
+@pytest.fixture
+async def client(db_initialised, tmp_data_dir, hmac_secret):
+    # Warm the async pool on the test's event loop so the first connection
+    # is already checked out / returned by the time TestClient's portal
+    # thread needs one (psycopg_pool's internal asyncio.Lock is loop-bound).
+    from plugins.artifacts.api import routes as art_routes
+    from plugins.artifacts.models import Artifact
+
+    await Artifact.search([("id", "=", "__warmup__")])
+
+    app = FastAPI()
+    app.include_router(art_routes.router, prefix="/artifacts")
+    return TestClient(app)
+
+
+async def test_meta_returns_public_fields(client):
+    from plugins.artifacts.service import ArtifactsService
+
+    r = await ArtifactsService().create(
+        title="Dashboard",
+        html="<!doctype html><html></html>",
+        agent_id="peggy",
+        owner_user_id="davide",
+    )
+    resp = client.get(f"/artifacts/{r['artifact_id']}/meta")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["title"] == "Dashboard"
+    assert body["agent_id"] == "peggy"
+    assert "size_bytes" in body
+    assert "created_at" in body
+    # Make sure sensitive / internal fields are NOT exposed
+    assert "content_hash" not in body
+    assert "file_path" not in body
+    assert "owner_user_id" not in body
+
+
+def test_meta_unknown_returns_404(client):
+    resp = client.get("/artifacts/00000000-0000-0000-0000-000000000000/meta")
+    assert resp.status_code == 404

--- a/tests/unit/plugins/artifacts/test_model.py
+++ b/tests/unit/plugins/artifacts/test_model.py
@@ -1,11 +1,18 @@
 """Tests for the Artifact ORM model."""
 
+import os
 from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 import pytest
 
-pytestmark = pytest.mark.integration
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("TEST_DATABASE_URL"),
+        reason="TEST_DATABASE_URL not set",
+    ),
+]
 
 
 async def test_artifact_schema_and_table(db_initialised):
@@ -59,3 +66,84 @@ async def test_artifact_update_pin(db_initialised):
     await Artifact.write(aid, pinned=True)
     rows = await Artifact.search([("id", "=", aid)])
     assert rows[0]["pinned"] is True
+
+
+async def test_size_bytes_check_constraint_rejects_oversized(db_initialised):
+    """CHECK constraint rejects size_bytes > 10485760 (10 MB hard safety)."""
+    from plugins.artifacts.models import Artifact
+
+    aid = str(uuid4())
+    now = datetime.now(UTC)
+    with pytest.raises(Exception) as exc_info:
+        await Artifact.create(
+            id=aid,
+            title="oversized",
+            agent_id="a",
+            owner_user_id="u",
+            conversation_id=None,
+            file_path=f"artifacts/{aid}.html",
+            size_bytes=10_485_761,  # 1 byte over the cap
+            content_hash="h" * 64,
+            pinned=False,
+            expires_at=now + timedelta(days=30),
+        )
+    # Expect the postgres CHECK violation to surface
+    assert (
+        "chk_artifact_size" in str(exc_info.value)
+        or "check" in str(exc_info.value).lower()
+    )
+
+
+async def test_pinned_defaults_to_false_when_omitted(db_initialised):
+    """`pinned` column default is false — row created without the kwarg comes back False."""
+    from plugins.artifacts.models import Artifact
+
+    aid = str(uuid4())
+    now = datetime.now(UTC)
+    await Artifact.create(
+        id=aid,
+        title="default-pin",
+        agent_id="a",
+        owner_user_id="u",
+        conversation_id=None,
+        file_path=f"artifacts/{aid}.html",
+        size_bytes=42,
+        content_hash="h" * 64,
+        # pinned intentionally omitted
+        expires_at=now + timedelta(days=30),
+    )
+    rows = await Artifact.search([("id", "=", aid)])
+    assert rows[0]["pinned"] is False
+
+
+async def test_created_at_and_updated_at_auto_populated(db_initialised):
+    """created_at and updated_at both populate on insert; updated_at changes on write."""
+    from plugins.artifacts.models import Artifact
+
+    aid = str(uuid4())
+    now = datetime.now(UTC)
+    await Artifact.create(
+        id=aid,
+        title="timestamps",
+        agent_id="a",
+        owner_user_id="u",
+        conversation_id=None,
+        file_path=f"artifacts/{aid}.html",
+        size_bytes=42,
+        content_hash="h" * 64,
+        pinned=False,
+        expires_at=now + timedelta(days=30),
+    )
+    rows = await Artifact.search([("id", "=", aid)])
+    created_initial = rows[0]["created_at"]
+    updated_initial = rows[0]["updated_at"]
+    assert created_initial is not None
+    assert updated_initial is not None
+
+    import asyncio
+
+    await asyncio.sleep(0.01)  # ensure timestamp can advance
+    await Artifact.write(aid, title="timestamps-renamed")
+    rows = await Artifact.search([("id", "=", aid)])
+    assert rows[0]["created_at"] == created_initial  # insert-only
+    assert rows[0]["updated_at"] > updated_initial  # updated on write

--- a/tests/unit/plugins/artifacts/test_model.py
+++ b/tests/unit/plugins/artifacts/test_model.py
@@ -1,0 +1,61 @@
+"""Tests for the Artifact ORM model."""
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+async def test_artifact_schema_and_table(db_initialised):
+    from plugins.artifacts.models import Artifact
+
+    assert Artifact._schema == "app"
+    assert Artifact._name == "artifacts"
+
+
+async def test_artifact_create_and_retrieve(db_initialised):
+    from plugins.artifacts.models import Artifact
+
+    aid = str(uuid4())
+    now = datetime.now(UTC)
+    await Artifact.create(
+        id=aid,
+        title="Test artifact",
+        agent_id="peggy",
+        owner_user_id="davide",
+        conversation_id=None,
+        file_path=f"artifacts/{aid}.html",
+        size_bytes=1024,
+        content_hash="a" * 64,
+        pinned=False,
+        expires_at=now + timedelta(days=30),
+    )
+    rows = await Artifact.search([("id", "=", aid)])
+    assert len(rows) == 1
+    assert rows[0]["title"] == "Test artifact"
+    assert rows[0]["pinned"] is False
+    assert rows[0]["revoked_at"] is None
+
+
+async def test_artifact_update_pin(db_initialised):
+    from plugins.artifacts.models import Artifact
+
+    aid = str(uuid4())
+    now = datetime.now(UTC)
+    await Artifact.create(
+        id=aid,
+        title="T",
+        agent_id="a",
+        owner_user_id="u",
+        conversation_id=None,
+        file_path=f"artifacts/{aid}.html",
+        size_bytes=10,
+        content_hash="h",
+        pinned=False,
+        expires_at=now + timedelta(days=30),
+    )
+    await Artifact.write(aid, pinned=True)
+    rows = await Artifact.search([("id", "=", aid)])
+    assert rows[0]["pinned"] is True

--- a/tests/unit/plugins/artifacts/test_serve.py
+++ b/tests/unit/plugins/artifacts/test_serve.py
@@ -1,0 +1,132 @@
+"""Tests for the public serve route."""
+
+import os
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("TEST_DATABASE_URL"),
+        reason="TEST_DATABASE_URL not set",
+    ),
+]
+
+
+@pytest.fixture
+async def client(db_initialised, tmp_data_dir, hmac_secret):
+    # Warm the async pool on the test's event loop so the first connection
+    # is already checked out / returned by the time TestClient's portal
+    # thread needs one (psycopg_pool's internal asyncio.Lock is loop-bound).
+    from plugins.artifacts.api import routes as art_routes
+    from plugins.artifacts.models import Artifact
+
+    await Artifact.search([("id", "=", "__warmup__")])
+
+    app = FastAPI()
+    app.include_router(art_routes.router, prefix="/artifacts")
+    return TestClient(app)
+
+
+async def _create_valid(**kw):
+    from plugins.artifacts.service import ArtifactsService
+
+    defaults = dict(
+        title="T",
+        html="<!doctype html><html><body>hi</body></html>",
+        agent_id="a",
+        owner_user_id="u",
+        pin=False,
+        ttl_days=30,
+    )
+    defaults.update(kw)
+    return await ArtifactsService().create(**defaults)
+
+
+async def test_wrapper_response(client):
+    r = await _create_valid()
+    uid = r["artifact_id"]
+    token = r["url"].split("t=")[1]
+    resp = client.get(f"/artifacts/{uid}", params={"t": token})
+    assert resp.status_code == 200
+    assert "<iframe" in resp.text
+    assert "mode=embed" in resp.text
+
+
+async def test_embed_response_has_csp(client):
+    r = await _create_valid(html="<!doctype html><html><body>payload</body></html>")
+    uid = r["artifact_id"]
+    token = r["url"].split("t=")[1]
+    resp = client.get(f"/artifacts/{uid}", params={"t": token, "mode": "embed"})
+    assert resp.status_code == 200
+    assert "payload" in resp.text
+    csp = resp.headers.get("content-security-policy", "")
+    assert "connect-src 'none'" in csp
+    assert "frame-ancestors 'self'" in csp
+    assert resp.headers.get("x-frame-options") == "SAMEORIGIN"
+
+
+async def test_invalid_token_returns_403(client):
+    r = await _create_valid()
+    resp = client.get(f"/artifacts/{r['artifact_id']}", params={"t": "deadbeef" * 4})
+    assert resp.status_code == 403
+
+
+async def test_unknown_uuid_returns_404(client):
+    # Async so the db_initialised async pool is bound to the same event loop
+    # that TestClient's portal uses for the endpoint coroutine.
+    from plugins.artifacts.signing import sign_uuid
+
+    uid = str(uuid4())
+    resp = client.get(f"/artifacts/{uid}", params={"t": sign_uuid(uid)})
+    assert resp.status_code == 404
+
+
+async def test_revoked_returns_410(client):
+    from plugins.artifacts.models import Artifact
+
+    r = await _create_valid()
+    uid = r["artifact_id"]
+    token = r["url"].split("t=")[1]
+    await Artifact.write(uid, revoked_at=datetime.now(UTC))
+    resp = client.get(f"/artifacts/{uid}", params={"t": token})
+    assert resp.status_code == 410
+    assert "revoked" in resp.text.lower()
+
+
+async def test_expired_not_pinned_returns_410(client):
+    from plugins.artifacts.models import Artifact
+
+    r = await _create_valid()
+    uid = r["artifact_id"]
+    token = r["url"].split("t=")[1]
+    await Artifact.write(uid, expires_at=datetime.now(UTC) - timedelta(days=1))
+    resp = client.get(f"/artifacts/{uid}", params={"t": token})
+    assert resp.status_code == 410
+    assert "expired" in resp.text.lower()
+
+
+async def test_expired_but_pinned_returns_200(client):
+    from plugins.artifacts.models import Artifact
+
+    r = await _create_valid(pin=True)
+    uid = r["artifact_id"]
+    token = r["url"].split("t=")[1]
+    await Artifact.write(uid, expires_at=datetime.now(UTC) - timedelta(days=1))
+    resp = client.get(f"/artifacts/{uid}", params={"t": token})
+    assert resp.status_code == 200
+
+
+async def test_file_missing_returns_404(client):
+    from plugins.artifacts.storage import delete_artifact
+
+    r = await _create_valid()
+    uid = r["artifact_id"]
+    token = r["url"].split("t=")[1]
+    delete_artifact(uid)
+    resp = client.get(f"/artifacts/{uid}", params={"t": token, "mode": "embed"})
+    assert resp.status_code == 404

--- a/tests/unit/plugins/artifacts/test_serve.py
+++ b/tests/unit/plugins/artifacts/test_serve.py
@@ -130,3 +130,48 @@ async def test_file_missing_returns_404(client):
     delete_artifact(uid)
     resp = client.get(f"/artifacts/{uid}", params={"t": token, "mode": "embed"})
     assert resp.status_code == 404
+
+
+async def test_meta_revoked_returns_410(client):
+    from datetime import UTC, datetime
+
+    from plugins.artifacts.models import Artifact
+
+    r = await _create_valid()
+    uid = r["artifact_id"]
+    await Artifact.write(uid, revoked_at=datetime.now(UTC))
+    resp = client.get(f"/artifacts/{uid}/meta")
+    assert resp.status_code == 410
+
+
+async def test_pin_without_token_returns_403(client):
+    r = await _create_valid()
+    resp = client.post(f"/artifacts/{r['artifact_id']}/pin", json={"pinned": True})
+    # Missing `t` → 422 from FastAPI validator OR we want 403; 422 is acceptable since token is required by schema
+    assert resp.status_code in (400, 403, 422)
+
+
+async def test_pin_with_invalid_token_returns_403(client):
+    r = await _create_valid()
+    resp = client.post(
+        f"/artifacts/{r['artifact_id']}/pin",
+        json={"pinned": True},
+        params={"t": "deadbeef" * 4},
+    )
+    assert resp.status_code == 403
+
+
+async def test_pin_with_valid_token_succeeds(client):
+    from plugins.artifacts.models import Artifact
+
+    r = await _create_valid()
+    uid = r["artifact_id"]
+    token = r["url"].split("t=")[1]
+    resp = client.post(
+        f"/artifacts/{uid}/pin",
+        json={"pinned": True},
+        params={"t": token},
+    )
+    assert resp.status_code == 200
+    rows = await Artifact.search([("id", "=", uid)])
+    assert rows[0]["pinned"] is True

--- a/tests/unit/plugins/artifacts/test_service_create.py
+++ b/tests/unit/plugins/artifacts/test_service_create.py
@@ -1,0 +1,79 @@
+"""Tests for ArtifactsService.create()."""
+
+import os
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("TEST_DATABASE_URL"),
+        reason="TEST_DATABASE_URL not set",
+    ),
+]
+
+
+async def test_create_persists_row_and_file(
+    db_initialised, tmp_data_dir, hmac_secret, monkeypatch
+):
+    monkeypatch.setenv("GRIDBEAR_BASE_URL", "https://gb.example.com")
+    from plugins.artifacts.models import Artifact
+    from plugins.artifacts.service import ArtifactsService
+    from plugins.artifacts.storage import read_artifact
+
+    svc = ArtifactsService()
+    html = "<!doctype html><html><body>ok</body></html>"
+    result = await svc.create(
+        title="Hello",
+        html=html,
+        agent_id="peggy",
+        owner_user_id="davide",
+        conversation_id="conv-1",
+        pin=False,
+        ttl_days=30,
+    )
+    assert "artifact_id" in result
+    assert result["url"].startswith("https://gb.example.com/artifacts/")
+    rows = await Artifact.search([("id", "=", result["artifact_id"])])
+    assert len(rows) == 1
+    assert read_artifact(result["artifact_id"]) == html
+
+
+async def test_create_rejects_non_doctype(db_initialised, tmp_data_dir, hmac_secret):
+    from plugins.artifacts.errors import InvalidHtmlError
+    from plugins.artifacts.service import ArtifactsService
+
+    with pytest.raises(InvalidHtmlError):
+        await ArtifactsService().create(
+            title="x",
+            html="<div>no doctype</div>",
+            agent_id="a",
+            owner_user_id="u",
+        )
+
+
+async def test_create_pin_true(db_initialised, tmp_data_dir, hmac_secret):
+    from plugins.artifacts.models import Artifact
+    from plugins.artifacts.service import ArtifactsService
+
+    result = await ArtifactsService().create(
+        title="T",
+        html="<!doctype html><html></html>",
+        agent_id="a",
+        owner_user_id="u",
+        pin=True,
+    )
+    rows = await Artifact.search([("id", "=", result["artifact_id"])])
+    assert rows[0]["pinned"] is True
+
+
+async def test_create_empty_title_raises(db_initialised, tmp_data_dir, hmac_secret):
+    from plugins.artifacts.service import ArtifactsService
+
+    with pytest.raises(ValueError):
+        await ArtifactsService().create(
+            title="   ",
+            html="<!doctype html><html></html>",
+            agent_id="a",
+            owner_user_id="u",
+        )

--- a/tests/unit/plugins/artifacts/test_signing.py
+++ b/tests/unit/plugins/artifacts/test_signing.py
@@ -1,0 +1,58 @@
+"""Tests for HMAC signing helpers."""
+
+from uuid import uuid4
+
+
+def test_sign_roundtrip(hmac_secret):
+    from plugins.artifacts.signing import sign_uuid, verify_signature
+
+    uid = str(uuid4())
+    token = sign_uuid(uid)
+    assert verify_signature(uid, token) is True
+
+
+def test_verify_rejects_tampered_uuid(hmac_secret):
+    from plugins.artifacts.signing import sign_uuid, verify_signature
+
+    uid = str(uuid4())
+    token = sign_uuid(uid)
+    assert verify_signature(str(uuid4()), token) is False
+
+
+def test_verify_rejects_tampered_token(hmac_secret):
+    from plugins.artifacts.signing import sign_uuid, verify_signature
+
+    uid = str(uuid4())
+    token = sign_uuid(uid)
+    mangled = token[:-1] + ("0" if token[-1] != "0" else "1")
+    assert verify_signature(uid, mangled) is False
+
+
+def test_token_is_32_hex_chars(hmac_secret):
+    from plugins.artifacts.signing import sign_uuid
+
+    token = sign_uuid(str(uuid4()))
+    assert len(token) == 32
+    assert all(c in "0123456789abcdef" for c in token)
+
+
+def test_build_capability_url(hmac_secret, monkeypatch):
+    from plugins.artifacts.signing import build_capability_url
+
+    monkeypatch.setenv("GRIDBEAR_BASE_URL", "https://gb.example.com/")
+    uid = str(uuid4())
+    url = build_capability_url(uid)
+    assert url.startswith(f"https://gb.example.com/artifacts/{uid}?t=")
+
+
+def test_sign_missing_secret_raises(monkeypatch):
+    from plugins.artifacts.signing import sign_uuid
+
+    monkeypatch.delenv("INTERNAL_API_SECRET", raising=False)
+    raised = False
+    try:
+        sign_uuid("deadbeef")
+    except RuntimeError as e:
+        raised = True
+        assert "INTERNAL_API_SECRET" in str(e)
+    assert raised

--- a/tests/unit/plugins/artifacts/test_storage.py
+++ b/tests/unit/plugins/artifacts/test_storage.py
@@ -1,0 +1,63 @@
+"""Tests for filesystem storage helpers."""
+
+import hashlib
+from uuid import uuid4
+
+import pytest
+
+
+def test_write_and_read_roundtrip(tmp_data_dir):
+    from plugins.artifacts.storage import read_artifact, write_artifact
+
+    uid = str(uuid4())
+    html = "<!doctype html><html><body>hi</body></html>"
+    rel = write_artifact(uid, html)
+    assert rel == f"artifacts/{uid}.html"
+    assert read_artifact(uid) == html
+
+
+def test_compute_hash_and_size(tmp_data_dir):
+    from plugins.artifacts.storage import compute_hash_and_size
+
+    html = "<!doctype html><html></html>"
+    h, s = compute_hash_and_size(html)
+    assert h == hashlib.sha256(html.encode()).hexdigest()
+    assert s == len(html.encode())
+
+
+def test_validate_rejects_non_doctype(tmp_data_dir):
+    from plugins.artifacts.errors import InvalidHtmlError
+    from plugins.artifacts.storage import validate_html
+
+    with pytest.raises(InvalidHtmlError):
+        validate_html("<div>no doc</div>", max_bytes=1_000_000)
+
+
+def test_validate_rejects_oversized(tmp_data_dir):
+    from plugins.artifacts.errors import HtmlTooLargeError
+    from plugins.artifacts.storage import validate_html
+
+    big = "<!doctype html>" + "x" * 1_000_000
+    with pytest.raises(HtmlTooLargeError):
+        validate_html(big, max_bytes=500)
+
+
+def test_validate_accepts_uppercase_doctype(tmp_data_dir):
+    from plugins.artifacts.storage import validate_html
+
+    validate_html("<!DOCTYPE HTML><html></html>", max_bytes=1_000_000)
+
+
+def test_delete_removes_file(tmp_data_dir):
+    from plugins.artifacts.storage import delete_artifact, write_artifact
+
+    uid = str(uuid4())
+    write_artifact(uid, "<!doctype html><html></html>")
+    delete_artifact(uid)
+    assert not (tmp_data_dir / f"{uid}.html").exists()
+
+
+def test_delete_missing_is_idempotent(tmp_data_dir):
+    from plugins.artifacts.storage import delete_artifact
+
+    delete_artifact("nonexistent-uuid")

--- a/tests/unit/plugins/artifacts/test_tool_provider.py
+++ b/tests/unit/plugins/artifacts/test_tool_provider.py
@@ -1,0 +1,46 @@
+"""Tests for ArtifactsToolProvider."""
+
+import os
+
+import pytest
+
+
+def test_server_name():
+    from plugins.artifacts.service import ArtifactsToolProvider
+
+    assert ArtifactsToolProvider().get_server_name() == "artifacts"
+
+
+def test_tools_contain_create_artifact():
+    from plugins.artifacts.service import ArtifactsToolProvider
+
+    names = [t["name"] for t in ArtifactsToolProvider().get_tools()]
+    assert "artifacts__create_artifact" in names
+
+
+async def test_unknown_tool_returns_error_text():
+    from plugins.artifacts.service import ArtifactsToolProvider
+
+    out = await ArtifactsToolProvider().handle_tool_call("artifacts__nope", {})
+    assert "Unknown" in out[0]["text"]
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("TEST_DATABASE_URL"),
+    reason="TEST_DATABASE_URL not set",
+)
+async def test_create_tool_success(
+    db_initialised, tmp_data_dir, hmac_secret, monkeypatch
+):
+    monkeypatch.setenv("GRIDBEAR_BASE_URL", "https://gb.example.com")
+    from plugins.artifacts.service import ArtifactsToolProvider
+
+    out = await ArtifactsToolProvider().handle_tool_call(
+        "artifacts__create_artifact",
+        {"title": "Hi", "html": "<!doctype html><html></html>"},
+        agent_name="peggy",
+        oauth2_user="davide",
+    )
+    assert "URL:" in out[0]["text"]
+    assert "https://gb.example.com/artifacts/" in out[0]["text"]

--- a/tests/unit/plugins/artifacts/test_tool_provider.py
+++ b/tests/unit/plugins/artifacts/test_tool_provider.py
@@ -6,27 +6,27 @@ import pytest
 
 
 def test_server_name():
-    from plugins.artifacts.service import ArtifactsToolProvider
+    from plugins.artifacts.virtual_tools import ArtifactsToolProvider
 
     assert ArtifactsToolProvider().get_server_name() == "artifacts"
 
 
 def test_tools_contain_create_artifact():
-    from plugins.artifacts.service import ArtifactsToolProvider
+    from plugins.artifacts.virtual_tools import ArtifactsToolProvider
 
     names = [t["name"] for t in ArtifactsToolProvider().get_tools()]
     assert "artifacts__create_artifact" in names
 
 
 async def test_unknown_tool_returns_error_text():
-    from plugins.artifacts.service import ArtifactsToolProvider
+    from plugins.artifacts.virtual_tools import ArtifactsToolProvider
 
     out = await ArtifactsToolProvider().handle_tool_call("artifacts__nope", {})
     assert "Unknown" in out[0]["text"]
 
 
 async def test_missing_identity_returns_error(hmac_secret):
-    from plugins.artifacts.service import ArtifactsToolProvider
+    from plugins.artifacts.virtual_tools import ArtifactsToolProvider
 
     out = await ArtifactsToolProvider().handle_tool_call(
         "artifacts__create_artifact",
@@ -46,7 +46,7 @@ async def test_create_tool_success(
     db_initialised, tmp_data_dir, hmac_secret, monkeypatch
 ):
     monkeypatch.setenv("GRIDBEAR_BASE_URL", "https://gb.example.com")
-    from plugins.artifacts.service import ArtifactsToolProvider
+    from plugins.artifacts.virtual_tools import ArtifactsToolProvider
 
     out = await ArtifactsToolProvider().handle_tool_call(
         "artifacts__create_artifact",

--- a/tests/unit/plugins/artifacts/test_tool_provider.py
+++ b/tests/unit/plugins/artifacts/test_tool_provider.py
@@ -25,6 +25,18 @@ async def test_unknown_tool_returns_error_text():
     assert "Unknown" in out[0]["text"]
 
 
+async def test_missing_identity_returns_error(hmac_secret):
+    from plugins.artifacts.service import ArtifactsToolProvider
+
+    out = await ArtifactsToolProvider().handle_tool_call(
+        "artifacts__create_artifact",
+        {"title": "x", "html": "<!doctype html><html></html>"},
+        # no agent_name, no oauth2_user
+    )
+    assert "Error" in out[0]["text"]
+    assert "agent" in out[0]["text"].lower() or "user" in out[0]["text"].lower()
+
+
 @pytest.mark.integration
 @pytest.mark.skipif(
     not os.environ.get("TEST_DATABASE_URL"),

--- a/ui/routes/auth.py
+++ b/ui/routes/auth.py
@@ -155,7 +155,10 @@ async def login_page(request: Request):
 
     user = get_current_user(request)
     if user:
-        # If already logged in and OAuth2 authorize pending, redirect there
+        # If already logged in and a redirect is pending (artifact, OAuth2), follow it
+        post_login = request.session.pop("post_login_redirect", None)
+        if post_login:
+            return RedirectResponse(url=post_login, status_code=303)
         oauth2_return = request.session.pop("oauth2_return_url", None)
         if oauth2_return:
             return RedirectResponse(url=oauth2_return, status_code=303)
@@ -295,9 +298,12 @@ async def login(
         success=True,
     )
 
-    # Check for pending OAuth2 authorization redirect
+    # Check for pending redirect (artifact link, OAuth2 authorize, etc.)
+    post_login = request.session.pop("post_login_redirect", None)
     oauth2_return = request.session.pop("oauth2_return_url", None)
-    if oauth2_return:
+    if post_login:
+        redirect_to = post_login
+    elif oauth2_return:
         redirect_to = oauth2_return
     elif user.get("is_superadmin"):
         redirect_to = "/"
@@ -356,7 +362,8 @@ async def verify_2fa(
     if encrypted_secret:
         secret = totp_manager.decrypt_secret(encrypted_secret, user_id)
         if secret and totp_manager.verify_code(secret, code):
-            # Get pending OAuth2 redirect before clearing session
+            # Get pending redirects before clearing session
+            post_login = request.session.get("post_login_redirect")
             oauth2_return = request.session.get("oauth2_return_url")
 
             request.session.pop("pending_2fa_user_id", None)
@@ -372,7 +379,10 @@ async def verify_2fa(
             )
 
             # Redirect based on role
-            if oauth2_return:
+            if post_login:
+                redirect_to = post_login
+                request.session.pop("post_login_redirect", None)
+            elif oauth2_return:
                 redirect_to = oauth2_return
                 request.session.pop("oauth2_return_url", None)
             elif user.get("is_superadmin"):
@@ -385,6 +395,7 @@ async def verify_2fa(
             return response
 
     if recovery_manager.verify_code(user_id, code):
+        post_login = request.session.get("post_login_redirect")
         oauth2_return = request.session.get("oauth2_return_url")
 
         request.session.pop("pending_2fa_user_id", None)
@@ -401,7 +412,10 @@ async def verify_2fa(
             details=f"Recovery code used, {remaining} remaining",
         )
 
-        if oauth2_return:
+        if post_login:
+            redirect_to = post_login
+            request.session.pop("post_login_redirect", None)
+        elif oauth2_return:
             redirect_to = oauth2_return
             request.session.pop("oauth2_return_url", None)
         elif user.get("is_superadmin"):
@@ -590,8 +604,11 @@ async def verify_passkey(request: Request):
         success=True,
     )
 
+    post_login = request.session.pop("post_login_redirect", None)
     oauth2_return = request.session.pop("oauth2_return_url", None)
-    if oauth2_return:
+    if post_login:
+        redirect_to = post_login
+    elif oauth2_return:
         redirect_to = oauth2_return
     elif user.get("is_superadmin"):
         redirect_to = "/"

--- a/ui/templates/me/chat.html
+++ b/ui/templates/me/chat.html
@@ -2294,4 +2294,8 @@ function chatApp() {
     };
 }
 </script>
+{# Artifact preview modal (provided by the artifacts plugin).
+   Resolved via Jinja ChoiceLoader from plugins/artifacts/admin/templates/.
+   `ignore missing` keeps chat working even when the artifacts plugin is disabled. #}
+{% include "artifact_modal.html" ignore missing %}
 {% endblock %}


### PR DESCRIPTION
## Summary

New core plugin `artifacts`: agents produce standalone HTML (charts, dashboards, filterable tables) served via shareable capability URLs with CSP-sandboxed iframes. Includes admin UI, portal view, webchat modal, cleanup worker, and end-to-end tests.

Two side-fixes shipped on this branch:

- `plugins/claude`: `--strict-mcp-config` flag prevents Claude CLI from merging ambient MCP servers (`~/.claude.json` projects, claude.ai remote connectors) with the agent's gateway config — fixes runtime permission denials for tools like `mcp__claude_ai_GridBear__*`.
- `ui/routes/auth.py`: generic `post_login_redirect` session key so protected pages (starting with private artifacts) can deep-link users through login and back.

## Access model

Each artifact gets a random `share_token` at creation; the URL returned by `artifacts__create_artifact` embeds it (`?t=<hmac>&s=<token>`). Anyone with the URL views it — no login required, CSP-sandboxed, iframe-isolated. Admin can revoke or regenerate the token from the artifacts admin page without deleting the artifact; owner/superadmin retain access via portal login. Share token comparison is constant-time (`hmac.compare_digest`).

## Hardening

- `X-Robots-Tag: noindex, nofollow, noarchive` + `<meta name=\"robots\">` in wrapper + `Cache-Control: private, no-store, max-age=0` on all artifact responses
- CSP: `connect-src 'none'`, scripts only from `esm.sh` / `unpkg.com` / `cdn.jsdelivr.net`
- Iframe `sandbox=\"allow-scripts\"`, separate wrapper/embed CSPs
- Default TTL 30d, `pinned` flag exempts from cleanup; revoke sets `revoked_at` → 410 Gone

## Admin UI

- Sidebar entry (`menu.json`), list page with search + filters (title/agent/owner/status/share)
- Detail page: metadata, capability URL with Copy button, iframe preview, Pin/Revoke/Delete + Regenerate/Revoke share link

## Agent skill

`plugins/artifacts/skills/using-artifacts.md` — prescriptive guidance on ESM-from-`esm.sh`, CSP-safe patterns, and when to use vs not.

## Test plan

- [ ] Log into /me portal → navigate to a private artifact via capability URL with valid share → renders
- [ ] Valid share token → 200; wrong/missing → 303 to login; login sends back to the deep link (password, TOTP, WebAuthn paths)
- [ ] Admin /plugin/artifacts sidebar entry visible; list search + filters work
- [ ] Regenerate share link → old URL 303s, new URL 200s
- [ ] Revoke share link → external URL 303s, owner still sees via portal
- [ ] Peggy (WhatsApp channel) can call `artifacts__create_artifact` and the returned URL renders a chart without the user needing to log in
- [ ] Claude runner with `--strict-mcp-config` only exposes MCP servers from the agent config file