### PR TITLE
[FIX] mcp: surface virtual-tool plugins in admin form and provision tokens by union

### DIFF
--- a/core/mcp_token_manager.py
+++ b/core/mcp_token_manager.py
@@ -48,25 +48,42 @@ class MCPTokenManager:
         """Provision OAuth2 client and token for a single agent."""
         agent_name = agent.name
         mcp_permissions = agent.config.mcp_permissions or []
+        plugins_enabled = agent.config.plugins_enabled or []
 
-        if not mcp_permissions:
+        # Effective permission set is the union of explicit mcp_permissions
+        # and plugins.enabled — this matches what the gateway already does
+        # for tools/list (see core/mcp_gateway/server.py). Without the
+        # union here, an agent that enables a virtual-tool plugin (e.g.
+        # artifacts, dwh_doreca) without restating it under
+        # mcp_permissions would never get a token, the subprocess would
+        # launch without --mcp-config, and Claude would see no tools at
+        # all even though the gateway is exposing them. See
+        # gridbeario/gridbear#152.
+        effective = sorted(set(mcp_permissions) | set(plugins_enabled))
+
+        if not effective:
             logger.debug(
-                f"Agent {agent_name} has no MCP permissions, skipping token provisioning"
+                f"Agent {agent_name} has no effective MCP permissions "
+                f"(mcp_permissions and plugins.enabled both empty), "
+                f"skipping token provisioning"
             )
             return
 
-        self._agent_mcp_permissions[agent_name] = mcp_permissions
+        self._agent_mcp_permissions[agent_name] = effective
 
         # Find existing client for this agent
         client = self.oauth2_db.get_by_agent_name(agent_name)
 
         if client:
-            # Update mcp_permissions if changed
+            # Update mcp_permissions if the effective set changed. This
+            # also repairs agents stuck in the implicit-enable state from
+            # before the union semantics — they get an update_client call
+            # without needing an unrelated config touch.
             current_perms = client.get_mcp_permissions_list() or []
-            if sorted(current_perms) != sorted(mcp_permissions):
-                self.oauth2_db.update_client(client.id, mcp_permissions=mcp_permissions)
+            if sorted(current_perms) != effective:
+                self.oauth2_db.update_client(client.id, mcp_permissions=effective)
                 logger.info(
-                    f"Updated MCP permissions for agent {agent_name}: {mcp_permissions}"
+                    f"Updated MCP permissions for agent {agent_name}: {effective}"
                 )
 
             # Regenerate secret so we can create a fresh token
@@ -82,7 +99,7 @@ class MCPTokenManager:
                 name=f"GridBear Agent - {agent_name}",
                 client_type="confidential",
                 agent_name=agent_name,
-                mcp_permissions=mcp_permissions,
+                mcp_permissions=effective,
                 access_token_expiry=86400,  # 24h
                 require_pkce=False,
                 allowed_scopes="mcp",

--- a/core/plugin_manager.py
+++ b/core/plugin_manager.py
@@ -1044,14 +1044,28 @@ class PluginManager:
         return {"mcpServers": servers}
 
     def get_all_mcp_server_names(self) -> list[str]:
-        """Get list of all MCP server names.
+        """Get list of all MCP server names visible through the gateway.
 
-        Returns:
-            List of server names from all providers
+        Includes:
+          1. Names from registered ``mcp`` providers (and ``service``
+             plugins that declare ``mcp_provider``).
+          2. ``service`` plugins that declare ``virtual_tools`` in their
+             manifest — these are exposed via the gateway's
+             LocalToolProvider machinery (see
+             ``core/mcp_gateway/tool_providers.py``) but are NOT in
+             ``self.mcp_providers``. Without this, the admin form's
+             "MCP Permissions" list and any other consumer relying on
+             the runtime path would silently hide them
+             (gridbeario/gridbear#152).
         """
         names = []
         for provider in self.mcp_providers.values():
             names.extend(provider.get_server_names())
+        for plugin_name, manifest in self._manifests.items():
+            if manifest.get("type") == "service" and manifest.get("virtual_tools"):
+                vt_name = manifest.get("name") or plugin_name
+                if vt_name not in names:
+                    names.append(vt_name)
         return names
 
     def get_private_only_servers(self) -> set[str]:

--- a/ui/utils/mcp_servers.py
+++ b/ui/utils/mcp_servers.py
@@ -53,7 +53,15 @@ def _static_server_names() -> list[str]:
     names: list[str] = []
     for plugin_name in enabled:
         manifest = manifests.get(plugin_name)
-        if not manifest or manifest.get("type") != "mcp":
+        if not manifest:
+            continue
+        # Two surfaces are exposed through the gateway: dedicated `type: mcp`
+        # plugins and `type: service` plugins that declare `virtual_tools`
+        # in their manifest (see core/mcp_gateway/tool_providers.py). Both
+        # become entries in the gateway's tool list and both must be
+        # selectable from the agent admin form, otherwise virtual-tool
+        # providers are unreachable from the UI (gridbeario/gridbear#152).
+        if manifest.get("type") != "mcp" and not manifest.get("virtual_tools"):
             continue
         if manifest.get("mcp_naming") in {"per_account", "per_tenant"}:
             continue


### PR DESCRIPTION
Closes #152.

Two filters were independently dropping virtual-tool plugins (`type: service` + `virtual_tools` in manifest, e.g. `artifacts`, `dwh_doreca`) in opposite ways. The result for an operator: enable the plugin in `plugins.enabled`, gateway's `tools/list` exposes the tools fine, but Claude in `/me/chat` replies "No such tool available" — because the agent process never got `--mcp-config`.

Both surfaces now use the same union semantics the gateway has always used (`mcp_permissions ∪ plugins.enabled`).

Changes:

- `ui/utils/mcp_servers.py::_static_server_names`: accept manifests with `type == "mcp"` OR `virtual_tools` set, so the agent edit form's "MCP Permissions" panel shows virtual-tool providers as selectable checkboxes instead of hiding them.
- `core/plugin_manager.py::get_all_mcp_server_names`: same widening for the runtime path. Iterates `_manifests` to pick up `service`-typed plugins with `virtual_tools` since they live outside `self.mcp_providers`.
- `core/mcp_token_manager.py::_provision_single_agent`: compute `effective = sorted(set(mcp_permissions) | set(plugins_enabled))`, skip only when both empty, persist `effective` to the OAuth2 client row so the gateway-side ACL and what the provisioner authorised stay in lock-step. Diff check (`current_perms != effective`) uses the same set, so existing agents stuck in the implicit-enable state from before this patch get repaired on next boot without an unrelated config touch. Skip log message rephrased to mention the effective set, not just `mcp_permissions`.

The two refinements you asked for (effective-set diff + log wording) are both in.

No data migration: existing rows with `mcp_permissions` set keep working unchanged; the union just covers the implicit-enable case that was broken.