### PR TITLE
[FIX] agents: expose WebChat allowed_users in agent edit form

### DIFF
--- a/ui/routes/agents.py
+++ b/ui/routes/agents.py
@@ -60,6 +60,26 @@ def get_known_users() -> dict:
                 if username not in result[platform]:
                     result[platform].append(username)
 
+    # Built-in webchat: every app user is a candidate (username == identity).
+    # Without this the webchat checkbox list would always be empty since
+    # users don't typically have a "webchat" entry in user_identities.
+    if "webchat" in result:
+        try:
+            from core.registry import get_database
+
+            db = get_database()
+            if db:
+                with db.acquire_sync() as conn:
+                    cur = conn.execute(
+                        "SELECT username FROM app.users WHERE username IS NOT NULL"
+                    )
+                    for row in cur.fetchall():
+                        uname = row["username"]
+                        if uname and uname not in result["webchat"]:
+                            result["webchat"].append(uname)
+        except Exception as exc:
+            logger.debug("Could not enumerate webchat users: %s", exc)
+
     # Sort alphabetically
     for platform in result:
         result[platform].sort(key=str.lower)
@@ -565,12 +585,17 @@ async def save_agent_config(
         token_key = f"{ch_name}_token_secret"
         users_key = f"{ch_name}_allowed_users"
         token_value = form_data.get(token_key, "")
-        if token_value:
+        allowed = form_data.getlist(users_key)
+        # Built-in channels (webchat) have no bot token; persist their
+        # config whenever there are allowed_users in the form. Plugin
+        # channels still gate on token presence.
+        is_builtin = ch_name == "webchat"
+        if token_value or (is_builtin and allowed):
             # Preserve existing channel config (e.g. phone_number_id)
             # and only update form-managed fields
             ch_config = channels.get(ch_name, {}).copy()
-            ch_config["token_secret"] = token_value
-            allowed = form_data.getlist(users_key)
+            if token_value:
+                ch_config["token_secret"] = token_value
             if allowed:
                 ch_config["allowed_users"] = [u.strip() for u in allowed if u.strip()]
             channels[ch_name] = ch_config

--- a/ui/templates/agents/edit.html
+++ b/ui/templates/agents/edit.html
@@ -173,16 +173,18 @@
             </h3>
         </div>
         <div class="p-5">
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+            {% set ch_config = agent.channels[ch.name] if agent and agent.channels and agent.channels.get(ch.name) else {} %}
+            <div class="grid grid-cols-1 {% if ch.name != 'webchat' %}md:grid-cols-2{% endif %} gap-5">
+                {% if ch.name != 'webchat' %}
                 <div class="space-y-2">
                     <label class="block text-sm font-medium text-void-700 dark:text-void-200">Token Secret Name</label>
-                    {% set ch_config = agent.channels[ch.name] if agent and agent.channels and agent.channels.get(ch.name) else {} %}
                     <input type="text" name="{{ ch.name }}_token_secret"
                            value="{{ ch_config.token_secret if ch_config else '' }}"
                            placeholder="e.g., {{ ch.name|upper }}_TOKEN"
                            class="w-full bg-void-50 dark:bg-void-800/50 border border-void-200 dark:border-void-700 rounded-xl py-2.5 px-4 text-void-900 dark:text-white placeholder-void-400 dark:placeholder-void-500 focus:outline-none focus:border-nordic-500/50 transition-all">
                     <p class="text-xs text-void-500 dark:text-void-400">Name of the secret containing the bot token (leave empty to disable)</p>
                 </div>
+                {% endif %}
 
                 <div class="space-y-2">
                     <label class="block text-sm font-medium text-void-700 dark:text-void-200">Allowed Users</label>
@@ -202,7 +204,13 @@
                     {% else %}
                     <p class="text-sm text-void-500 dark:text-void-400 p-3 bg-void-50 dark:bg-void-800/30 rounded-xl border border-void-200 dark:border-void-700">No known users. Add identities in Settings &rarr; Users.</p>
                     {% endif %}
-                    <p class="text-xs text-void-500 dark:text-void-400">Select users who can interact with this agent (none = all allowed)</p>
+                    <p class="text-xs text-void-500 dark:text-void-400">
+                        {% if ch.name == 'webchat' %}
+                        Select users who can see and chat with this agent in the WebChat. Superadmins always see all agents; regular users only see agents where they are listed.
+                        {% else %}
+                        Select users who can interact with this agent on this channel (none = all allowed).
+                        {% endif %}
+                    </p>
                 </div>
             </div>
         </div>

--- a/ui/utils/channels.py
+++ b/ui/utils/channels.py
@@ -20,6 +20,21 @@ CHANNEL_DEFAULTS = {
     "badge_abbr": None,  # Will use platform[:2].upper()
 }
 
+# Built-in (non-plugin) channels always present in the agent edit form.
+# WebChat lives in core (ui/routes/me.py + ws_chat.py), not as a plugin,
+# so it doesn't show up via plugin discovery — we inject it manually here
+# so admins can manage allowed_users for the webchat surface.
+_BUILTIN_CHANNELS = [
+    {
+        "name": "webchat",
+        "display_name": "WebChat",
+        "icon": "fas fa-globe",
+        "color": "#6366F1",
+        "badge_abbr": "WC",
+        "username_prefix": "",
+    },
+]
+
 
 def get_available_channels() -> list[dict]:
     """Discover all enabled channel plugins with UI metadata.
@@ -27,6 +42,7 @@ def get_available_channels() -> list[dict]:
     Returns list of dicts with keys:
         name, display_name, icon, color, badge_abbr, enabled
     Uses PluginManager (runtime) with fallback to plugin registry DB + manifest (static).
+    Built-in channels (webchat) are always included regardless of plugin state.
     """
     channels = []
 
@@ -42,7 +58,7 @@ def get_available_channels() -> list[dict]:
                 ui = manifest.get("ui", {})
                 channels.append(_build_channel_dict(name, ui, enabled=True))
             if channels:
-                return sorted(channels, key=lambda c: c["name"])
+                return _merge_builtins(channels)
     except Exception:
         pass
 
@@ -65,7 +81,18 @@ def get_available_channels() -> list[dict]:
         except Exception:
             logger.warning("Failed to read manifest for %s", plugin_name)
 
-    return sorted(channels, key=lambda c: c["name"])
+    return _merge_builtins(channels)
+
+
+def _merge_builtins(plugin_channels: list[dict]) -> list[dict]:
+    """Prepend built-in channels (webchat) to plugin channels, deduplicated."""
+    existing_names = {c["name"] for c in plugin_channels}
+    builtins = [
+        _build_channel_dict(b["name"], b, enabled=True)
+        for b in _BUILTIN_CHANNELS
+        if b["name"] not in existing_names
+    ]
+    return builtins + sorted(plugin_channels, key=lambda c: c["name"])
 
 
 def get_channel_ui(platform: str) -> dict:


### PR DESCRIPTION
Regular (non-superadmin) users see an agent in `/me/chat` only if their username appears in at least one of the agent's per-channel `allowed_users` lists (`me.py:_get_user_agents`). But "WebChat" is a built-in surface, not a plugin — `get_available_channels()` only returns channel plugins, so the agent edit form never renders an `allowed_users` widget for it. The only way to grant a regular user WebChat access to an agent was to enable a real channel plugin (telegram/discord/whatsapp) just to borrow its `allowed_users` list, or to promote the user to superadmin.

Changes:

- `ui/utils/channels.py`: prepend a built-in `webchat` entry to `get_available_channels()`, so the agent form always renders a WebChat section.
- `ui/routes/agents.py::get_known_users`: when `webchat` is among the channels, enumerate every `app.users.username` so the checkbox list is populated (webchat identity == username, no separate `user_identities` row needed).
- `ui/routes/agents.py` save handler: webchat has no bot token, so the existing `if token_value` guard would silently drop its config. Built-in channels now persist their block whenever `allowed_users` is non-empty.
- `ui/templates/agents/edit.html`: hide the "Token Secret Name" field for webchat (irrelevant), make the column layout adapt, and rewrite the helper text since for webchat "none = admin-only", not "none = all allowed".

The runtime filter in `me.py:_get_allowed_users()` already iterates all channels, so saving `channels.webchat.allowed_users` from the form is enough — no logic change needed there.

Verified locally: container rebuilds clean, ORM discovers 1 extra model is unrelated to this change (Language from #145), UI on :8088 returns 200, /agents/<id>/edit renders the new WebChat section.