### PR TITLE
[FIX] ui: persist agent avatars via data/ so rebuilds don't wipe them

### DIFF
--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -11,7 +11,6 @@ services:
       - .env
     volumes:
       - ./data:/app/data
-      - ./data/avatars:/app/ui/static/avatars
       - ./credentials:/app/credentials
       - ./config:/app/config
       - claude_state:/home/gridbear/.claude

--- a/ui/app.py
+++ b/ui/app.py
@@ -153,6 +153,27 @@ for _pname, _manifest in _all_manifests.items():
                     name=f"theme-static-{_pname}",
                 )
 
+# Agent avatars live under data/ so they persist via the ./data:/app/data
+# bind-mount. Keeping them under ui/static would require a dedicated mount
+# in docker-compose.yml that not every existing deploy has — see issue where
+# avatars vanished on container rebuild for installs predating 8c229bd.
+_AVATARS_DIR = BASE_DIR / "data" / "avatars"
+_AVATARS_DIR.mkdir(parents=True, exist_ok=True)
+
+_legacy_avatars = ADMIN_DIR / "static" / "avatars"
+if (
+    _legacy_avatars.is_dir()
+    and any(_legacy_avatars.iterdir())
+    and not any(_AVATARS_DIR.iterdir())
+):
+    import shutil
+
+    for _f in _legacy_avatars.iterdir():
+        if _f.is_file():
+            shutil.move(str(_f), str(_AVATARS_DIR / _f.name))
+    logger.info("Migrated agent avatars from ui/static/avatars to data/avatars")
+
+app.mount("/static/avatars", StaticFiles(directory=_AVATARS_DIR), name="avatars")
 app.mount("/static", StaticFiles(directory=ADMIN_DIR / "static"), name="static")
 
 from ui.jinja_env import rebuild_template_loader, templates  # noqa: E402

--- a/ui/routes/agents.py
+++ b/ui/routes/agents.py
@@ -14,7 +14,7 @@ from ui.routes.auth import require_login
 logger = logging.getLogger(__name__)
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
-AVATARS_DIR = BASE_DIR / "ui" / "static" / "avatars"
+AVATARS_DIR = BASE_DIR / "data" / "avatars"
 ALLOWED_AVATAR_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 MAX_AVATAR_SIZE = 2 * 1024 * 1024  # 2MB
 


### PR DESCRIPTION
## Summary
- Agent avatars were stored under \`ui/static/avatars\` inside the container, relying on a dedicated bind-mount (\`./data/avatars:/app/ui/static/avatars\`) added in 8c229bd
- Any deploy whose \`docker-compose.yml\` predates that change, or any operator running a custom compose file that wasn't re-merged from the \`.example\`, loses the avatars at every \`docker compose up -d --build\` — the files live in the container layer and evaporate with the image
- Move \`AVATARS_DIR\` to \`data/avatars\` (always persisted via the standard \`./data:/app/data\` mount), serve it with a dedicated \`StaticFiles\` mount at \`/static/avatars\`, and migrate any legacy files on first boot
- Drop the now-redundant dedicated mount from \`docker-compose.yml.example\`

## Test plan
- [ ] Fresh install: upload an agent avatar, rebuild the container (\`docker compose up -d --build gridbear\`), the avatar still displays
- [ ] Legacy install with existing files under \`ui/static/avatars\`: files are moved to \`data/avatars\` on first boot (check startup log \`Migrated agent avatars\`) and continue to render
- [ ] Avatar upload, removal, and change-of-extension all still work from the agent editor UI