### PR TITLE
dashboard: warn when GRIDBEAR_BASE_URL mismatches real host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,16 +31,32 @@ ANTHROPIC_API_KEY=
 # Claude model: sonnet (default), opus (more capable), haiku (fastest)
 CLAUDE_MODEL=sonnet
 
-# --- OPTIONAL: Public URL & Auth --------------------------------
+# --- REQUIRED in non-dev deploys: Public URL & Auth -------------
+#
+# The three variables below default to localhost for local development.
+# BEFORE exposing GridBear to a LAN IP, a hostname, or the internet you
+# MUST change all three to match the public URL — otherwise:
+#   - Artifact / share links emitted by the bot point at "localhost"
+#     and are unopenable from anyone else's device
+#   - OAuth2 callback URLs mismatch (login / integrations break)
+#   - WebAuthn (FIDO2 passkeys) refuses to register or authenticate
+#     because the relying-party ID doesn't match the origin
+#
+# The admin dashboard emits a persistent warning until these are
+# consistent with the request's real host.
 
-# Public URL where the UI is accessible (for OAuth callbacks, WebAuthn)
-# Default: http://localhost:8088
+# Public URL where the UI is accessible — the SAME URL operators
+# and external users will use to reach the bot. Example for a LAN
+# deploy:  http://192.168.20.25:8088   or   https://bot.example.com
 GRIDBEAR_BASE_URL=http://localhost:8088
 
-# WebAuthn relying party ID (your domain without protocol/port)
+# WebAuthn relying party ID — the domain (NO scheme, NO port).
+# For http://192.168.20.25:8088  →  WEBAUTHN_RP_ID=192.168.20.25
+# For https://bot.example.com     →  WEBAUTHN_RP_ID=bot.example.com
 WEBAUTHN_RP_ID=localhost
 
-# WebAuthn origin (same as GRIDBEAR_BASE_URL)
+# WebAuthn origin — MUST be identical to GRIDBEAR_BASE_URL above,
+# scheme included.
 WEBAUTHN_ORIGIN=http://localhost:8088
 
 # --- OPTIONAL: Platform Authorization --------------------------

--- a/ui/app.py
+++ b/ui/app.py
@@ -830,6 +830,10 @@ async def dashboard(request: Request, _: dict = Depends(require_login)):
             gmail_accounts=config.get_gmail_accounts(),
             user_identities=config.get_user_identities(),
             agents_count=get_agents_count(),
+            # Exposed so the template can warn when the configured public
+            # URL doesn't match where the admin is actually reaching the
+            # dashboard from (see dashboard.html base-url sanity check).
+            config_base_url=os.environ.get("GRIDBEAR_BASE_URL", ""),
             plugins_summary={
                 "channels": len(plugins["channels"]),
                 "services": len(plugins["services"]),

--- a/ui/templates/dashboard.html
+++ b/ui/templates/dashboard.html
@@ -6,6 +6,43 @@
 {% block page_description %}<p class="text-void-500 dark:text-void-400 mt-1">{{ _("Overview of your AI agent ecosystem") }}</p>{% endblock %}
 
 {% block content %}
+{# --- Public URL sanity check -------------------------------------------- #}
+{# GRIDBEAR_BASE_URL is baked into artifact share links, OAuth callbacks,   #}
+{# and WebAuthn challenges. When it points at localhost but the admin is   #}
+{# reaching the dashboard from a real hostname/IP, every link emitted by   #}
+{# the bot is unopenable from anywhere else. Warn loudly until the env     #}
+{# variables are fixed. See .env.example for the three variables to set.   #}
+{% set base_url = config_base_url or '' %}
+{% set request_host = request.url.hostname or '' %}
+{% set _lo = ('localhost', '127.0.0.1', '0.0.0.0', 'host.docker.internal') %}
+{% set base_url_is_localhost = 'localhost' in base_url or '127.0.0.1' in base_url %}
+{% set reached_via_localhost = request_host in _lo %}
+{% if base_url_is_localhost and not reached_via_localhost %}
+<div class="mb-6 p-4 rounded-xl bg-ember-500/10 border border-ember-500/30 text-ember-600 dark:text-ember-400">
+    <div class="flex items-start gap-3">
+        <i class="fas fa-exclamation-triangle mt-0.5"></i>
+        <div class="flex-1 text-sm">
+            <div class="font-semibold mb-1">{{ _("Base URL mismatch") }}</div>
+            <p>
+                <code>GRIDBEAR_BASE_URL</code> is set to
+                <code>{{ base_url or '(unset)' }}</code>, but you're reaching this
+                dashboard at <code>{{ request_host }}</code>. Every link the bot
+                emits — artifact URLs, OAuth callbacks, WebAuthn origin — will
+                still point at <code>localhost</code> and be unopenable from
+                outside this host.
+            </p>
+            <p class="mt-2">
+                Edit <code>.env</code> and set all three to match the real public URL, then
+                <code>docker compose restart gridbear</code>:
+            </p>
+            <pre class="mt-2 p-2 bg-void-900/60 dark:bg-void-900 text-void-100 rounded text-xs overflow-x-auto">GRIDBEAR_BASE_URL=http://{{ request_host }}:8088
+WEBAUTHN_RP_ID={{ request_host }}
+WEBAUTHN_ORIGIN=http://{{ request_host }}:8088</pre>
+        </div>
+    </div>
+</div>
+{% endif %}
+
 <!-- Hero Stats Card -->
 <div class="relative overflow-hidden rounded-2xl gradient-border p-6 mb-8">
     <div class="relative z-10">


### PR DESCRIPTION
## Summary

On any deploy exposed beyond localhost (LAN, cloud, internet), three env variables must match the actual public URL or the bot emits unopenable links:

- \`GRIDBEAR_BASE_URL\` — baked into artifact share URLs, OAuth callbacks, any self-reference
- \`WEBAUTHN_RP_ID\` — relying-party ID for FIDO2 passkeys
- \`WEBAUTHN_ORIGIN\` — matching origin for WebAuthn challenges

Operators miss this step routinely. By the time they notice (an artifact link that says \`localhost\` inside a WhatsApp message; a failed FIDO2 enrollment), the deploy is already live. Reported from the latest client install.

## What changes

### 1. Dashboard banner

Amber warning appears when \`GRIDBEAR_BASE_URL\` contains localhost AND the admin reached the dashboard from a non-loopback hostname. Copy-pasteable: the exact three env lines come pre-filled with the correct hostname, plus the restart command. Disappears the moment the operator fixes the env.

### 2. .env.example reshape

Section header changed from \"OPTIONAL: Public URL & Auth\" → \"REQUIRED in non-dev deploys: Public URL & Auth\" — because that's the truth. Added per-variable examples (LAN IP, public hostname) and a short list of symptoms that hit you if you skip the step.

## Test plan

- [ ] With \`GRIDBEAR_BASE_URL=http://localhost:8088\` and dashboard reached via \`http://192.168.20.25:8088\` → banner renders with the IP prefilled
- [ ] After editing .env and restarting → banner disappears
- [ ] Dev setup reaching via \`http://localhost:8088\` → no banner (expected; operator IS dev)
- [ ] \`pytest tests/unit\` → 645 pass (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)