### PR TITLE
[FIX] ui: hide /me sidebar Workflows link when plugin not installed

### DIFF
--- a/ui/jinja_env.py
+++ b/ui/jinja_env.py
@@ -31,6 +31,21 @@ def _jinja_translate(message: str) -> str:
 templates.env.globals["_"] = _jinja_translate
 
 
+def _plugin_enabled(name: str) -> bool:
+    """Template helper: is the given plugin installed and enabled?
+
+    Used to guard hardcoded menu links in templates (e.g. the user
+    portal sidebar) against enterprise plugins that may not be
+    present on this install.
+    """
+    from ui.plugin_helpers import get_enabled_plugins
+
+    return name in get_enabled_plugins()
+
+
+templates.env.globals["plugin_enabled"] = _plugin_enabled
+
+
 def _load_active_theme_data() -> dict:
     """Load theme data from the active theme plugin.
 

--- a/ui/templates/me/base.html
+++ b/ui/templates/me/base.html
@@ -145,6 +145,7 @@
                         <i class="fas fa-wrench w-5 text-center flex-shrink-0"></i>
                         <span class="sidebar-label">{{ _("MCP Tools") }}</span>
                     </a>
+                    {% if plugin_enabled('workflow') %}
                     <a href="/me/workflows"
                        class="flex items-center rounded-xl text-sm font-medium transition-all hover:bg-void-100 dark:hover:bg-void-800 {% if '/me/workflows' in request.url.path %}menu-active text-nordic-600 dark:text-nordic-400{% else %}text-void-600 dark:text-void-300{% endif %}"
                        :class="sidebarCollapsed ? 'justify-center px-2 py-3' : 'gap-3 px-4 py-3'"
@@ -152,6 +153,7 @@
                         <i class="fas fa-diagram-project w-5 text-center flex-shrink-0"></i>
                         <span class="sidebar-label">{{ _("Workflows") }}</span>
                     </a>
+                    {% endif %}
                     <a href="/me/vault"
                        class="flex items-center rounded-xl text-sm font-medium transition-all hover:bg-void-100 dark:hover:bg-void-800 {% if '/me/vault' in request.url.path %}menu-active text-nordic-600 dark:text-nordic-400{% else %}text-void-600 dark:text-void-300{% endif %}"
                        :class="sidebarCollapsed ? 'justify-center px-2 py-3' : 'gap-3 px-4 py-3'"


### PR DESCRIPTION
## Summary
- The user portal sidebar at \`/me\` always rendered a **Workflows** link pointing at \`/me/workflows\`, even on installs that don't ship the enterprise \`workflow\` plugin — clicking it hit a 404
- Add \`plugin_enabled(name)\` as a Jinja global (\`ui/jinja_env.py\`) — thin wrapper around \`ui.plugin_helpers.get_enabled_plugins()\`
- Gate the Workflows link in \`ui/templates/me/base.html\` behind \`{% if plugin_enabled('workflow') %}\`

## Follow-up (not in this PR)
The six \`workflow_*.html\` templates still under \`ui/templates/me/\` are enterprise-plugin leakage from a previous era. They should move to \`gridbear-plugins/workflow/admin/templates/\` so the core repo stops shipping UI for an enterprise-only feature. Inert for now — without the plugin the routes aren't registered and the templates aren't rendered.

## Test plan
- [ ] Fresh install without the workflow plugin: Workflows link does **not** appear in \`/me\` sidebar
- [ ] Install with workflow plugin enabled: Workflows link appears and clicks through
- [ ] No regression on other sidebar items (Agents, Connections, MCP Tools, Vault, Profile, Chat)