### PR TITLE
[FIX] artifacts: harvest <a href> when scanning for artifact URLs

### DIFF
--- a/plugins/artifacts/admin/templates/artifact_modal.html
+++ b/plugins/artifacts/admin/templates/artifact_modal.html
@@ -124,11 +124,17 @@ function artifactModal() {
 
   // Given a message container (.msg-agent), find the .prose content,
   // extract artifact URLs, and append one card per unique URL (dedup).
+  // Agents commonly emit the URL as a markdown link — the rendered
+  // textContent only carries the label, not the href — so we also
+  // harvest hrefs from any <a> in the prose.
   function decorate(container) {
     if (!container || container.nodeType !== 1) return;
     const prose = container.querySelector ? container.querySelector('.prose') : null;
     if (!prose) return;
-    const text = prose.textContent || '';
+    const hrefs = Array.from(prose.querySelectorAll('a[href]'))
+      .map(function(a) { return a.getAttribute('href') || ''; })
+      .join(' ');
+    const text = (prose.textContent || '') + ' ' + hrefs;
     const urls = extractUrls(text);
     if (!urls.length) return;
     for (const url of urls) {


### PR DESCRIPTION
## Summary
- Agents commonly emit artifact URLs as markdown links: \`[Title](https://host/artifacts/<uuid>?t=<hex>)\`
- The webchat decorator only read \`prose.textContent\` — which exposes the rendered label, not the href — so the regex never matched and no Preview/New-tab card was appended below the message
- Extend \`decorate()\` to also harvest hrefs from any \`a[href]\` inside the prose, concatenating them with textContent before running \`extractUrls()\`
- Plain-text URL emissions keep working unchanged; dedup via the existing \`data-artifact-card\` query prevents double cards when the same URL appears both as link and as text

## Repro
- On a fresh deploy where the agent replies with a markdown-linked artifact URL (the default style for most prompts), no Preview card appears below the message. Inline answer quote from a field diagnosis of the running install

## Test plan
- [ ] Agent replies with a markdown-linked artifact URL → Preview + New tab card appears under the message
- [ ] Agent replies with a plain-text artifact URL → card still appears (unchanged behaviour)
- [ ] Agent replies with both forms of the same URL → single card (dedup works)