### PR TITLE
[FIX] mcp gateway: notify user only on actionable auth failures

### DIFF
--- a/core/mcp_gateway/client_manager.py
+++ b/core/mcp_gateway/client_manager.py
@@ -1163,26 +1163,30 @@ class MCPClientManager:
                         f"to {server_name}: {e}" + (f" | sub: {sub}" if sub else ""),
                         exc_info=True,
                     )
-                    # Mark token as expired if auth failure (401/unauthorized)
-                    if "401" in err_str or "unauthorized" in err_str:
+                    # Only surface the failure as a user-facing notification
+                    # when it's an actionable auth problem — not for
+                    # transient network / TaskGroup-wrapped errors that the
+                    # next request typically recovers from on its own.
+                    is_auth_error = "401" in err_str or "unauthorized" in err_str
+                    if is_auth_error:
                         conn_id = self._known_servers[server_name].service_connection_id
                         if conn_id:
                             _mark_token_expired(unified_id, conn_id)
-                    try:
-                        from ui.services.notifications import NotificationService
+                        try:
+                            from ui.services.notifications import NotificationService
 
-                        asyncio.ensure_future(
-                            NotificationService.get().create(
-                                category="oauth_expired",
-                                severity="error",
-                                title=f"Connection failed: {server_name}",
-                                message=str(e)[:200],
-                                source=server_name,
-                                user_id=unified_id,
+                            asyncio.ensure_future(
+                                NotificationService.get().create(
+                                    category="oauth_expired",
+                                    severity="error",
+                                    title=f"Connection failed: {server_name}",
+                                    message=str(e)[:200],
+                                    source=server_name,
+                                    user_id=unified_id,
+                                )
                             )
-                        )
-                    except Exception:
-                        pass
+                        except Exception:
+                            pass
                 return None
 
         return conn


### PR DESCRIPTION
## Summary
- Live deploy shows a stream of \`Connection failed: odoo-mcp — unhandled errors in a TaskGroup (1 sub-exception)\` notifications even when the odoo-mcp server is working fine
- Root cause: \`core/mcp_gateway/client_manager.py\` emitted the user-facing notification for **any** connection error. Network glitches, SDK timeouts wrapped by anyio TaskGroup, transient upstream hiccups — all surfaced as 'Connection failed' with category \`oauth_expired\`, even when nothing was expired
- Fix: only emit the notification when the error is an actionable auth failure (\`401\` / \`unauthorized\`). Non-auth errors keep their server-side \`logger.error\` with \`exc_info\` for diagnosis but no longer spam the notification tray

## Repro
User reported persistent false-positive notifications on \`odoo-mcp\` while the plugin itself was operating normally — the screenshot attached to the internal report showed four 'Connection failed: odoo-mcp' entries over 5 days, all with 'unhandled errors in a TaskGroup (1 sub-exception)' which is anyio wrapping a transient MCP SDK connect error the next request would have recovered from.

## Test plan
- [ ] Simulate a 401 from an MCP server: notification 'Connection failed: <server>' appears once, category \`oauth_expired\`
- [ ] Simulate a transient connect error (network timeout, TaskGroup sub-exception): no notification; server log records \`MCP Gateway: failed to connect user ... to ...\` with \`exc_info\`
- [ ] On retry after cooldown the normal reconnect path still works