### PR TITLE
misc: plugin admin hardening — menu gate, shutdown stubs, log

### DIFF
--- a/core/mcp_gateway/tool_providers.py
+++ b/core/mcp_gateway/tool_providers.py
@@ -73,3 +73,13 @@ def discover_local_tool_providers(mcp_server) -> None:
             logger.error(f"Failed to load virtual tools from {plugin_name}: {e}")
 
     mcp_server.set_local_tool_providers(providers)
+
+    # Summary line so operators can spot "zero providers registered" at a
+    # glance when diagnosing a tool-not-found report. The per-provider
+    # INFO lines above are easy to miss in the startup log.
+    server_names = [p.get_server_name() for p in providers]
+    logger.info(
+        "Local tool providers: registered %d — %s",
+        len(providers),
+        server_names or "(none)",
+    )

--- a/plugins/artifacts/service.py
+++ b/plugins/artifacts/service.py
@@ -51,6 +51,14 @@ class ArtifactsService:
         """No-op initializer — service is stateless."""
         return None
 
+    async def shutdown(self) -> None:
+        """No-op shutdown — service is stateless (no pool / no long-lived state).
+
+        Present to satisfy the plugin manager's reload / stop contract;
+        without it every reload logs a noisy AttributeError.
+        """
+        return None
+
     async def create(
         self,
         *,

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -494,6 +494,7 @@
                     {% endif %}
 
                     <!-- Data -->
+                    {% if 'memory' in enabled_services %}
                     <div data-section="data">
                         <h3 @click="toggle('data')"
                             class="px-4 mb-2 text-[10px] font-semibold uppercase tracking-widest text-void-400 dark:text-void-500 cursor-pointer select-none flex items-center justify-between">
@@ -514,6 +515,7 @@
                             </a>
                         </div>
                     </div>
+                    {% endif %}
 
                     <!-- System -->
                     <div data-section="system">


### PR DESCRIPTION
## Summary

Three small quality-of-life improvements reported from a live deploy investigation.

## 1. Sidebar 'Data' section hidden when memory not enabled

\`ui/templates/base.html:497-516\` hard-coded \`/memory\` and \`/memory/browse\` links. On any deploy where the memory plugin is not enabled, clicking those sidebar items goes to a 404.

**Fix:** wrapped the entire Data section in \`{% if 'memory' in enabled_services %}\` (enabled_services is already in the template context per \`get_template_context\`).

## 2. ArtifactsService missing async shutdown()

\`plugins/artifacts/service.py\` had \`initialize()\` but no \`shutdown()\`. Plugin manager logged per reload / stop:

\`\`\`
ERROR - Error shutting down service artifacts:
  'ArtifactsService' object has no attribute 'shutdown'
\`\`\`

**Fix:** added a no-op \`async def shutdown(self)\` with docstring explaining why (service is stateless, no cleanup needed). Same as what I just added to the dwh_doreca plugin (which had the same issue but a real pool to drain).

## 3. discover_local_tool_providers summary log

\`core/mcp_gateway/tool_providers.py\` logs INFO per-provider at registration time, but no summary. During startup-log triage, a 'zero providers registered' condition (which happens when an operator forgets to enable any plugin with \`virtual_tools\`) is very easy to miss.

**Fix:** trailing summary line at end of discovery — \`Local tool providers: registered N — [names]\` — so operators can grep for it when diagnosing tool-not-found reports.

## Test plan

- [ ] \`pytest tests/unit\` → 645 pass, 89 skipped (unchanged)
- [ ] With memory plugin disabled, sidebar renders without the Data section
- [ ] With memory plugin enabled, Data section renders as before
- [ ] Container reload — no more \`Error shutting down service artifacts\` in logs
- [ ] Startup logs include \`Local tool providers: registered N — [...]\` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)