### PR TITLE
[FIX] security: harden master-key discovery and env-var lifetime

### DIFF
--- a/core/encryption.py
+++ b/core/encryption.py
@@ -16,12 +16,17 @@ _logger = logging.getLogger(__name__)
 
 # Key search paths — same as ui/secrets_manager.py (no import dependency on ui/)
 _BASE_DIR = Path(__file__).resolve().parent.parent
+# Candidate key file locations, in preference order. The dedicated
+# `config/secrets.key` wins; the home-dir SSH paths stay for operators
+# who were already relying on that fallback. The previous hard-coded
+# `/root/.ssh/*` entries were dropped — the container should never run
+# as root in the first place, and if it does, silently consuming a
+# root-owned SSH key as the vault master key is a surprise bomb
+# (different host → different key → vault unreadable).
 KEY_PATHS = [
     _BASE_DIR / "config" / "secrets.key",
     Path.home() / ".ssh" / "id_ed25519",
     Path.home() / ".ssh" / "id_rsa",
-    Path("/root/.ssh/id_ed25519"),
-    Path("/root/.ssh/id_rsa"),
     Path("/app/config/secrets.key"),
 ]
 MASTER_KEY_ENV = "GRIDBEAR_MASTER_KEY"
@@ -73,11 +78,36 @@ def _get_key() -> bytes:
     env_val = os.environ.get(MASTER_KEY_ENV)
     if env_val:
         _cached_key = hashlib.sha256(env_val.encode()).digest()
+        # Purge the env var once cached so child processes (plugin
+        # subprocesses, Claude CLI, Playwright, MCP stdio servers)
+        # can't `os.environ[MASTER_KEY_ENV]` to pull the plaintext
+        # master key out of /proc/<pid>/environ.
+        os.environ.pop(MASTER_KEY_ENV, None)
         return _cached_key
 
     raise RuntimeError(
         "No encryption key found. Create config/secrets.key or set GRIDBEAR_MASTER_KEY."
     )
+
+
+def ensure_master_key_loaded() -> None:
+    """Force master-key derivation and purge ``GRIDBEAR_MASTER_KEY`` from env.
+
+    Call eagerly during app startup, before any plugin subprocess is
+    spawned. Two guarantees after the call returns:
+
+    1. The cached key is derived (from file if present, else env var),
+       so later encrypt/decrypt calls are purely file-free.
+    2. ``GRIDBEAR_MASTER_KEY`` is removed from ``os.environ`` regardless
+       of which source actually fed the cache, so any subprocess
+       launched afterwards (Claude CLI, Playwright, MCP stdio servers)
+       cannot read the plaintext master key out of
+       ``/proc/<pid>/environ``.
+
+    Safe to call multiple times — ``_get_key`` is cached.
+    """
+    _get_key()
+    os.environ.pop(MASTER_KEY_ENV, None)
 
 
 def encrypt(plaintext: str) -> str:

--- a/ui/app.py
+++ b/ui/app.py
@@ -33,7 +33,21 @@ def _throttled_deliver_cancellation(self, origin):
 _anyio_asyncio.CancelScope._deliver_cancellation = _throttled_deliver_cancellation
 # ────────────────────────────────────────────────────────────────────
 from core.__version__ import __version__
+from core.encryption import ensure_master_key_loaded
 from core.mcp_gateway.server import router as mcp_gateway_router
+
+# Derive the master key once, at import time, so that
+# GRIDBEAR_MASTER_KEY is purged from os.environ before any plugin
+# subprocess (Claude CLI, Playwright, MCP stdio servers) is spawned
+# and would otherwise inherit it via /proc/<pid>/environ. A fresh
+# install (no key file, no env var) logs and continues — the first
+# call to encrypt/decrypt later will raise explicitly.
+try:
+    ensure_master_key_loaded()
+except RuntimeError:
+    logger.info(
+        "ui: master key not configured yet (fresh install) — will derive on first use"
+    )
 from core.oauth2.discovery import router as oauth2_discovery_router
 from core.oauth2.server import router as oauth2_server_router
 from core.oauth2.server import set_db as set_oauth2_db

--- a/ui/secrets_manager.py
+++ b/ui/secrets_manager.py
@@ -38,16 +38,19 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Key paths to try (in order of preference)
 # 1. GridBear-specific key in config dir (preferred - portable)
 # 2. SSH keys as fallback
+# Candidate key file locations, in preference order. Dedicated
+# config/secrets.key wins; the home-dir SSH paths remain for operators
+# who were relying on the fallback. The hard-coded /root/.ssh/* paths
+# have been removed: the container should not run as root, and if it
+# does, using a root-owned SSH key as the vault master key is a
+# host-pinned surprise (different host → different key → vault lost).
 KEY_PATHS = [
-    BASE_DIR / "config" / "secrets.key",  # GridBear-specific key (recommended)
+    BASE_DIR / "config" / "secrets.key",
     Path.home() / ".ssh" / "id_ed25519",
     Path.home() / ".ssh" / "id_rsa",
-    Path("/root/.ssh/id_ed25519"),
-    Path("/root/.ssh/id_rsa"),
-    Path("/app/config/secrets.key"),  # Container path
+    Path("/app/config/secrets.key"),
 ]
 
-# Fallback to env var if no SSH key found
 MASTER_KEY_ENV = "GRIDBEAR_MASTER_KEY"
 
 # PostgreSQL DDL — applied once via _init_pg()
@@ -208,6 +211,16 @@ class SecretsManager:
             path = BASE_DIR / "config" / "secrets.key"
 
         path.parent.mkdir(parents=True, exist_ok=True)
+        # Tighten the parent directory — the key file itself is 0600,
+        # but a 0755 containing dir still lets any local user enumerate
+        # "there is a secret here" and race a replacement if perms ever
+        # slip. 0700 matches the OpenSSH .ssh convention.
+        try:
+            path.parent.chmod(0o700)
+        except OSError:
+            # Non-fatal: shared filesystems (e.g. Windows bind mounts)
+            # reject chmod. The file permission above is still enforced.
+            pass
 
         # Generate 64 bytes of random data (512 bits)
         key_data = stdlib_secrets.token_bytes(64)
@@ -231,6 +244,14 @@ class SecretsManager:
                 # Derive a 256-bit key using SHA-256 of the key file content
                 self._key = hashlib.sha256(key_content).digest()
                 self._key_source = str(key_path)
+                # Purge the env-var fallback now that we've derived the
+                # key from a file — leaving GRIDBEAR_MASTER_KEY visible
+                # in os.environ would let any child process
+                # (plugin subprocesses, Claude CLI, Playwright, MCP
+                # stdio servers) read the plaintext master key out of
+                # /proc/<pid>/environ, which bypasses the AES layer
+                # entirely.
+                os.environ.pop(MASTER_KEY_ENV, None)
                 return self._key
             except PermissionError:
                 pass  # Fall through to env var
@@ -240,6 +261,9 @@ class SecretsManager:
         if master_key:
             self._key = hashlib.sha256(master_key.encode()).digest()
             self._key_source = f"env:{MASTER_KEY_ENV}"
+            # Same purge rationale as above — the env var is no longer
+            # needed once we've derived the key.
+            os.environ.pop(MASTER_KEY_ENV, None)
             return self._key
 
         raise RuntimeError(


### PR DESCRIPTION
Three small hardening changes to how the secrets vault discovers and caches its master key.

## Summary
1. **Drop `/root/.ssh/*` from the candidate master-key path list.** The container is not meant to run as root; if it does, silently binding the vault to a root-owned SSH key turns the vault into a host-pinned artefact. Home-dir SSH paths stay for operators who rely on the legacy fallback.
2. **Purge `GRIDBEAR_MASTER_KEY` from `os.environ` after derivation.** The env var is read once at boot (via the new `core.encryption.ensure_master_key_loaded()`), used to cache the key, then removed so subprocesses spawned later — Claude CLI, Playwright, MCP stdio servers, plugin scripts — cannot read the plaintext out of `/proc/<pid>/environ`. Purge runs regardless of whether the source was the env var or a key file.
3. **Tighten parent-dir perms of the generated key file to `0700`.** The file itself was already `0600`; the containing directory defaulted to `0755` under the default umask.

## Verified
- Container rebuilt with the branch, boots cleanly (fresh-install path tolerated — `ensure_master_key_loaded` logs and continues when neither file nor env var is present yet).
- In-container test: env var set on spawn + forced cache reset + `ensure_master_key_loaded()` → env var absent from `os.environ` afterwards.
- No behavioural change for operators who use `config/secrets.key` and never set `GRIDBEAR_MASTER_KEY`.

## Test plan
- [ ] CI green (lint, type-check, security, test, smoke-install)
- [ ] Fresh-install smoke: first boot without key file and without env var logs the expected info and doesn't crash
- [ ] Existing install boots without changes; the master key is still derived from `config/secrets.key`