### PR TITLE
claude runner: pass OAuth env to non-pool subprocess path

### DIFF
--- a/plugins/claude/runner.py
+++ b/plugins/claude/runner.py
@@ -630,12 +630,19 @@ class ClaudeRunner(BaseRunner):
             retry_without_resume: Retry without --resume on session expiry.
             stdin_data: Data to pass via stdin (used for prompt).
         """
+        # Inject CLAUDE_CODE_OAUTH_TOKEN the same way the pool path does,
+        # otherwise the CLI authenticates as anonymous and every call fails
+        # when use_pool=False (the default). See _get_cli_env for the full
+        # secrets-manager + refresh flow.
+        from plugins.claude.api.routes import _get_cli_env
+
         process = await asyncio.create_subprocess_exec(
             *cmd,
             stdin=asyncio.subprocess.PIPE if stdin_data else None,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=self.working_dir,
+            env=_get_cli_env(),
             limit=4 * 1024 * 1024,  # 4MB buffer for large MCP responses
         )
 


### PR DESCRIPTION
## Summary

\`runner._run_subprocess\` built the subprocess without an \`env=\` argument, so the CLI inherited the bare process environment — which does **not** contain \`CLAUDE_CODE_OAUTH_TOKEN\` when the token is stored only in the secrets manager (the normal state after OAuth login via \`/plugin/claude\`). With \`use_pool=False\` (the default in most deployments), every Claude call ran as unauthenticated → 401.

## Why

- Pool path at \`process_pool._create_process\` already did the right thing via its own \`_get_oauth_token\` helper.
- \`api/routes._get_cli_env\` is the canonical env-builder (used by auth_status) that includes token refresh if expired.
- Both paths should behave identically. The non-pool path was simply missing the env injection.

Reported symptom: \`use_pool=false\` is broken for every agent — each call fails auth until the operator toggles \`use_pool=true\` or the token happens to be in the parent process env (rare).

## What changes

One-line fix in \`plugins/claude/runner.py\`:

\`\`\`python
# Before
process = await asyncio.create_subprocess_exec(
    *cmd, stdin=..., stdout=..., stderr=..., cwd=..., limit=...
)

# After
from plugins.claude.api.routes import _get_cli_env
process = await asyncio.create_subprocess_exec(
    *cmd, stdin=..., stdout=..., stderr=..., cwd=..., env=_get_cli_env(), limit=...
)
\`\`\`

Import is function-local to avoid a circular import between runner.py and api/routes.py at module load time.

## Not included

DRY cleanup between \`process_pool._get_oauth_token\` + env assembly and \`api/routes._get_cli_env\` — both paths do similar work now with two different helpers. That's a follow-up refactor, not part of this bug fix.

## Test plan

- [ ] With \`use_pool: false\` (default config), run an agent backed by Claude CLI → reply should succeed, no auth error
- [ ] With \`use_pool: true\`, confirm no regression — pool path still passes env
- [ ] Unit tests \`pytest -k claude\` pass (104 pass, no regressions in this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)