### PR TITLE
Document master key setup in README install flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,28 @@ nano config/plugins.json
 # Start
 docker compose up -d
 
+# Generate the master key used to encrypt all Secrets Manager entries
+# (bot tokens, OAuth refresh tokens, per-plugin DB passwords, TOTP
+# seeds, etc.). Uses the container's Python env, writes the file to
+# /app/config/secrets.key which persists on the host as ./config/secrets.key
+# via the bind mount. chmod 0600 is applied automatically.
+docker exec gridbear python3 -c \
+  "from ui.secrets_manager import SecretsManager; print(SecretsManager.generate_key_file())"
+
+# >>> BACK UP ./config/secrets.key OUT-OF-BAND <<<
+# Losing this file makes every row in vault.secrets unreadable and
+# there is no recovery path — you would need to re-enter every
+# credential from scratch.
+
 # Create admin account
 # Visit http://localhost:8088/auth/setup
 ```
+
+> **Alternative to the key file**: if you prefer an env var (e.g. for
+> ephemeral deployments that inject secrets from a KMS), set
+> `GRIDBEAR_MASTER_KEY=$(openssl rand -base64 64)` in `.env` instead of
+> running `generate_key_file()`. The file takes precedence when both
+> exist — pick one source of truth and back it up.
 
 ### Agent Configuration
 


### PR DESCRIPTION
## Summary

Adds the missing master key generation step to the README Setup block. Without it, fresh-install operators following the README hit a 500 error the first time they try to save any secret (admin setup, bot token, plugin DB password, etc.) because the Secrets Manager has no key to encrypt with.

## Why

The Secrets Manager (\`ui/secrets_manager.py\`) derives its AES-256-GCM key from:

1. \`config/secrets.key\` — preferred
2. SSH keys on the container user — not present in typical containerised deploys
3. \`GRIDBEAR_MASTER_KEY\` env var — fallback

On a new containerised deployment (no SSH keys bind-mounted to the \`gridbear\` user inside the container), options 1 and 2 are unavailable. The operator gets a clean RuntimeError the first time something hits encrypt/decrypt, but only after they've already proceeded past the install steps — typical first trigger is clicking Save in the admin UI to store a bot token or a plugin credential.

The error message in the code already tells the operator what to do; the install flow in the README didn't.

## What changes

- Adds the \`docker exec gridbear python3 -c \"... generate_key_file() ...\"\` step to the Setup block, placed after \`docker compose up -d\` (so the container's Python env is available) and before \`/auth/setup\` (so admin creation can use encrypted storage).
- Inline back-up warning: \`config/secrets.key\` has no recovery path. Losing it means every row in \`vault.secrets\` is gone — operator would have to re-enter every credential.
- Documents the env-var alternative (\`GRIDBEAR_MASTER_KEY\`) for operators who inject secrets from a KMS and can't persist a file.

## Test plan

- [ ] On a fresh clone + fresh pg volume, run the README steps as-is including the new step → the key file lands at \`./config/secrets.key\` with 0600 perms
- [ ] After running, \`/auth/setup\` creates the admin account without 500 errors
- [ ] Saving a secret via admin UI (e.g. a bot token) persists and roundtrips a read back
- [ ] Setting \`GRIDBEAR_MASTER_KEY=...\` in \`.env\` instead of running the file-gen step also produces a working system

🤖 Generated with [Claude Code](https://claude.com/claude-code)