### PR TITLE
[IMP] docs: direct contributors to Discussions for RFCs and open-ended conversations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,12 +142,16 @@ Before opening a PR, consider discussing your approach on [Discord](https://disc
 - All CI checks must pass (lint, tests, type-check)
 - Describe the **why** in the PR description, not just the what
 
-## Reporting Issues
+## Reporting Issues & Proposing Changes
 
-- Use GitHub Issues for bug reports and feature requests
-- For security vulnerabilities, see [SECURITY.md](SECURITY.md)
-- Include steps to reproduce for bug reports
-- Check existing issues before opening a new one
+Pick the right channel:
+
+- **[GitHub Issues](https://github.com/gridbeario/gridbear/issues)** — bug reports and concrete feature requests (something broken or a well-scoped ask ready to be worked on). Include steps to reproduce for bugs; check existing issues before opening a new one.
+- **[GitHub Discussions](https://github.com/gridbeario/gridbear/discussions)** — open-ended conversations and design work:
+  - *RFC / Design* — propose a non-trivial change (new plugin, architecture shift, cross-cutting refactor). Post the design first, iterate, then open a PR that links back to the discussion.
+  - *Ideas* — informal "what if we…" suggestions not yet ready for a full RFC.
+  - *Q&A* — usage questions, setup help.
+- **[SECURITY.md](SECURITY.md)** — security vulnerabilities (do **not** open a public Issue or Discussion for these).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -202,8 +202,9 @@ tests/              Unit and integration tests
 
 ## Community
 
-- [Discord](https://discord.gg/WhTK4PPmaE) — chat, questions, and discussions
-- [GitHub Issues](https://github.com/gridbeario/gridbear/issues) — bug reports and feature requests
+- [Discord](https://discord.gg/WhTK4PPmaE) — chat and realtime Q&A
+- [GitHub Issues](https://github.com/gridbeario/gridbear/issues) — bug reports and concrete feature requests
+- [GitHub Discussions](https://github.com/gridbeario/gridbear/discussions) — design proposals, RFCs, general Q&A, and show-and-tell
 
 ## License
 


### PR DESCRIPTION
## Summary
- README and CONTRIBUTING only mentioned GitHub Issues; Discussions has been enabled with categories Announcements, General, Ideas, Polls, Q&A, **RFC / Design**, Show and tell — contributors need to know when to use which channel
- README \`## Community\`: add Discussions link, sharpen the Issues scope ('concrete feature requests')
- CONTRIBUTING \`## Reporting Issues\` → \`## Reporting Issues & Proposing Changes\`: explicit routing — Issues (bugs + scoped asks), Discussions (RFCs, Ideas, Q&A), SECURITY.md (vulns)

## Test plan
- [ ] Render README and CONTRIBUTING on GitHub — links resolve, scope wording reads cleanly
- [ ] No broken anchor or nested-list rendering glitch in the new CONTRIBUTING block