### PR TITLE
[FIX] ci: invoke pre-commit directly to drop Node 20 transitive dep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,15 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - name: Cache pre-commit hooks
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-py3.12-${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --all-files --show-diff-on-failure
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`pre-commit/action@v3.0.1` internally pins `actions/cache@v4` which runs on Node.js 20 — GitHub forces Node 20 actions onto Node 24 starting June 2026 and removes Node 20 from runners in September 2026. Upstream `pre-commit/action` has been in slow-maintenance since November 2023 with no Node 24 release in sight, hence the warning visible on every CI run today.

Replaced the action with a direct three-step invocation: cache `~/.cache/pre-commit` using `actions/cache@v5.0.5` (already pinned elsewhere in this workflow), `pip install pre-commit`, then run with `--show-diff-on-failure` so the failing diff lands in the CI log instead of just the exit code.

Drops the transitive Node 20 dependency entirely without adding any new pinned action.