### PR TITLE
[FIX] ui: populate MCP server list on fresh install

### DIFF
--- a/ui/routes/permissions.py
+++ b/ui/routes/permissions.py
@@ -14,13 +14,15 @@ router = APIRouter()
 async def permissions_page(request: Request, _: bool = Depends(require_login)):
     from ui.auth.models import AdminUser
     from ui.utils.channels import get_available_channels, get_channel_ui_map
+    from ui.utils.mcp_servers import get_available_mcp_servers
 
     config = ConfigManager()
     permissions = config.get_all_user_permissions()
-    available_servers = config.get_available_mcp_servers()
+    available_servers = get_available_mcp_servers()
 
-    # Fallback: collect server names from existing permissions when
-    # plugin_manager is unavailable (admin runs in a separate container)
+    # Last-chance fallback: union with any server names referenced by
+    # existing user/group permissions (covers older installs whose plugin
+    # registry predates the MCP plugin registration).
     if not available_servers:
         seen = set()
         for servers in permissions.values():

--- a/ui/utils/mcp_servers.py
+++ b/ui/utils/mcp_servers.py
@@ -1,0 +1,61 @@
+"""Dynamic MCP server discovery for the Admin UI.
+
+Mirrors ``ui/utils/channels.py``: runtime ``PluginManager`` first, fallback to
+plugin registry DB + static manifest discovery. Needed because the UI container
+does not call ``set_plugin_manager()`` — only the bot container does — so
+``core.registry.get_available_mcp_servers()`` always returns ``[]`` under the
+admin app.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def get_available_mcp_servers() -> list[str]:
+    """Return all enabled MCP server names visible to the admin UI.
+
+    Runtime ``PluginManager`` is queried first; if unavailable (UI container
+    case), fall back to enabled plugins in the DB registry, resolving each
+    plugin's static server name(s) from its manifest.
+    """
+    try:
+        from core.registry import get_plugin_manager
+
+        pm = get_plugin_manager()
+        if pm is not None:
+            names = pm.get_all_mcp_server_names()
+            if names:
+                return sorted(names)
+    except Exception as exc:
+        logger.debug("runtime plugin_manager lookup failed: %s", exc)
+
+    return sorted(_static_server_names())
+
+
+def _static_server_names() -> list[str]:
+    """Resolve MCP server names from DB-enabled plugins + their manifests.
+
+    Multi-instance providers (``mcp_naming == per_account`` / ``per_tenant``)
+    require runtime expansion and are skipped here — their instances only exist
+    once the bot container has started. The fallback therefore covers
+    single-server plugins, which is the common case for the first-boot form.
+    """
+    from core.registry import get_path_resolver
+    from ui.plugin_helpers import get_enabled_plugins
+
+    resolver = get_path_resolver()
+    manifests = resolver.discover_all() if resolver else {}
+    enabled = get_enabled_plugins()
+
+    names: list[str] = []
+    for plugin_name in enabled:
+        manifest = manifests.get(plugin_name)
+        if not manifest or manifest.get("type") != "mcp":
+            continue
+        if manifest.get("mcp_naming") in {"per_account", "per_tenant"}:
+            continue
+        names.append(manifest.get("name") or plugin_name)
+    return names


### PR DESCRIPTION
## Summary
- On a fresh install the "Add/Edit User" form on `/permissions` showed no MCP server checkboxes — admins couldn't grant permissions to newly created users from the sidebar form
- Root cause: UI container never calls `set_plugin_manager()`, so `core.registry.get_available_mcp_servers()` returns `[]`. The existing "union of permissions/groups" fallback is also empty on day zero
- Add `ui/utils/mcp_servers.py` mirroring the pattern used by `ui/utils/channels.py`: runtime `PluginManager` first, then DB-enabled plugins + static manifest discovery via `PathResolver.discover_all()` as fallback
- Multi-instance providers (`mcp_naming=per_account`/`per_tenant`) are intentionally skipped — their instances require runtime expansion and the user hasn't connected any account yet on fresh install

## Test plan
- [ ] On a fresh install (no permissions configured), `/permissions` right-hand form shows the MCP server checkboxes for all enabled single-instance MCP plugins (github, homeassistant, playwright, dwh_doreca, etc.)
- [ ] After installs where runtime `plugin_manager` is available (e.g. via bot container sharing registry), the runtime list is preferred over the static fallback
- [ ] Existing behaviour preserved when permissions already exist — the last-chance union fallback still kicks in if both runtime and DB paths return empty