### PR TITLE
[IMP] ui/auth: sliding session expiration so active users stay logged in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,13 @@ LOG_LEVEL=INFO
 SESSION_TTL_HOURS=4
 CLAUDE_TIMEOUT_SECONDS=120
 
+# Admin/portal login sessions use sliding expiration: each authenticated
+# request resets the inactivity window; the session is only killed after
+# INACTIVITY_HOURS without traffic, and never lives longer than MAX_DAYS
+# from the moment of login (hard cap, protects against cookie theft).
+GRIDBEAR_SESSION_INACTIVITY_HOURS=72
+GRIDBEAR_SESSION_MAX_DAYS=30
+
 # Verbose logging for agent communications (prompts, responses)
 VERBOSE_AGENT_LOG=false
 

--- a/ui/auth/database.py
+++ b/ui/auth/database.py
@@ -347,13 +347,20 @@ class AuthDatabase:
         )
         return [dict(r) for r in rows]
 
-    def update_session_activity(self, session_token: str) -> bool:
-        """Update last activity timestamp for a session."""
+    def update_session_activity(
+        self,
+        session_token: str,
+        new_expires_at: Optional[datetime] = None,
+    ) -> bool:
+        """Update last activity timestamp, and optionally slide expires_at."""
         from ui.auth.models import AdminSession
 
+        fields = {"last_activity": datetime.now()}
+        if new_expires_at is not None:
+            fields["expires_at"] = new_expires_at
         updated = AdminSession.write_multi_sync(
             [("session_token", "=", session_token)],
-            last_activity=datetime.now(),
+            **fields,
         )
         return updated > 0
 

--- a/ui/auth/session.py
+++ b/ui/auth/session.py
@@ -23,17 +23,29 @@ def _ensure_naive_dt(val: datetime) -> datetime:
 from ui.auth.database import auth_db
 
 SESSION_COOKIE_NAME = "gridbear_session_token"
-SESSION_DURATION_HOURS = 8
+# Inactivity timeout: the session expires after this much time without any
+# authenticated request. Each validated request slides expires_at forward.
+SESSION_INACTIVITY_HOURS = int(os.getenv("GRIDBEAR_SESSION_INACTIVITY_HOURS", "72"))
+# Absolute hard cap from the moment of login — the session cannot be
+# extended past this, even under continuous activity. Protects against a
+# stolen cookie being refreshed indefinitely.
+SESSION_ABSOLUTE_MAX_DAYS = int(os.getenv("GRIDBEAR_SESSION_MAX_DAYS", "30"))
 SESSION_TOKEN_BYTES = 64
 
 
 class SessionManager:
-    """Manages persistent admin sessions."""
+    """Manages persistent admin sessions with sliding expiration.
+
+    Sessions expire after ``SESSION_INACTIVITY_HOURS`` of inactivity,
+    but never live longer than ``SESSION_ABSOLUTE_MAX_DAYS`` from login
+    regardless of activity.
+    """
 
     def __init__(self):
         self.db = auth_db
         self.cookie_name = SESSION_COOKIE_NAME
-        self.session_duration = timedelta(hours=SESSION_DURATION_HOURS)
+        self.inactivity_window = timedelta(hours=SESSION_INACTIVITY_HOURS)
+        self.absolute_max = timedelta(days=SESSION_ABSOLUTE_MAX_DAYS)
 
     def create_session(
         self,
@@ -46,7 +58,7 @@ class SessionManager:
         Returns the session token.
         """
         token = secrets.token_hex(SESSION_TOKEN_BYTES)
-        expires_at = datetime.now() + self.session_duration
+        expires_at = datetime.now() + self.inactivity_window
 
         ip_address = self._get_client_ip(request)
         user_agent = request.headers.get("user-agent", "")[:500]
@@ -59,7 +71,7 @@ class SessionManager:
             user_agent=user_agent,
         )
 
-        self._set_cookie(response, token, expires_at)
+        self._set_cookie(response, token)
 
         self.db.update_user(user_id, last_login=datetime.now().isoformat())
 
@@ -78,15 +90,29 @@ class SessionManager:
         if not session:
             return None
 
-        if _ensure_naive_dt(session["expires_at"]) < datetime.now():
+        now = datetime.now()
+        if _ensure_naive_dt(session["expires_at"]) < now:
             self.db.delete_session(token)
             return None
+
+        # Absolute hard cap: expire sessions that have been alive longer
+        # than SESSION_ABSOLUTE_MAX_DAYS regardless of activity.
+        created_at = session.get("created_at")
+        if created_at is not None:
+            age_limit = _ensure_naive_dt(created_at) + self.absolute_max
+            if now > age_limit:
+                self.db.delete_session(token)
+                return None
+        else:
+            age_limit = now + self.inactivity_window
 
         user = self.db.get_user_by_id(session["user_id"])
         if not user or not user.get("is_active"):
             return None
 
-        self.db.update_session_activity(token)
+        # Slide expires_at forward on activity, capped at the absolute max.
+        new_expires_at = min(now + self.inactivity_window, age_limit)
+        self.db.update_session_activity(token, new_expires_at=new_expires_at)
 
         return user
 
@@ -144,10 +170,17 @@ class SessionManager:
     def _is_https() -> bool:
         return os.getenv("ADMIN_HTTPS_ONLY", "false").lower() == "true"
 
-    def _set_cookie(self, response: Response, token: str, expires_at: datetime) -> None:
-        """Set the session cookie with security flags."""
+    def _set_cookie(self, response: Response, token: str) -> None:
+        """Set the session cookie with security flags.
+
+        Cookie lifetime is pinned to the absolute max so the browser
+        keeps sending it as long as the server considers the session
+        valid. Server-side inactivity enforcement happens in
+        ``validate_session`` (the DB row's ``expires_at`` shrinks the
+        effective window even though the cookie lives longer).
+        """
         https = self._is_https()
-        max_age = int((expires_at - datetime.now()).total_seconds())
+        max_age = int(self.absolute_max.total_seconds())
         response.set_cookie(
             key=self.cookie_name,
             value=token,


### PR DESCRIPTION
## Summary
- Admin/portal sessions previously expired **8 hours after login regardless of activity**, forcing users to re-enter credentials daily even while continuously working — reported from live deploy
- Switch to **inactivity-based window** (default 72h) refreshed on every validated request, with an **absolute hard cap** (default 30 days from login) so a stolen cookie can't be renewed indefinitely
- Two env vars expose the policy to operators: \`GRIDBEAR_SESSION_INACTIVITY_HOURS\`, \`GRIDBEAR_SESSION_MAX_DAYS\`

## Changes
- \`ui/auth/session.py\`: rename \`SESSION_DURATION_HOURS\` → \`SESSION_INACTIVITY_HOURS\`, add \`SESSION_ABSOLUTE_MAX_DAYS\`; \`validate_session\` slides \`expires_at = min(now + inactivity, created_at + max_days)\` and enforces the absolute cap; cookie \`Max-Age\` pinned to the absolute max so the browser keeps sending it while the server governs inactivity
- \`ui/auth/database.py\`: \`update_session_activity\` now accepts \`new_expires_at\` so the slide lands in the same write as \`last_activity\`
- \`.env.example\`: document the two new env vars

## Test plan
- [ ] Log in, idle for less than INACTIVITY window → still authenticated
- [ ] Log in, make a request every few hours for multiple days → session lives up to the absolute cap then requires re-login
- [ ] Log in, wait past INACTIVITY window without making any request → next request bounces to login
- [ ] Cookie \`Max-Age\` set to 30 days (not 72h) so the browser retains it across inactivity periods the server would otherwise tolerate
- [ ] \`GRIDBEAR_SESSION_INACTIVITY_HOURS=2 GRIDBEAR_SESSION_MAX_DAYS=1\` knobs work end-to-end