### PR TITLE
master-key: skip unreadable KEY_PATHS, fall through on race

### DIFF
--- a/core/encryption.py
+++ b/core/encryption.py
@@ -6,10 +6,13 @@ Storage format: base64(nonce_12bytes + ciphertext) as a single TEXT string.
 
 import base64
 import hashlib
+import logging
 import os
 from pathlib import Path
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+_logger = logging.getLogger(__name__)
 
 # Key search paths — same as ui/secrets_manager.py (no import dependency on ui/)
 _BASE_DIR = Path(__file__).resolve().parent.parent
@@ -27,9 +30,20 @@ _cached_key: bytes | None = None
 
 
 def _find_key_file() -> Path | None:
+    """Return the first path from KEY_PATHS that is BOTH existent AND readable.
+
+    Using `.exists()` alone hits a trap in containerised deploys: paths
+    like `/root/.ssh/id_ed25519` may exist (owned by root) but the
+    non-root container process can't read them. Picking such a path
+    here would crash every caller with `PermissionError [Errno 13]`.
+    """
     for p in KEY_PATHS:
-        if p.exists():
-            return p
+        try:
+            if p.exists() and os.access(p, os.R_OK):
+                return p
+        except OSError:
+            # stat() itself can fail on exotic mount errors — skip the path.
+            continue
     return None
 
 
@@ -41,9 +55,20 @@ def _get_key() -> bytes:
 
     key_file = _find_key_file()
     if key_file:
-        raw = key_file.read_bytes()
-        _cached_key = hashlib.sha256(raw).digest()
-        return _cached_key
+        try:
+            raw = key_file.read_bytes()
+            _cached_key = hashlib.sha256(raw).digest()
+            return _cached_key
+        except PermissionError as exc:
+            # Belt-and-suspenders: _find_key_file already filters unreadable
+            # paths, but a race (permissions dropped between check and read)
+            # is possible. Fall through to the env var instead of crashing.
+            _logger.warning(
+                "core.encryption: candidate key file %s unreadable (%s); "
+                "falling through to GRIDBEAR_MASTER_KEY",
+                key_file,
+                exc,
+            )
 
     env_val = os.environ.get(MASTER_KEY_ENV)
     if env_val:

--- a/ui/secrets_manager.py
+++ b/ui/secrets_manager.py
@@ -181,7 +181,12 @@ class SecretsManager:
 
         for path in KEY_PATHS:
             try:
-                if path.exists():
+                # os.access(R_OK) is the right check: `.exists()` succeeds
+                # on a file the non-root container user can stat but not
+                # read (e.g. /root/.ssh/id_ed25519 on a deploy where
+                # KEY_PATHS still lists it). Picking such a path makes
+                # downstream read_bytes() crash with PermissionError.
+                if path.exists() and os.access(path, os.R_OK):
                     return path
             except (PermissionError, OSError):
                 continue


### PR DESCRIPTION
## Summary

Fixes a \`PermissionError\` crash in \`core.encryption\` that surfaces on any deploy where the container's non-root user can \`stat\` a KEY_PATHS entry (e.g. \`/root/.ssh/id_ed25519\`) but can't \`read\` it. The selection logic picked the path anyway, the subsequent \`read_bytes()\` threw, and the error propagated all the way up to the caller — WebChat's \`save_message\` in the reported case, producing \`[Errno 13] Permission denied: '/root/.ssh/id_ed25519'\` for every chat message.

## Observed symptom

\`\`\`
2026-04-18 23:16:10,442 - gridbear - WARNING -
WebChat: failed to save message:
[Errno 13] Permission denied: '/root/.ssh/id_ed25519'
\`\`\`

Every chat message silently failed to persist.

## Root cause

Two parallel modules — \`core/encryption.py\` (used by WebChat history, chat_api, Encrypted ORM fields) and \`ui/secrets_manager.py\` (used by the vault / plugin secrets) — both implement \`_find_key_file\` as:

\`\`\`python
for p in KEY_PATHS:
    if p.exists():
        return p
\`\`\`

\`\`.exists()\`\` succeeds on any file the process can stat, even when it can't read. Downstream \`read_bytes()\` then crashes. \`core.encryption\` had no try/except at all → crash propagates. \`ui.secrets_manager\` wrapped the read in try/except but fell through to the env var rather than trying the NEXT candidate in KEY_PATHS — subtle functional regression.

## Fix

1. Both modules now select only paths that are BOTH existent AND readable, via \`os.access(p, os.R_OK)\`. Unreadable paths are silently skipped and the next candidate is tried.
2. \`core.encryption._get_key\` gains a defensive try/except around the read itself (covering a permission race between the check and the read) and falls through to \`GRIDBEAR_MASTER_KEY\`.
3. \`ui.secrets_manager\` already had the inner try/except; kept for symmetry.

## Test plan

- [ ] With \`/root/.ssh/id_ed25519\` present-but-unreadable and \`config/secrets.key\` absent but \`GRIDBEAR_MASTER_KEY\` set: WebChat save_message succeeds, chat history persists.
- [ ] With \`config/secrets.key\` present and readable: still selected as the primary key source.
- [ ] \`pytest -k 'encryption or secret'\` unchanged (7 pass, 22 skipped due to no live PG).

## Not included

- Removing \`/root/.ssh/\` entries from KEY_PATHS entirely. They are legitimately useful for dev workstations where the ops account is root and GridBear runs under root. Keeping them in the list for backward compatibility; the selection step now just skips them when the current process can't read them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)