### PR TITLE
[FIX] mcp gateway: route tool-provider discovery logs through gridbear logger

### DIFF
--- a/core/mcp_gateway/tool_providers.py
+++ b/core/mcp_gateway/tool_providers.py
@@ -1,9 +1,8 @@
 """Discover and register LocalToolProvider instances from plugins."""
 
 import importlib.util
-import logging
 
-logger = logging.getLogger(__name__)
+from config.logging_config import logger
 
 
 def discover_local_tool_providers(mcp_server) -> None:


### PR DESCRIPTION
Closes #150.

`tool_providers.py` was the only file under `core/mcp_gateway/` instantiating its own module logger via `logging.getLogger(__name__)` instead of importing from `config.logging_config`. The `gridbear` logger is the only one with a configured `StreamHandler`, so the module-named logger inherited the handler-less root chain and every INFO/WARNING/ERROR from `discover_local_tool_providers` silently vanished — including the "Registered virtual tool provider" lines and the "registered N — [...]" summary at the end.

Two-line swap, identical pattern to `client_manager.py`, `provider_loader.py`, and `server.py`. No functional change.