### PR TITLE
[FIX] agents: skip webchat in channel instantiation to silence misleading ERROR

### DIFF
--- a/core/agent_manager.py
+++ b/core/agent_manager.py
@@ -206,6 +206,13 @@ class AgentManager:
         for ch_config in agent.config.channels:
             platform = ch_config.platform
 
+            # Built-in surfaces (webchat) have no channel plugin class to
+            # instantiate and no bot token. Skip silently — the old path
+            # fell through the token check and logged a misleading
+            # "token not found" ERROR on every boot.
+            if platform == "webchat":
+                continue
+
             # Get token from environment
             token = secrets_manager.get(ch_config.token_env, fallback_env=True)
             if not token:


### PR DESCRIPTION
Follow-up to #146 flagged in #146 (comment).

#146 added webchat to the agent edit form and save handler, so agents now persist `channels = {"webchat": {"allowed_users": [...]}}`. But `core/agent_manager._create_agent_channels` still iterates every entry, calls `secrets_manager.get(ch_config.token_env, ...)` with an empty `token_env` (webchat has no bot token), gets `None`, and logs:

```
ERROR - Agent <name>: token not found for webchat (env: )
```

on every agent boot. The subsequent `continue` is semantically right — webchat has no channel plugin class to instantiate — but the ERROR log above it makes it look like a broken agent config.

Add an early `if platform == "webchat": continue` before the token check. One line, zero behaviour change beyond silencing the misleading log.