### PR TITLE
[FIX] agents: rename and reorder Services / MCP Permissions / Tool Management

### DIFF
--- a/ui/templates/agents/edit.html
+++ b/ui/templates/agents/edit.html
@@ -329,6 +329,29 @@
         </div>
     </div>
 
+    <!-- Services (type=service plugins only) -->
+    <div class="rounded-2xl bg-white dark:bg-void-900/50 border border-void-200 dark:border-void-800 overflow-hidden">
+        <div class="p-5 border-b border-void-200 dark:border-void-800 bg-gradient-to-r from-frost-500/5 to-transparent">
+            <h3 class="font-semibold text-void-900 dark:text-white flex items-center gap-2">
+                <i class="fas fa-puzzle-piece text-frost-500"></i>
+                Enabled Services
+            </h3>
+            <p class="text-sm text-void-500 dark:text-void-400 mt-1">Service plugins (memory, sessions, attachments…) loaded for this agent. MCP tool plugins are managed under "MCP Permissions" below; channel plugins under their own sections.</p>
+        </div>
+        <div class="p-5">
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-2">
+                {% for plugin in available_services %}
+                <label class="flex items-center gap-2 p-3 rounded-xl hover:bg-void-50 dark:hover:bg-void-800/50 cursor-pointer transition-colors border border-transparent hover:border-void-200 dark:hover:border-void-700">
+                    <input type="checkbox" name="plugins_enabled" value="{{ plugin }}"
+                           {% if agent and plugin in agent.get('plugins', {}).get('enabled', []) %}checked{% endif %}
+                           class="w-4 h-4 rounded border-void-300 dark:border-void-600 text-frost-500 focus:ring-frost-500/20">
+                    <span class="text-sm text-void-700 dark:text-void-200">{{ plugin }}</span>
+                </label>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+
     <!-- MCP Permissions -->
     <div class="rounded-2xl bg-white dark:bg-void-900/50 border border-void-200 dark:border-void-800 overflow-hidden">
         <div class="p-5 border-b border-void-200 dark:border-void-800 bg-gradient-to-r from-ember-500/5 to-transparent">
@@ -405,29 +428,6 @@
                 </a>
             </div>
             {% endif %}
-        </div>
-    </div>
-
-    <!-- Services (type=service plugins only) -->
-    <div class="rounded-2xl bg-white dark:bg-void-900/50 border border-void-200 dark:border-void-800 overflow-hidden">
-        <div class="p-5 border-b border-void-200 dark:border-void-800 bg-gradient-to-r from-frost-500/5 to-transparent">
-            <h3 class="font-semibold text-void-900 dark:text-white flex items-center gap-2">
-                <i class="fas fa-puzzle-piece text-frost-500"></i>
-                Enabled Services
-            </h3>
-            <p class="text-sm text-void-500 dark:text-void-400 mt-1">Service plugins (memory, sessions, attachments…) loaded for this agent. MCP tool plugins are managed under "MCP Permissions" above; channel plugins under their own sections.</p>
-        </div>
-        <div class="p-5">
-            <div class="grid grid-cols-2 md:grid-cols-4 gap-2">
-                {% for plugin in available_services %}
-                <label class="flex items-center gap-2 p-3 rounded-xl hover:bg-void-50 dark:hover:bg-void-800/50 cursor-pointer transition-colors border border-transparent hover:border-void-200 dark:hover:border-void-700">
-                    <input type="checkbox" name="plugins_enabled" value="{{ plugin }}"
-                           {% if agent and plugin in agent.get('plugins', {}).get('enabled', []) %}checked{% endif %}
-                           class="w-4 h-4 rounded border-void-300 dark:border-void-600 text-frost-500 focus:ring-frost-500/20">
-                    <span class="text-sm text-void-700 dark:text-void-200">{{ plugin }}</span>
-                </label>
-                {% endfor %}
-            </div>
         </div>
     </div>
 

--- a/ui/templates/agents/edit.html
+++ b/ui/templates/agents/edit.html
@@ -408,14 +408,14 @@
         </div>
     </div>
 
-    <!-- Plugins -->
+    <!-- Services (type=service plugins only) -->
     <div class="rounded-2xl bg-white dark:bg-void-900/50 border border-void-200 dark:border-void-800 overflow-hidden">
         <div class="p-5 border-b border-void-200 dark:border-void-800 bg-gradient-to-r from-frost-500/5 to-transparent">
             <h3 class="font-semibold text-void-900 dark:text-white flex items-center gap-2">
                 <i class="fas fa-puzzle-piece text-frost-500"></i>
-                Enabled Plugins
+                Enabled Services
             </h3>
-            <p class="text-sm text-void-500 dark:text-void-400 mt-1">Select which plugins should be enabled for this agent</p>
+            <p class="text-sm text-void-500 dark:text-void-400 mt-1">Service plugins (memory, sessions, attachments…) loaded for this agent. MCP tool plugins are managed under "MCP Permissions" above; channel plugins under their own sections.</p>
         </div>
         <div class="p-5">
             <div class="grid grid-cols-2 md:grid-cols-4 gap-2">


### PR DESCRIPTION
Two cosmetic-but-meaningful UX cleanups in the agent edit form, no behaviour change.

**Commit 1 — rename "Enabled Plugins" → "Enabled Services"**

The section iterates `available_services` (only `type: service` plugins), but the heading "Enabled Plugins" implied a comprehensive list. Operators looking for an MCP plugin like `homeassistant` under "Enabled Plugins" found nothing and assumed it was disabled or missing, when in fact MCP-typed plugins live under "MCP Permissions" and channel plugins live in their own per-channel sections. Tightened the helper text to spell out the three layers.

**Commit 2 — reorder to lifecycle → ACL → tuning**

The three sections were ordered `MCP Permissions → Tool Management → Enabled Services`, which read backwards: pick the fine-grained ACL first, configure how it loads, then declare which services to enable in the first place. The natural mental model is the reverse — first decide which services this agent runs, then which MCP servers it may reach, then how the resulting tool set is loaded. Reordered to:

  Enabled Services → MCP Permissions → Tool Management

Form field names (`plugins_enabled`, `mcp_permissions`, `max_tools`, `tool_loading`) and the persisted DB schema are unchanged.