### PR TITLE
claude: apply agent mcp_permissions to --allowedTools

### DIFF
--- a/core/mcp_token_manager.py
+++ b/core/mcp_token_manager.py
@@ -121,20 +121,30 @@ class MCPTokenManager:
         return None
 
     def get_allowed_tools(self, agent_name: str) -> list[str]:
-        """Get per-server wildcard patterns for an agent's MCP permissions.
+        """Return the Claude-CLI allowlist pattern covering this gateway.
 
-        Generates patterns like 'mcp__gridbear-gateway__github__*' for each
-        server the agent has access to, based on its mcp_permissions.
-        Server names are sanitized the same way as in the gateway.
+        Claude Code's permission matcher treats an MCP tool name as three
+        double-underscore-separated parts: ``mcp__<server>__<tool>``. The
+        tool segment is a single unit even when it contains ``__`` itself
+        (e.g. ``artifacts__create_artifact`` or ``dwh_doreca__list_tables``).
+        A pattern with four segments (``mcp__<gw>__<sub>__*``) therefore
+        never matches the CLI's three-segment view of the tool name, and
+        every tool call fires the manual-approval popup regardless of
+        ``mcp_permissions``.
+
+        The right pattern is the three-segment form ``mcp__<gateway>__*``
+        which accepts every tool the gateway exposes. Per-server and
+        per-user ACL is still authoritative — it's enforced server-side
+        inside the gateway against the agent's bearer token (oauth2
+        client permissions). The client-side glob is only a coarse
+        outer fence; the fine filter is already where it belongs.
         """
         if agent_name not in self._agent_tokens:
             return []
         perms = self._agent_mcp_permissions.get(agent_name, [])
-        patterns = []
-        for server_name in perms:
-            sanitized = _MCP_NAME_RE.sub("_", server_name)
-            patterns.append(f"mcp__{self.GATEWAY_SERVER_NAME}__{sanitized}__*")
-        return patterns
+        if not perms:
+            return []
+        return [f"mcp__{self.GATEWAY_SERVER_NAME}__*"]
 
     def _write_agent_mcp_config(self, agent_name: str, token: str) -> None:
         """Write static MCP config file for an agent."""

--- a/plugins/claude/process_pool.py
+++ b/plugins/claude/process_pool.py
@@ -249,14 +249,27 @@ class ClaudeProcessPool:
         if mcp_config_path:
             cmd.extend(["--mcp-config", mcp_config_path, "--strict-mcp-config"])
 
-        # Add permissions from settings (includes MCP gateway wildcard)
-        all_perms = []
+        # Add permissions from settings (file ops + gateway wildcard from
+        # claude_settings) AND the agent-specific MCP allowlist from the
+        # token manager. Without the token-manager addition every tool
+        # call fires the manual-approval popup, breaking non-interactive
+        # channels (WebChat, Telegram) where no human can click Allow.
+        all_perms: list[str] = []
         try:
             from core.system_config import SystemConfig
 
             settings = SystemConfig.get_param_sync("claude_settings")
             if settings:
-                all_perms = settings.get("permissions", {}).get("allow", [])
+                all_perms = list(settings.get("permissions", {}).get("allow", []) or [])
+        except Exception:
+            pass
+
+        try:
+            from core.mcp_token_manager import get_mcp_token_manager
+
+            tm = get_mcp_token_manager()
+            if tm:
+                all_perms.extend(tm.get_allowed_tools(agent_id))
         except Exception:
             pass
 

--- a/plugins/claude/runner.py
+++ b/plugins/claude/runner.py
@@ -596,9 +596,13 @@ class ClaudeRunner(BaseRunner):
         if mcp_config and mcp_config.exists():
             cmd.extend(["--mcp-config", str(mcp_config), "--strict-mcp-config"])
 
-        # Add file operation permissions
-        # Permissions: file ops + MCP gateway wildcard from claude_settings.json
-        all_perms = self._get_file_permissions()
+        # Add file operation permissions from SystemConfig AND the agent-
+        # specific MCP allowlist from the token manager. Skipping the
+        # latter means every tool call fires the manual-approval popup,
+        # which breaks non-interactive channels (WebChat, Telegram) where
+        # there's nobody to click Allow.
+        all_perms = list(self._get_file_permissions())
+        all_perms.extend(self._get_mcp_allowed_tools(agent_id))
         if all_perms:
             cmd.extend(["--allowedTools"] + all_perms)
 


### PR DESCRIPTION
## Summary

The Claude CLI invocation was passing \`--allowedTools\` built only from \`SystemConfig['claude_settings'].permissions.allow\` — the agent-specific MCP allowlist produced by the token manager (\`get_allowed_tools\` based on \`agent.config.mcp_permissions\`) was never applied. Every tool call fired the manual-approval popup regardless of configuration.

For WebChat / Telegram / Discord / any non-interactive channel there is no human to press Allow — the agent hangs.

## Why this pairs with #111

- PR #111 makes \`get_allowed_tools\` return a pattern Claude CLI can actually match (\`mcp__<gateway>__*\`, three segments).
- This PR wires that return value into the command line at both the pool and non-pool paths.
- Both must land for the approval popup to stop firing in non-interactive channels. Either alone is a half-fix.

## Production-deploy workaround that this PR replaces

Operators had been manually editing \`SystemConfig['claude_settings']\` to include \`mcp__gridbear-gateway__*\` in \`permissions.allow\`, so the catch-all leaked in through the settings-level path and the agent-specific token manager return value was just ignored. Fragile and duplicated the token manager's job.

## Changes

- \`plugins/claude/runner.py:_build_command\` — \`all_perms = self._get_file_permissions()\` now becomes \`list(self._get_file_permissions()) + self._get_mcp_allowed_tools(agent_id)\`
- \`plugins/claude/process_pool.py:_create_process\` — the SystemConfig read is preserved (file ops + legacy perms) and extended with \`get_mcp_token_manager().get_allowed_tools(agent_id)\`. Both try/except blocks are independent so a failure in one doesn't kill the other.

## Not included

- Deduplicating the SystemConfig read between runner and pool (both hit it). Cleanup, not a bug.
- Logging the effective allowlist on process create. Useful diagnostic, separate commit.

## Test plan

- [ ] \`pytest -k claude\` → 104 pass (unchanged)
- [ ] On a live deploy with PR #111 merged first: agent with \`mcp_permissions: [dwh_doreca]\` calls a tool → no approval popup
- [ ] Agent with \`mcp_permissions: []\` → no MCP glob added (token manager returns empty); file perms still applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)