### PR TITLE
artifacts: Copy link + Open in tab actions in wrapper top-bar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,3 +160,75 @@ jobs:
 
       - name: Verify container structure
         run: docker run --rm gridbear:test python -c "import ui; import core; print('Import OK')"
+
+  smoke-install:
+    # Reproduces the README Setup block against a freshly-cloned workspace.
+    # Catches a class of bugs that unit tests can't:
+    #   - missing env secrets (POSTGRES_PASSWORD, INTERNAL_API_SECRET,
+    #     GRIDBEAR_MASTER_KEY) silently breaking first encrypt/decrypt
+    #   - compose override referencing a missing service (e.g. gridbear-ui
+    #     after the single-container refactor)
+    #   - plugin load failures at boot (import typos, bad manifest,
+    #     Dockerfile USER vs entrypoint mismatches)
+    #   - admin UI routes 500-ing at first paint
+    needs: build-docker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Reproduce README Setup — config files
+        run: |
+          cp docker-compose.yml.example docker-compose.yml
+          [ -f .env.example ] && cp .env.example .env || touch .env
+          {
+            echo "POSTGRES_PASSWORD=$(openssl rand -base64 24 | tr -d '/=+\n')"
+            echo "INTERNAL_API_SECRET=$(openssl rand -hex 32)"
+            echo "EXECUTOR_TOKEN=$(openssl rand -hex 32)"
+            echo "GRIDBEAR_MASTER_KEY=$(openssl rand -base64 64 | tr -d '/=+\n')"
+            echo "GRIDBEAR_BASE_URL=http://localhost:8088"
+            echo "WEBAUTHN_ORIGIN=http://localhost:8088"
+            echo "WEBAUTHN_RP_ID=localhost"
+          } >> .env
+
+      - name: docker compose up
+        run: |
+          docker compose up -d --build
+          echo "::group::Waiting for UI"
+          for i in $(seq 1 60); do
+            if curl -sf -o /dev/null http://localhost:8088/auth/login; then
+              echo "UI reachable on attempt $i"
+              break
+            fi
+            sleep 2
+          done
+          echo "::endgroup::"
+
+      - name: Assert admin endpoints respond without 500
+        run: |
+          set -e
+          for path in /auth/login /auth/setup; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:8088${path}")
+            echo "$path -> $code"
+            test "${code:0:1}" != "5"
+          done
+
+      - name: Assert no plugin failed to load
+        run: |
+          logs=$(docker compose logs gridbear 2>&1)
+          if echo "$logs" | grep -E "(Plugin [a-z_]+ initialization failed|Failed to register routes|No encryption key found|cannot import name)" ; then
+            echo "::error::Plugin/import/encryption failure in startup logs — see above"
+            exit 1
+          fi
+
+      - name: Dump logs + teardown
+        if: always()
+        run: |
+          mkdir -p smoke-logs
+          docker compose logs > smoke-logs/compose.log 2>&1 || true
+          docker compose down -v --remove-orphans || true
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: failure()
+        with:
+          name: smoke-install-logs
+          path: smoke-logs/

--- a/plugins/artifacts/api/routes.py
+++ b/plugins/artifacts/api/routes.py
@@ -108,6 +108,9 @@ def _wrapper_html(
     size_kb = size_bytes // 1024 or 1
     safe_title = _html_escape(title)
     share_qs = f"&amp;s={share}" if share else ""
+    # The share URL is the current page; users who arrived here via
+    # WhatsApp/Telegram/email often don't see the address bar (mobile
+    # preview modals, in-app browsers) — expose explicit actions.
     return f"""<!doctype html>
 <html>
 <head>
@@ -120,14 +123,58 @@ def _wrapper_html(
   <style>
     body {{ margin: 0; font-family: system-ui, sans-serif; }}
     .top-bar {{ display: flex; justify-content: space-between; align-items: center;
-               padding: 12px 16px; background: #1a1a1a; color: #fff; height: 48px; }}
+               padding: 12px 16px; background: #1a1a1a; color: #fff; height: 48px; gap: 12px; }}
+    .top-bar h1 {{ margin: 0; font-size: 14px; font-weight: 500;
+                   flex: 1; overflow: hidden; text-overflow: ellipsis;
+                   white-space: nowrap; }}
+    .top-bar .actions {{ display: flex; gap: 8px; flex-shrink: 0; }}
+    .top-bar button, .top-bar a {{
+        background: #2a2a2a; color: #fff; border: 1px solid #3a3a3a;
+        padding: 4px 10px; border-radius: 6px; font-size: 12px;
+        cursor: pointer; text-decoration: none;
+    }}
+    .top-bar button:hover, .top-bar a:hover {{ background: #3a3a3a; }}
     iframe {{ width: 100%; height: calc(100vh - 48px); border: 0; display: block; }}
+    #copy-ok {{ color: #4ade80; font-size: 12px; display: none; }}
+    #copy-ok.visible {{ display: inline; }}
   </style>
 </head>
 <body>
-  <header class="top-bar"><h1>{safe_title}</h1></header>
+  <header class="top-bar">
+    <h1>{safe_title}</h1>
+    <div class="actions">
+      <span id="copy-ok">Copied</span>
+      <button type="button" onclick="copyShareUrl()">Copy link</button>
+      <a href="/artifacts/{uid}?t={token}{share_qs}&amp;mode=embed" target="_blank" rel="noopener">
+        Open in tab
+      </a>
+    </div>
+  </header>
   <iframe src="/artifacts/{uid}?t={token}{share_qs}&amp;mode=embed"
           sandbox="allow-scripts" allow="clipboard-write"></iframe>
+  <script>
+    function copyShareUrl() {{
+      const url = window.location.href;
+      const ok = document.getElementById('copy-ok');
+      const done = () => {{
+        ok.classList.add('visible');
+        setTimeout(() => ok.classList.remove('visible'), 1500);
+      }};
+      if (navigator.clipboard) {{
+        navigator.clipboard.writeText(url).then(done).catch(() => {{
+          const ta = document.createElement('textarea');
+          ta.value = url; document.body.appendChild(ta);
+          ta.select(); document.execCommand('copy'); ta.remove();
+          done();
+        }});
+      }} else {{
+        const ta = document.createElement('textarea');
+        ta.value = url; document.body.appendChild(ta);
+        ta.select(); document.execCommand('copy'); ta.remove();
+        done();
+      }}
+    }}
+  </script>
 </body>
 </html>"""
 


### PR DESCRIPTION
## Summary

The wrapper page served at \`/artifacts/<uuid>\` used to render only a title bar and an iframe — no share affordances. Users who opened the link from WhatsApp / Telegram / webchat often didn't see the browser address bar (mobile in-app browsers, modal previews), so they couldn't copy the link back out or re-open the artifact in a standalone tab.

Reported from a live client deploy.

## Changes

Two controls added to the dark top-bar:

- **Copy link** — JS button, copies \`window.location.href\` via \`navigator.clipboard\` with a textarea/execCommand fallback for HTTP deploys and older browsers. Transient \"Copied\" indicator next to the button.
- **Open in tab** — plain \`<a target=\"_blank\">\` pointing at the embed URL (token + share token preserved). Lets users in an in-app browser break out to a real browser.

No change to:
- The agent-facing MCP tool (\`artifacts__create_artifact\`)
- The stored HTML (still the user/agent's raw HTML, untouched)
- The \`/artifacts/<uuid>?mode=embed\` endpoint (still iframe-only content, no chrome)

Only the wrapper shell that the public serve route renders around the iframe grows the two buttons.

## Test plan

- [ ] \`pytest tests/unit/plugins/artifacts\` → 18 pass (unchanged)
- [ ] Open \`/artifacts/<uuid>?t=...&s=...\` from a webchat link → sees the top bar with title + Copy link + Open in tab
- [ ] Click \"Copy link\" → clipboard contains the current URL (not the embed URL)
- [ ] Click \"Open in tab\" → new tab renders the iframe-only content
- [ ] Clicking Copy on an HTTP-only deploy (no clipboard API) → still works via fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)