### PR TITLE
[ADD] docs: MkDocs Material site + GitHub Pages deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,42 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docs/**
+      - mkdocs.yml
+      - CHANGELOG.md
+      - CONTRIBUTING.md
+      - .github/workflows/docs.yml
+  workflow_dispatch:
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install MkDocs Material
+        run: |
+          python -m pip install --upgrade pip
+          pip install "mkdocs-material>=9.5" "mkdocs-material[imaging]" "pymdown-extensions>=10.7"
+
+      - name: Build and deploy
+        run: mkdocs gh-deploy --force --clean --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -113,8 +113,10 @@ ui/static/avatars/
 !ui/static/logo.png
 !ui/static/icons/*.png
 
-# Local development scripts and docs
-docs/
+# Local development scripts (no longer ignoring docs/ — it hosts the
+# MkDocs site sources now; internal specs have moved to GitHub
+# Discussions under the RFC / Design category)
+site/
 scripts/migrate_chroma_to_pg.py
 scripts/migrate_encrypt_data.py
 claude-debate.sh

--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ docker-compose.override.yml
 !CHANGELOG.md
 !LICENSE
 !plugins/*/skills/*.md
+!docs/**/*.md
 *.txt
 !executor/requirements.txt
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,10 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        # mkdocs.yml uses Python-tagged YAML constructors
+        # (e.g. !!python/name:pymdownx.superfences.fence_code_format)
+        # which the stock YAML loader can't instantiate.
+        exclude: ^mkdocs\.yml$
       - id: check-added-large-files
         args: ['--maxkb=1000']
       - id: check-merge-conflict

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,17 @@ Before opening a PR, consider discussing your approach on [Discord](https://disc
 - All CI checks must pass (lint, tests, type-check)
 - Describe the **why** in the PR description, not just the what
 
+## Documentation
+
+The public docs site (**[docs.gridbear.io](https://docs.gridbear.io)**) is built with MkDocs Material from the `docs/` directory. To preview locally:
+
+```bash
+pip install -e ".[dev]"
+mkdocs serve
+```
+
+Open `http://localhost:8000`. Pages edit live on save. The GitHub Actions workflow `.github/workflows/docs.yml` deploys every push to `main` that touches `docs/**`, `mkdocs.yml`, or `CHANGELOG.md`.
+
 ## Reporting Issues & Proposing Changes
 
 Pick the right channel:
@@ -151,8 +162,8 @@ Pick the right channel:
   - *RFC / Design* — propose a non-trivial change (new plugin, architecture shift, cross-cutting refactor). Post the design first, iterate, then open a PR that links back to the discussion.
   - *Ideas* — informal "what if we…" suggestions not yet ready for a full RFC.
   - *Q&A* — usage questions, setup help.
-- **[SECURITY.md](SECURITY.md)** — security vulnerabilities (do **not** open a public Issue or Discussion for these).
+- **[SECURITY.md](https://github.com/gridbeario/gridbear/blob/main/SECURITY.md)** — security vulnerabilities (do **not** open a public Issue or Discussion for these).
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the [LGPL-3.0 License](LICENSE).
+By contributing, you agree that your contributions will be licensed under the [LGPL-3.0 License](https://github.com/gridbeario/gridbear/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ scripts/            Database init and maintenance scripts
 tests/              Unit and integration tests
 ```
 
+## Documentation
+
+Full documentation — Getting Started, Architecture, Plugin Development, API Reference, Changelog — lives at **[docs.gridbear.io](https://docs.gridbear.io)**. Preview locally with `mkdocs serve` after `pip install -e ".[dev]"` — the source sits under `docs/`.
+
 ## Community
 
 - [Discord](https://discord.gg/WhTK4PPmaE) — chat and realtime Q&A

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.gridbear.io

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,45 @@
+# API Reference
+
+GridBear exposes a REST API backed by an auto-generated OpenAPI spec. Rather than hand-rolling docs here, this page points at the live Swagger UI and covers the cross-cutting topics (authentication, generic CRUD pattern, rate limits) that aren't obvious from the spec.
+
+## Discover the endpoints
+
+- **Swagger UI** — `https://<your-host>/api/docs`
+- **OpenAPI JSON** — `https://<your-host>/api/openapi.json`
+
+Both are served from the running GridBear instance. The admin UI itself consumes the same endpoints — there is no private API.
+
+## Authentication
+
+Two mechanisms:
+
+- **Session cookie** (`gridbear_session_token`) — used by the admin UI and the user portal after login. Sliding expiration; cookie lifetime defaults to 30 days, the server-side inactivity window to 72 hours (tunable via `GRIDBEAR_SESSION_INACTIVITY_HOURS` / `GRIDBEAR_SESSION_MAX_DAYS`).
+- **Internal API secret** (`INTERNAL_API_SECRET` env var) — required on `/api/internal/*` endpoints used by the bot to talk to the admin side of the same process.
+
+For programmatic access from external scripts, obtain an admin session via `/auth/login` (form POST) and reuse the cookie.
+
+## Generic CRUD pattern
+
+Every ORM model is exposed at `/api/v1/{model}` with a consistent CRUD surface:
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/v1/{model}` | List (supports filtering, pagination) |
+| GET | `/api/v1/{model}/{id}` | Read one |
+| POST | `/api/v1/{model}` | Create |
+| PUT | `/api/v1/{model}/{id}` | Replace |
+| PATCH | `/api/v1/{model}/{id}` | Partial update |
+| DELETE | `/api/v1/{model}/{id}` | Delete |
+
+Model-level ACLs gate each verb. Check `/api/v1/{model}` in the Swagger UI for the exact schema of your target model.
+
+## Rate limits
+
+- `/api/v1/*` — per-user throttle (default: reasonable for UI use, not for scraping). Over-limit responses return HTTP 429 with a `Retry-After` header.
+- `/mcp/*` (MCP gateway) — per-user-per-server token bucket. Circuit breakers kick in after repeated upstream errors.
+
+Exact limits are declared in code at `core/rest_api/` / `core/mcp_gateway/` and may change between minor releases. For long-running batch operations, prefer the background task tools exposed via MCP (`async_run_tool`, `async_task_status`).
+
+## Webhooks
+
+Plugins that receive external webhooks (e.g. WhatsApp Meta Cloud API) can opt in by setting `"public_api": true` in their manifest — their `api/routes.py` router is then mounted on the public FastAPI app. See [Plugin Development](plugin-development.md) for the contract.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,70 @@
+# Architecture
+
+GridBear is a plugin-based framework. A single container (`gridbear`) hosts the bot runtime, the admin UI, the MCP gateway, and the REST API; external channels talk to the agents through plugin adapters, and external tools reach the agents through the MCP gateway.
+
+## Containers
+
+| Container | Purpose | Port |
+|---|---|---|
+| `gridbear` | Bot runtime, admin UI, MCP gateway, REST API | 8000 internal / 8080 UI (`8088` on the host by default) |
+| `gridbear-postgres` | PostgreSQL 17 with the `pgvector` extension | 5432 |
+| `gridbear-executor` | Sandboxed code execution container (no internet) | 8090 internal |
+| `gridbear-evolution` | Optional WhatsApp gateway (Evolution API) | 8082 → 8080 |
+
+The sandboxed executor and WhatsApp gateway are opt-in, enabled by copying `docker-compose.override.yml.example` and uncommenting the relevant blocks.
+
+## Plugin system
+
+Plugins live under `plugins/` in the main repo, or under any extra directory listed in the `GRIDBEAR_PLUGIN_PATHS` env var (comma-separated). Each plugin ships a `manifest.json` with:
+
+- **`type`** — one of `channel`, `service`, `runner`, `mcp`, `theme`
+- **`entry_point`** / **`class_name`** — Python module + class implementing the corresponding interface from `core/interfaces/`
+- **`dependencies`** — either a flat list (all required) or `{required: […], optional: […]}`
+- **`provides`** — optional capability name that lets one plugin extend or replace another
+
+The plugin manager at `core/plugin_manager.py` discovers manifests at boot, performs a topological sort over the dependency graph, and instantiates plugins in order. Channels are per-agent (one instance per agent × channel pair); services are shared across all agents.
+
+Plugin configuration, state, and the enabled/disabled flag live in the `app.plugin_registry` table — hot-reload via the admin UI updates that table and signals the runtime without a restart (with a few exceptions documented in the admin banner).
+
+## Message flow
+
+```mermaid
+flowchart LR
+    A["Channel adapter<br/>(telegram / discord / whatsapp / webchat)"] --> B["_message_handler"]
+    B --> C["MessageProcessor.process_message"]
+    C --> D[Session service]
+    D --> E[ContextBuilder]
+    E --> F["Runner.run<br/>(claude / openai / …)"]
+    F --> G[Memory service]
+    G --> H[Response to channel]
+```
+
+At each arrow a configurable hook fires (`on_message_received`, `before_context_build`, `after_context_build`, `after_runner_call`, `before_send_response`) — plugins subscribe to the hooks they care about without editing core code.
+
+## Database
+
+PostgreSQL only (no SQLite fallback). GridBear ships a lightweight Odoo-inspired ORM at `core/orm/`: `Model.create()`, `search()`, `write()`, `delete()`. Placeholders are psycopg-style `%s`. Major schemas:
+
+- **`app`** — users, agents, plugin registry, model-layer tables
+- **`chat`** — webchat conversations, messages, participants, documents, plans
+- **`vault`** — AES-256-GCM encrypted secrets
+- **`oauth2`** — access tokens for the gateway
+- **`admin`** — auth sessions, recovery codes, WebAuthn credentials
+
+Migrations are idempotent and run on boot — no manual Alembic/step.
+
+## MCP gateway
+
+`core/mcp_gateway/` is an SSE-based MCP server mounted inside the same process as the admin UI. It aggregates tools from every enabled MCP plugin, filters by the agent's `mcp_permissions` and the invoking user's `user_mcp_permissions`, and applies a per-server circuit breaker and rate limit.
+
+Users connect personal OAuth2 providers (Gmail, Google Workspace, Odoo, …) through `/me/connections`. The gateway looks credentials up per request: the agent can impersonate a specific identity through the `service_account` field on its `context_options`, otherwise it uses the invoking user's identity.
+
+## REST API
+
+`core/rest_api/` exposes generic CRUD on every ORM model at `/api/v1/{model}`, gated by an ACL system. OpenAPI schema at `/api/openapi.json`, Swagger UI at `/api/docs`. The API is the same used internally by the admin UI — no private endpoints.
+
+## Admin UI
+
+FastAPI + Jinja2 + Tailwind (Nordic palette). Every plugin can ship its own admin routes under `plugins/<name>/admin/routes.py` plus templates under `plugins/<name>/admin/templates/`. A shared `PluginAdminRegistry` discovers them and registers against the UI FastAPI app at boot; a Jinja `ChoiceLoader` adds each plugin's `admin/templates/` to the search path so templates are referenced by filename alone.
+
+See [Plugin Development](plugin-development.md) for the conventions to follow when building a plugin's admin surface.

--- a/docs/assets/theme.css
+++ b/docs/assets/theme.css
@@ -1,0 +1,31 @@
+/* GridBear brand palette — teal primary, dark navy accent.
+   Overrides the Material "custom" palette slot declared in mkdocs.yml. */
+
+:root {
+  --md-primary-fg-color:         #3ECFB4;
+  --md-primary-fg-color--light:  #5ED8C1;
+  --md-primary-fg-color--dark:   #2FB39B;
+  --md-primary-bg-color:         #0D1B2A;
+  --md-primary-bg-color--light:  rgba(13, 27, 42, 0.7);
+
+  --md-accent-fg-color:          #0D1B2A;
+  --md-accent-fg-color--transparent: rgba(13, 27, 42, 0.1);
+  --md-accent-bg-color:          #ffffff;
+  --md-accent-bg-color--light:   #ffffff;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color:         #3ECFB4;
+  --md-primary-fg-color--light:  #5ED8C1;
+  --md-primary-fg-color--dark:   #2FB39B;
+  --md-primary-bg-color:         #ffffff;
+  --md-primary-bg-color--light:  rgba(255, 255, 255, 0.7);
+
+  --md-accent-fg-color:          #5ED8C1;
+  --md-accent-fg-color--transparent: rgba(94, 216, 193, 0.15);
+  --md-accent-bg-color:          #0D1B2A;
+  --md-accent-bg-color--light:   #0D1B2A;
+
+  --md-default-bg-color:         #0D1B2A;
+  --md-default-bg-color--light:  rgba(13, 27, 42, 0.7);
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,5 @@
+---
+title: Changelog
+---
+
+--8<-- "CHANGELOG.md"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,5 @@
+---
+title: Contributing
+---
+
+--8<-- "CONTRIBUTING.md"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,66 @@
+# Getting Started
+
+This page walks through the first boot of a local GridBear stack. For production / hardened deployments see the [Architecture](architecture.md) page and the repo's `SECURITY.md`.
+
+## Prerequisites
+
+- Docker Engine + Docker Compose v2
+- Git
+- At least one LLM runner credential (Anthropic API key, OpenAI key, or a local Ollama)
+- At least one channel to bind (Telegram bot token is the quickest to set up)
+
+## Install
+
+```bash
+git clone https://github.com/gridbeario/gridbear.git
+cd gridbear
+
+# Configure
+cp .env.example .env
+cp docker-compose.yml.example docker-compose.yml
+
+# Generate required secrets
+echo "POSTGRES_PASSWORD=$(openssl rand -base64 24)" >> .env
+echo "INTERNAL_API_SECRET=$(openssl rand -hex 32)" >> .env
+echo "EXECUTOR_TOKEN=$(openssl rand -hex 32)" >> .env
+
+# Edit .env — at minimum set GRIDBEAR_BASE_URL (public URL) and
+# at least one channel token (TELEGRAM_BOT_TOKEN, …)
+nano .env
+
+# Boot
+docker compose up -d
+```
+
+Once the containers are up, generate the master key that encrypts the secrets vault:
+
+```bash
+docker exec gridbear python3 -c \
+  "from ui.secrets_manager import SecretsManager; print(SecretsManager.generate_key_file())"
+```
+
+!!! danger "Back up `./config/secrets.key`"
+    The master key lives at `./config/secrets.key`. Without it every row in the vault (OAuth tokens, plugin-scoped DB passwords, TOTP seeds, …) becomes permanently unreadable. Back it up **out-of-band** (password manager, encrypted storage), not next to the repo.
+
+## First login
+
+- Visit `http://localhost:8088/auth/setup` (or whatever `GRIDBEAR_BASE_URL` resolves to)
+- Create the first admin account — it automatically becomes `is_superadmin=true`
+- From `/plugins/` enable the runner and channel plugins you want active
+- From `/agents/` create the first agent, binding it to the runner and at least one channel
+
+## Optional extras
+
+Copy the override template to enable extra services (sandboxed code executor, WhatsApp via Evolution API, local Ollama, n8n):
+
+```bash
+cp docker-compose.override.yml.example docker-compose.override.yml
+```
+
+Edit the override to toggle only the services you need.
+
+## Next steps
+
+- Add your LLM credentials to the agent under `/agents/<id>`
+- Connect personal accounts (Gmail, Google Workspace, …) from `/me/connections`
+- Read the [Architecture](architecture.md) page to understand the message flow and plugin lifecycle

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,30 @@
+# GridBear
+
+**GridBear is a secure, open-source platform to run AI agents in production.** Wire multiple LLM runners (Claude, OpenAI, Gemini, Ollama) to multiple channels (Telegram, Discord, WhatsApp, web chat) with a shared plugin ecosystem for tools, memory, workflows, and per-user identity.
+
+## What's in the box
+
+- **Multi-runner** — switch runner per-agent; hot-reload config from the admin UI
+- **Multi-channel** — receive messages from chat apps, reply through the same agent pool
+- **Plugin system** — 40+ plugins with `manifest.json` discovery, dependency resolution, hot-reload
+- **MCP gateway** — SSE-based gateway with per-user OAuth2 connections, circuit breakers, rate limiting
+- **Memory** — episodic and declarative memory on PostgreSQL + pgvector
+- **Workflow engine** — visual DAG editor with agent, tool, condition, transform, and approval steps
+- **Admin UI** — web-based management; every plugin can ship its own admin page
+- **User portal** — per-user dashboard, service connections (Gmail, Google Workspace, …), MCP tool toggles
+
+## Get started
+
+- **[Getting Started](getting-started.md)** — clone, configure, boot the stack
+- **[Architecture](architecture.md)** — containers, plugin system, message flow, data model
+- **[Plugin Development](plugin-development.md)** — build your own channel / service / runner / MCP plugin
+- **[API Reference](api-reference.md)** — REST endpoints, authentication, rate limits
+
+## Community
+
+- [Discord](https://discord.gg/WhTK4PPmaE) — live chat and Q&A
+- [GitHub Discussions](https://github.com/gridbeario/gridbear/discussions) — RFCs, Ideas, Q&A
+- [GitHub Issues](https://github.com/gridbeario/gridbear/issues) — bug reports, concrete feature requests
+
+!!! warning "Early-stage project"
+    GridBear is currently pre-1.0. We don't recommend production deployments yet — see the warning on the [GitHub README](https://github.com/gridbeario/gridbear) for details. Feedback and contributions are very welcome.

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -1,0 +1,72 @@
+# Plugin Development
+
+GridBear has five plugin types, all discovered from `manifest.json` at boot:
+
+| Type | Implements | Example |
+|---|---|---|
+| **channel** | `core/interfaces/channel.py::BaseChannel` | Telegram, Discord, WhatsApp, webchat |
+| **service** | `core/interfaces/service.py::BaseService` | memory, sessions, attachments, voice |
+| **runner** | `core/interfaces/runner.py::BaseRunner` | Claude (CLI and API), OpenAI, Gemini, Ollama |
+| **mcp** | `core/interfaces/mcp_provider.py::BaseMCPProvider` | Gmail, Google Workspace, GitHub, Playwright |
+| **theme** | `core/interfaces/theme.py::BaseTheme` | Nordic (default), Tailadmin, Enterprise |
+
+## Minimal manifest
+
+```json
+{
+  "name": "my-plugin",
+  "version": "0.1.0",
+  "type": "service",
+  "description": "What this plugin does in one sentence.",
+  "entry_point": "service.py",
+  "class_name": "MyPluginService",
+  "dependencies": {
+    "required": ["memory"],
+    "optional": ["gmail"]
+  },
+  "provides": "my-capability"
+}
+```
+
+- **`type`** — decides which interface the `class_name` must implement
+- **`dependencies`** — can also be a flat list `[…]`, treated as all-required
+- **`provides`** — capability name; another plugin declaring the same `provides` replaces this one. Useful for swapping in alternative implementations (e.g. `memory` vs a vector-store-backed alternative)
+
+## Layout conventions
+
+A plugin is fully self-contained. All its files live under its own directory:
+
+```
+plugins/my-plugin/
+├── manifest.json
+├── service.py                 # the class referenced by entry_point + class_name
+├── admin/
+│   ├── routes.py              # FastAPI router exposed to the admin UI
+│   ├── menu.json              # sidebar entry metadata
+│   └── templates/             # Jinja templates, referenced by filename alone
+├── api/
+│   └── routes.py              # optional internal REST endpoints
+├── portal/
+│   └── routes.py              # optional user-portal routes under /me/...
+├── skills/                    # optional markdown skills surfaced to agents
+└── service_connections/       # optional OAuth2 provider configs
+```
+
+## Dependency direction
+
+```
+plugins/ ──depends on──► core/
+plugins/ ──depends on──► ui/   (admin routes only)
+
+core/ ──NEVER imports──► plugins/
+ui/   ──NEVER imports──► plugins/  (use interfaces + registry)
+```
+
+If you need plugin functionality in `core/` or `ui/`, declare an **interface** under `core/interfaces/` and have your plugin implement it. Consume it from core through `core.registry.get_service_by_interface(BaseMyService)` — never hardcode plugin names.
+
+## Next steps
+
+- Copy one of the existing plugins under `plugins/` as a starting point — `plugins/memo` is a minimal example
+- Read through `core/interfaces/<type>.py` for your plugin type to see the full contract
+- Add your plugin to `config/plugins.json` (or enable it from `/plugins/` in the admin UI) and restart the container
+- See the [Architecture](architecture.md) page for how plugins fit into the message flow

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,82 @@
+site_name: GridBear
+site_description: Secure, open-source platform to run AI agents in production.
+site_url: https://docs.gridbear.io/
+repo_url: https://github.com/gridbeario/gridbear
+repo_name: gridbeario/gridbear
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  language: en
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - content.action.edit
+    - search.suggest
+    - search.highlight
+    - toc.follow
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  icon:
+    repo: fontawesome/brands/github
+
+extra_css:
+  - assets/theme.css
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - footnotes
+  - pymdownx.details
+  - pymdownx.snippets:
+      base_path:
+        - .
+      check_paths: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Architecture: architecture.md
+  - Plugin Development: plugin-development.md
+  - API Reference: api-reference.md
+  - Changelog: changelog.md
+  - Contributing: contributing.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/gridbeario/gridbear
+    - icon: fontawesome/brands/discord
+      link: https://discord.gg/WhTK4PPmaE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,10 @@ dev = [
     "mypy>=1.8.0",
     "pre-commit>=4.5.1",
     "pytest-benchmark>=4.0",
+    # Docs site (MkDocs Material) — used to build docs.gridbear.io.
+    "mkdocs-material>=9.5",
+    "mkdocs-material[imaging]",
+    "pymdown-extensions>=10.7",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Bootstrap the public documentation site at **https://docs.gridbear.io** (pending DNS setup). Built with MkDocs Material, deployed via GitHub Pages by a new GitHub Actions workflow.

## What's in

Split in 3 commits for a clean history:

1. **Scaffold** (`97591bb`) — `mkdocs.yml` at repo root, GridBear palette (teal `#3ECFB4` + navy `#0D1B2A`) via `docs/assets/theme.css`, markdown extensions (admonitions, tabbed, Mermaid, snippets, highlight), 7-entry nav. `pyproject.toml` picks up `mkdocs-material` / `pymdown-extensions` as dev deps. `.gitignore` stops ignoring `docs/` (internal specs already moved to Discussions), adds `site/`. `.pre-commit-config.yaml` exempts `mkdocs.yml` from `check-yaml` (Python-tagged YAML constructors).
2. **Seed pages** (`498e37b`) — 7 stub pages: Home, Getting Started, Architecture (seeded from `CLAUDE.md`, rewritten public, with a Mermaid flow diagram), Plugin Development, API Reference, Changelog (snippet include of root `CHANGELOG.md`), Contributing (snippet include of root `CONTRIBUTING.md`). `docs/CNAME` for the custom domain. README + CONTRIBUTING gain a *Documentation* section linking the site and explaining `mkdocs serve`.
3. **CI deploy** (`a8217e9`) — `.github/workflows/docs.yml`: checkout, setup Python 3.11, install MkDocs Material, run `mkdocs gh-deploy --force`. Triggers on pushes to `main` touching `docs/**`/`mkdocs.yml`/`CHANGELOG.md`/`CONTRIBUTING.md`/the workflow itself, plus manual `workflow_dispatch`. Concurrency group prevents racing force-pushes to `gh-pages`.

## Post-merge one-shot config
- **Settings → Pages** → Source: *Deploy from a branch* → Branch: `gh-pages` / `/ (root)`
- **Custom domain**: set `docs.gridbear.io` in the same panel (GitHub will verify via DNS)
- **DNS** (registrar): `CNAME docs → gridbeario.github.io`
- First run can also be triggered manually from *Actions → Docs → Run workflow*

## Local preview verified
`mkdocs build --strict` green, `mkdocs serve` renders all 7 pages, Mermaid diagram renders on Architecture, code-copy buttons present, Changelog snippet pulls in full version history, dark-mode toggle works.

## Out of scope
- Full prose for Getting Started / Architecture / Plugin Development / API Reference beyond the stubs — content-only PRs follow
- Multi-version docs (`mike`)
- i18n
- Search engine beyond Material's built-in