### PR TITLE
[FIX] i18n: add Language ORM model so i18n.languages auto-creates at boot

### DIFF
--- a/core/config_migration.py
+++ b/core/config_migration.py
@@ -26,6 +26,7 @@ _MARKER_MCP_PERMS_UNIFIED_ID = "_migration_mcp_perms_unified_id"
 _MARKER_DEFAULT_COMPANY = "_migration_default_company"
 _MARKER_UNIFY_USERS = "_migration_unify_users"
 _MARKER_USER_PLATFORMS = "_migration_user_platforms"
+_MARKER_SEED_LANGUAGES = "_migration_seed_languages"
 
 
 async def migrate_admin_config_to_db(config_path: Path) -> bool:
@@ -492,6 +493,47 @@ async def migrate_create_default_company() -> bool:
 
     await SystemConfig.set_param(_MARKER_DEFAULT_COMPANY, True)
     logger.info("Default company migration complete")
+    return True
+
+
+async def migrate_seed_languages() -> bool:
+    """Seed i18n.languages with English (default) and Italian on first boot.
+
+    The Language ORM model auto-creates the table; this seed populates the
+    minimum set so /admin/languages is functional out of the box. Idempotent
+    via SystemConfig marker.
+
+    Returns True if seed was performed, False if skipped.
+    """
+    from core.registry import get_database
+    from core.system_config import SystemConfig
+
+    marker = await SystemConfig.get_param(_MARKER_SEED_LANGUAGES)
+    if marker:
+        return False
+
+    db = get_database()
+    async with db.acquire() as conn:
+        # Defensive: ORM should have created the table, skip cleanly if not
+        tbl_check = await conn.execute(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_schema = 'i18n' AND table_name = 'languages'"
+        )
+        if not await tbl_check.fetchone():
+            logger.warning("i18n.languages table not found — skipping language seed")
+            return False
+
+        await conn.execute(
+            """
+            INSERT INTO i18n.languages (code, name, active, is_default)
+            VALUES ('en', 'English', TRUE, TRUE),
+                   ('it', 'Italiano', TRUE, FALSE)
+            ON CONFLICT (code) DO NOTHING
+            """
+        )
+
+    await SystemConfig.set_param(_MARKER_SEED_LANGUAGES, True)
+    logger.info("Language seed complete (en, it)")
     return True
 
 

--- a/core/models/language.py
+++ b/core/models/language.py
@@ -1,0 +1,17 @@
+"""ORM model for i18n languages (replaces dormant SQL migration 009)."""
+
+from core.orm import Model, fields
+
+
+class Language(Model):
+    _schema = "i18n"
+    _name = "languages"
+    _primary_key = "code"
+
+    code = fields.Text(required=True)
+    name = fields.Text(required=True)
+    active = fields.Boolean(default=False)
+    direction = fields.Text(default="ltr")
+    date_format = fields.Text(default="%Y-%m-%d")
+    is_default = fields.Boolean(default=False)
+    created_at = fields.DateTime(auto_now_add=True)

--- a/core/models/models.py
+++ b/core/models/models.py
@@ -16,5 +16,6 @@ from core.config_models import (  # noqa: F401
 )
 from core.models.company import Company  # noqa: F401
 from core.models.company_user import CompanyUser  # noqa: F401
+from core.models.language import Language  # noqa: F401
 from core.models.user import User  # noqa: F401
 from core.system_config import SystemConfig  # noqa: F401

--- a/main.py
+++ b/main.py
@@ -1198,6 +1198,7 @@ async def main():
                 migrate_create_default_company,
                 migrate_mcp_perms_to_unified_id,
                 migrate_rest_api_config_to_db,
+                migrate_seed_languages,
                 migrate_unify_users,
                 migrate_user_platforms,
             )
@@ -1209,6 +1210,7 @@ async def main():
             )
             await migrate_mcp_perms_to_unified_id()
             await migrate_create_default_company()
+            await migrate_seed_languages()
             await migrate_unify_users()
             await migrate_user_platforms()
             await migrate_agent_configs_to_db()


### PR DESCRIPTION
On a fresh install, opening `/admin/languages` and trying to add a language fails with:

```
WARNING - Failed to add language it: relation "i18n.languages" does not exist
```

Root cause: the `i18n.languages` schema is only declared in `scripts/migrations/009_i18n_languages.sql`, but the project has no runner that applies those numbered SQL files. `init_pg.sh` creates schemas + the `_migrations` tracking table and then stops; the rest of the schema is managed by the ORM auto-migrate from model classes. `i18n.languages` was the one orphan — SQL file but no model — so the table never gets created.

Fix: convert it to a regular core ORM model under `core/models/language.py`, column-for-column with the SQL. The model is discovered by `Registry._scan_directory` via `core/models/models.py`, and `migrate_all()` creates the table at boot like every other ORM-managed table. Plus a one-shot idempotent seed in `config_migration.py` (marker `_migration_seed_languages`) that inserts `en` + `it` so the page is functional out of the box, matching the previous SQL seed.

The SQL migration file is left as historical reference but is no longer load-bearing.