### PR TITLE
mcp gateway: fall through when user has no explicit perms

### DIFF
--- a/core/mcp_gateway/server.py
+++ b/core/mcp_gateway/server.py
@@ -232,11 +232,12 @@ def _filter_by_permissions(tools: list[dict], mcp_permissions: list[str]) -> lis
 def _filter_by_user_mcp_permissions(tools: list[dict], unified_id: str) -> list[dict]:
     """Filter tools by per-user MCP permissions (set in admin /permissions page).
 
-    If the user has no explicit permissions, all tools pass through (backwards compat).
-    If the user has permissions, only namespaced tools from allowed servers are kept.
-    Non-namespaced tools (gridbear_help, send_file_to_chat, etc.) always pass through.
-    System callers (inter-agent, workflow) bypass user-level filtering — they
-    rely on agent-level mcp_permissions instead.
+    If the user has no explicit permissions, all tools pass through (agent-level
+    mcp_permissions has already been enforced upstream). If the user has
+    permissions, only namespaced tools from allowed servers are kept.
+    Non-namespaced tools (gridbear_help, send_file_to_chat, etc.) always pass
+    through. System callers (inter-agent, workflow) bypass user-level filtering
+    — they rely on agent-level mcp_permissions instead.
     """
     # System callers are not real users — skip per-user filtering
     if unified_id and unified_id.startswith("inter_agent:"):
@@ -247,9 +248,13 @@ def _filter_by_user_mcp_permissions(tools: list[dict], unified_id: str) -> list[
 
         user_perms = get_user_mcp_permissions(unified_id)
         if not user_perms:
-            # No permissions configured = no MCP tools allowed.
-            # Keep only non-namespaced built-in tools.
-            return [t for t in tools if "__" not in t.get("name", "")]
+            # No per-user perms configured → defer entirely to the agent-level
+            # filter that has already run on this list. Returning only the
+            # non-namespaced subset (the previous behaviour) silently killed
+            # every MCP tool on any deploy that hadn't hand-populated
+            # app.user_mcp_permissions — directly contradicting the docstring
+            # contract this function advertises.
+            return tools
         pre = len(tools)
         reverse_map = _client_manager._sanitized_to_original if _client_manager else {}
         from core.permissions.mcp_resolver import matches_permission


### PR DESCRIPTION
## Summary

\`_filter_by_user_mcp_permissions\` at \`core/mcp_gateway/server.py:232\` advertises in its docstring:

> If the user has no explicit permissions, all tools pass through (backwards compat).

The code does the opposite:

\`\`\`python
if not user_perms:
    return [t for t in tools if \"__\" not in t.get(\"name\", \"\")]
\`\`\`

That discards every namespaced MCP tool (anything with a \`__\` in its name — i.e. every tool from every plugin). Only the ~8 non-namespaced built-ins survive. On any fresh deploy that hasn't hand-populated \`app.user_mcp_permissions\`, the agent silently loses access to every MCP tool, with no log line and no path forward.

## Why this is not a security hole

The function runs AFTER the agent-level filter has already restricted \`tools\` to the agent's \`mcp_permissions\`. User-level perms (the data this function reads) is an optional FINER restriction on top. Fall-through when no row exists is the correct semantic and matches the documented contract.

## Reported

Live client deploy of the dwh_doreca plugin. Tools correctly registered, agent config correctly set, but every call arrived at the gateway and was filtered out before reaching the plugin.

## What changes

\`_filter_by_user_mcp_permissions\` now returns \`tools\` unchanged when \`user_perms\` is empty, and the docstring is tightened to match. The rest of the function (the match-against-explicit-perms branch) is unchanged.

## Test plan

- [ ] Deploy with \`app.user_mcp_permissions\` empty, agent with \`mcp_permissions: [dwh_doreca]\` — tools reach the agent
- [ ] Deploy with \`app.user_mcp_permissions\` populated with \`dwh_doreca\` for the user — tools still reach the agent
- [ ] Deploy with \`app.user_mcp_permissions\` populated with a DIFFERENT server (\`github\`) for the user — \`dwh_doreca\` tools correctly filtered OUT (existing behaviour preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)