### PR TITLE
[FIX] mcp gateway: invalidate tools cache on agent reload and identity switch

### DIFF
--- a/core/mcp_gateway/server.py
+++ b/core/mcp_gateway/server.py
@@ -341,11 +341,40 @@ def _load_agent_config(agent_name: str) -> dict | None:
 
 
 def invalidate_agent_config_cache(agent_name: str | None = None) -> None:
-    """Invalidate agent config cache. Called on reload."""
+    """Invalidate agent config cache. Called on reload.
+
+    Also drops any ``_tools_cache`` entries tied to the agent so that
+    ``mcp_permissions``, ``service_account``, ``max_tools`` or other
+    changes land immediately instead of waiting for the 120s TTL to
+    expire.
+    """
     if agent_name:
         _agent_config_cache.pop(agent_name, None)
+        _invalidate_tools_cache(agent_name)
     else:
         _agent_config_cache.clear()
+        _tools_cache.clear()
+
+
+def _invalidate_tools_cache(agent_name: str) -> None:
+    """Drop ``_tools_cache`` entries whose key targets ``agent_name``.
+
+    Cache keys are shaped as
+    ``"<agent>:<user>:<tool_loading>:<tool_budget>[:<perms>]"``; keys
+    belonging to ``agent_name`` therefore share the ``"<agent>:"``
+    prefix. A full prefix match on ``"<agent>:"`` is enough — no need
+    to parse the rest of the key.
+    """
+    prefix = f"{agent_name}:"
+    stale = [k for k in _tools_cache if k.startswith(prefix)]
+    for k in stale:
+        _tools_cache.pop(k, None)
+    if stale:
+        logger.debug(
+            "Dropped %d stale tools_cache entries for agent %s",
+            len(stale),
+            agent_name,
+        )
 
 
 # Server category mapping (populated after provider refresh)
@@ -2527,11 +2556,17 @@ async def mcp_set_user_context(request: Request):
     except Exception:
         return api_error(400, "invalid json", "validation_error")
 
-    _agent_user_context[agent_name] = body.get("user_identity")
+    new_user = body.get("user_identity")
+    old_user = _agent_user_context.get(agent_name)
+    _agent_user_context[agent_name] = new_user
+    if old_user != new_user:
+        # Tools cache is keyed on (agent, effective_user, ...); an
+        # identity swap makes prior entries stale, so drop them.
+        _invalidate_tools_cache(agent_name)
     logger.debug(
         "user context set: agent=%s user=%s",
         agent_name,
-        body.get("user_identity"),
+        new_user,
     )
     return api_ok()
 


### PR DESCRIPTION
## Summary
- Agent hot-reload (`invalidate_agent_config_cache`) dropped the agent config cache but **left `_tools_cache` untouched**. That cache keys on `<agent>:<effective_user>:<tool_loading>:<tool_budget>[:<perms>]` with a 120 s TTL
- Any change to `mcp_permissions`, `context_options.service_account`, `max_tools`, or the per-user identity attached to the agent was silently served from stale cache for up to 2 minutes after the supposed hot-reload
- Worse, when the cache had been populated during a transient bad-configuration window (e.g. before `service_account` was set, or before `set_user_context` ran), the agent kept seeing only built-in tools even after the config was fixed — **only a full container restart cleared the state**

## Repro
Observed while flipping `context_options.service_account` on an agent from identity `<A>` (no credentials) to identity `<B>` (has credentials for the target MCP server via `user_service_accounts` + vault) and calling the reload endpoint. Logs showed `tools/list filtered 319→33` at the filter step, but the final `tools/list for agent=<agent> user=<B>: 8 tools (builtin:8)` — the 33 MCP tools never made it out, because the cache key had been populated earlier with only built-ins. After a container restart (cache flushed) the same config produced `44 tools` with the expected MCP server breakdown and the agent could call those tools.

## Fix
- `invalidate_agent_config_cache(agent)` now also drops `_tools_cache` entries whose key starts with `<agent>:`, via a new `_invalidate_tools_cache(agent)` helper
- `set_user_context` endpoint drops tools cache for the agent whenever `user_identity` changes (old vs new compared), so a service_account swap takes effect on the next `tools/list`

## Test plan
- [ ] Change `mcp_permissions` on an agent, hit reload, the newly-allowed MCP tools appear in the next prompt without restart
- [ ] Flip `context_options.service_account` to a user with different credentials, hit reload, the next message uses the new identity
- [ ] No regression on existing behaviour when cache is warm and nothing has changed (normal cache hit path still works)
