### PR TITLE
mcp token manager: emit 3-segment wildcard (not 4)

### DIFF
--- a/core/mcp_token_manager.py
+++ b/core/mcp_token_manager.py
@@ -121,20 +121,30 @@ class MCPTokenManager:
         return None
 
     def get_allowed_tools(self, agent_name: str) -> list[str]:
-        """Get per-server wildcard patterns for an agent's MCP permissions.
+        """Return the Claude-CLI allowlist pattern covering this gateway.
 
-        Generates patterns like 'mcp__gridbear-gateway__github__*' for each
-        server the agent has access to, based on its mcp_permissions.
-        Server names are sanitized the same way as in the gateway.
+        Claude Code's permission matcher treats an MCP tool name as three
+        double-underscore-separated parts: ``mcp__<server>__<tool>``. The
+        tool segment is a single unit even when it contains ``__`` itself
+        (e.g. ``artifacts__create_artifact`` or ``dwh_doreca__list_tables``).
+        A pattern with four segments (``mcp__<gw>__<sub>__*``) therefore
+        never matches the CLI's three-segment view of the tool name, and
+        every tool call fires the manual-approval popup regardless of
+        ``mcp_permissions``.
+
+        The right pattern is the three-segment form ``mcp__<gateway>__*``
+        which accepts every tool the gateway exposes. Per-server and
+        per-user ACL is still authoritative — it's enforced server-side
+        inside the gateway against the agent's bearer token (oauth2
+        client permissions). The client-side glob is only a coarse
+        outer fence; the fine filter is already where it belongs.
         """
         if agent_name not in self._agent_tokens:
             return []
         perms = self._agent_mcp_permissions.get(agent_name, [])
-        patterns = []
-        for server_name in perms:
-            sanitized = _MCP_NAME_RE.sub("_", server_name)
-            patterns.append(f"mcp__{self.GATEWAY_SERVER_NAME}__{sanitized}__*")
-        return patterns
+        if not perms:
+            return []
+        return [f"mcp__{self.GATEWAY_SERVER_NAME}__*"]
 
     def _write_agent_mcp_config(self, agent_name: str, token: str) -> None:
         """Write static MCP config file for an agent."""


### PR DESCRIPTION
## Summary

\`core.mcp_token_manager.get_allowed_tools\` has been generating a four-segment Claude Code allowlist pattern per \`mcp_permissions\` entry — \`mcp__<gateway>__<server>__*\`. This pattern can never match because Claude Code's permission matcher parses an MCP tool name as **three** double-underscore-separated parts — \`mcp__<server>__<tool>\` — where the tool segment is a single opaque unit even when it contains \`__\` itself (e.g. \`artifacts__create_artifact\`, \`dwh_doreca__list_tables\`).

Consequence: every tool call fired the manual-approval popup regardless of mcp_permissions configuration, effectively blocking the agent.

## Why

Diagnosed on a live client deploy of the dwh_doreca plugin. Tools were visible to the CLI but every invocation triggered the approval dialog. A collaborator on the server confirmed experimentally that only \`mcp__gridbear-gateway__*\` matches, and any attempt to narrow the pattern to \`mcp__<gateway>__<server>__*\` fails — the CLI's glob does not decompose the tool name on \`__\`.

## What changes

\`get_allowed_tools\` now returns a single entry \`mcp__<gateway>__*\` when the agent has any non-empty \`mcp_permissions\` list.

Per-server and per-user ACL remains authoritative — it's enforced server-side inside the gateway against the agent's bearer token (oauth2 client permissions). The client-side glob was never the primary authorisation layer; treating it as one is what produced this bug.

Docstring rewritten to make the contract explicit for future maintainers.

## Not touched

- **The oauth2 client permissions table** — still authoritative, still filters tool calls server-side
- **\`_MCP_NAME_RE\`** — kept around in case future code needs to sanitize server names for some other context
- **Per-server tokens / MCP config files** — unchanged

## Test plan

- [ ] On a live deploy after this merge, a tool call from an agent that has \`mcp_permissions: [dwh_doreca]\` is executed without the manual-approval popup
- [ ] An agent with \`mcp_permissions: []\` still has \`get_allowed_tools\` return \`[]\` (no gateway glob leaks in)
- [ ] Agent with unknown name returns \`[]\` (unchanged)
- [ ] Grep \`tests/\` for callers — zero assertions on the old 4-segment shape, no test regressions expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)