### PR TITLE
migration: skip unified_id backfill when user_identities absent

### DIFF
--- a/core/config_migration.py
+++ b/core/config_migration.py
@@ -314,6 +314,26 @@ async def migrate_mcp_perms_to_unified_id() -> bool:
 
     db = get_database()
     async with db.acquire() as conn:
+        # Fresh-install guard: the backfill JOINs against app.user_identities,
+        # a legacy table that only exists on upgraded installs. A brand-new
+        # database has the target table (user_mcp_permissions, ORM-managed)
+        # AND still has the `username` column (it's a current model field,
+        # not legacy), so the column check alone is not enough to bail out —
+        # without this guard the subsequent SQL raises UndefinedTable and
+        # kills the boot sequence on every fresh deploy.
+        ui_check = await conn.execute(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_schema = 'app' AND table_name = 'user_identities'"
+        )
+        if not await ui_check.fetchone():
+            logger.info(
+                "app.user_identities not found — no legacy mapping to "
+                "migrate; marking %s complete.",
+                _MARKER_MCP_PERMS_UNIFIED_ID,
+            )
+            await SystemConfig.set_param(_MARKER_MCP_PERMS_UNIFIED_ID, True)
+            return False
+
         # Check if the old username column still exists
         col_check = await conn.execute(
             "SELECT 1 FROM information_schema.columns "


### PR DESCRIPTION
## Summary

**This bug was caught by the smoke-install CI in PR #110.** Every fresh GridBear install since the UserMcpPermission model stopped dropping its \`username\` column has been crashing on boot:

\`\`\`
ERROR - PostgreSQL initialization failed: relation \"app.user_identities\" does not exist
LINE 5: ...(SELECT ui.unified_id FROM app.user_identities ui
                                                  ^
\`\`\`

The container restart-loops forever — no admin UI ever comes up.

## Root cause

\`migrate_mcp_perms_to_unified_id\` (core/config_migration.py:299) uses the presence of \`app.user_mcp_permissions.username\` as its migration discriminator. That assumption held when \`username\` was a legacy column scheduled for removal, but it's a CURRENT field in the UserMcpPermission model (config_models.py:57). The ORM creates it on every fresh install.

After the column check passes, the migration unconditionally JOINs against \`app.user_identities\` — a legacy table that exists only on upgraded installs, never part of the current schema. Fresh DBs hit \`UndefinedTable\` and the whole boot sequence craters.

## Fix

Before the \`username\` column check, gate the whole migration on whether \`app.user_identities\` exists at all. If the legacy source table isn't there, there's nothing to backfill — set the marker, log, return. Same idempotent pattern the sibling migration at line 790 already uses.

## Why PR #110 matters

This is a textbook example of the bug class PR #110 (smoke-install CI) was meant to catch. Before this PR, a fresh install's failure mode was:
- Unit tests: pass
- Image build: pass
- Container starts... then crashes
- Restarts forever (compose default policy)
- No log surface from CI anywhere — you'd only notice on a live deploy

Now the CI explicitly checks \`/auth/login\` responds before declaring success, so this regression is a red build in <5 min.

## Test plan

- [ ] Merge PR #110 first (the CI job)
- [ ] This PR's CI smoke-install job comes up green
- [ ] After merge, fresh install via README flow boots through to admin UI without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)