### PR TITLE
[FIX] gmail: persist PKCE code_verifier across OAuth redirect

### DIFF
--- a/plugins/gmail/admin/routes.py
+++ b/plugins/gmail/admin/routes.py
@@ -85,6 +85,9 @@ async def start_oauth(request: Request, token: str):
     )
 
     request.session["oauth_state"] = state
+    # google-auth-oauthlib ≥1.3 enables PKCE by default — the verifier must
+    # survive to the callback, else Google rejects the exchange.
+    request.session["oauth_code_verifier"] = getattr(flow, "code_verifier", None)
     return RedirectResponse(url=auth_url)
 
 
@@ -150,8 +153,12 @@ async def oauth_callback(
 
     os.environ["OAUTHLIB_RELAX_TOKEN_SCOPE"] = "1"
 
+    code_verifier = request.session.pop("oauth_code_verifier", None)
+
     try:
         flow = get_flow(redirect_uri)
+        if code_verifier:
+            flow.code_verifier = code_verifier
         flow.fetch_token(code=code)
         credentials = flow.credentials
 

--- a/plugins/gmail/portal/routes.py
+++ b/plugins/gmail/portal/routes.py
@@ -33,6 +33,10 @@ async def gmail_oauth_start(
 
     request.session["oauth_state"] = state
     request.session["oauth_conn"] = "gmail:gmail"
+    # google-auth-oauthlib ≥1.3 enables PKCE by default: flow.code_verifier
+    # is generated above and MUST be replayed in the callback's fetch_token
+    # exchange — otherwise Google rejects with "Missing code verifier".
+    request.session["oauth_code_verifier"] = getattr(flow, "code_verifier", None)
     return RedirectResponse(url=auth_url, status_code=303)
 
 
@@ -45,6 +49,7 @@ async def gmail_oauth_callback(
     code = request.query_params.get("code")
     state = request.query_params.get("state")
     session_state = request.session.pop("oauth_state", None)
+    code_verifier = request.session.pop("oauth_code_verifier", None)
     request.session.pop("oauth_conn", None)
 
     if not code or not state or state != session_state:
@@ -67,6 +72,8 @@ async def gmail_oauth_callback(
 
     try:
         flow = get_flow(redirect_uri)
+        if code_verifier:
+            flow.code_verifier = code_verifier
         flow.fetch_token(code=code)
         credentials = flow.credentials
 


### PR DESCRIPTION
## Summary
- Gmail OAuth on `/me/connections` (and the admin flow at `/oauth/gmail`) fails with `(invalid_grant) Missing code verifier` — no `gmail_token_<email>` gets stored
- Root cause: `google-auth-oauthlib ≥1.3.1` (bumped in 0.8.1) enables **PKCE by default** in `Flow.authorization_url()`. The generated `code_verifier` lives on the `Flow` instance; Google then requires it in the token exchange
- Gmail's OAuth handlers construct a **fresh `Flow` instance in the callback**, so the verifier from the start handler is lost and the exchange fails
- Fix: persist `flow.code_verifier` in the request session at start, restore it on the new `Flow` before `fetch_token()` in the callback
- Both flows affected (portal + admin)

## Scope
Claude runner's OAuth already manages PKCE manually; MS365 uses MSAL; google-workspace uses service accounts. Gmail was the only plugin hit by this 1.3.x change.

## Test plan
- [ ] Fresh `/me/connections` → connect Gmail → OAuth succeeds, `gmail_token_<email>` appears in `vault.secrets`, row appears in `app.user_service_accounts`
- [ ] Admin `/oauth/gmail` flow reaches the same outcome
- [ ] Token refresh (offline access) still works on subsequent requests