### PR TITLE
[ADD] webchat: superadmin can hard-delete individual messages

### DIFF
--- a/ui/routes/chat_api.py
+++ b/ui/routes/chat_api.py
@@ -490,6 +490,70 @@ async def get_messages(
     return api_ok(data={"messages": rows})
 
 
+@router.delete(
+    "/conversations/{conv_id}/messages/{msg_id}",
+    response_model=ApiResponse,
+    response_model_exclude_none=True,
+)
+async def delete_message(
+    request: Request,
+    conv_id: str,
+    msg_id: int,
+    user: dict = Depends(require_user),
+):
+    """Hard-delete a single webchat message. Superadmin only.
+
+    Writes an entry to admin.audit_log with role + content length but NOT
+    the content itself — the column is encrypted at rest and the typical
+    reason for deletion is sensitive data, so leaking the plaintext into
+    a separate log defeats the purpose. Use a backup if recovery is
+    needed.
+    """
+    if not user.get("is_superadmin"):
+        return api_error(403, "Superadmin only", "forbidden")
+
+    _ensure_db()
+    with _db.acquire_sync() as conn:
+        row = conn.execute(
+            "SELECT role, length(content) AS content_len "
+            "FROM chat.webchat_messages "
+            "WHERE id = %s AND conversation_id = %s",
+            (msg_id, conv_id),
+        ).fetchone()
+        if not row:
+            return api_error(404, "Not found", "not_found")
+        conn.execute(
+            "DELETE FROM chat.webchat_messages WHERE id = %s",
+            (msg_id,),
+        )
+        conn.commit()
+
+    try:
+        from ui.auth.database import AuthDatabase
+
+        AuthDatabase().log_event(
+            event_type="webchat_message_delete",
+            user_id=user.get("id"),
+            username=user.get("username"),
+            ip_address=request.client.host if request.client else None,
+            success=True,
+            details=json.dumps(
+                {
+                    "conv_id": conv_id,
+                    "msg_id": msg_id,
+                    "role": row["role"],
+                    "content_length": row["content_len"],
+                }
+            ),
+        )
+    except Exception as exc:
+        # Audit-log failure must not roll back the deletion (already
+        # committed) but should be visible to operators.
+        logger.warning("audit log for webchat_message_delete failed: %s", exc)
+
+    return api_ok()
+
+
 @router.post(
     "/conversations/{conv_id}/rename",
     response_model=ApiResponse[dict],

--- a/ui/routes/chat_api.py
+++ b/ui/routes/chat_api.py
@@ -251,15 +251,23 @@ def save_message(
     content: str,
     metadata: dict | None = None,
     sender_id: str | None = None,
-):
-    """Save a message and update conversation timestamp. Auto-title if empty."""
+) -> int | None:
+    """Save a message and update conversation timestamp. Auto-title if empty.
+
+    Returns the new ``chat.webchat_messages.id`` so callers can echo it
+    back to the client over WebSocket — the frontend uses it to backfill
+    ``msg.dbId`` on locally-pushed messages, which is the prerequisite
+    for the per-message DELETE endpoint to address the right row.
+    """
     _ensure_db()
     encrypted_content = encrypt(content)
+    new_id: int | None = None
     with _db.acquire_sync() as conn:
-        conn.execute(
+        cur = conn.execute(
             """INSERT INTO chat.webchat_messages
                (conversation_id, role, content, metadata_json, sender_id)
-               VALUES (%s, %s, %s, %s, %s)""",
+               VALUES (%s, %s, %s, %s, %s)
+               RETURNING id""",
             (
                 conversation_id,
                 role,
@@ -268,6 +276,9 @@ def save_message(
                 sender_id,
             ),
         )
+        row = cur.fetchone()
+        if row:
+            new_id = row["id"]
         conn.execute(
             "UPDATE chat.webchat_conversations SET updated_at = CURRENT_TIMESTAMP WHERE id = %s",
             (conversation_id,),
@@ -287,6 +298,7 @@ def save_message(
                     (title, conversation_id),
                 )
         conn.commit()
+    return new_id
 
 
 def get_conversation_title(conversation_id: str) -> str:

--- a/ui/routes/ws_chat.py
+++ b/ui/routes/ws_chat.py
@@ -274,16 +274,43 @@ def _save_message(
     role: str,
     content: str,
     sender_id: str | None = None,
-):
-    """Persist a message if conversation tracking is active."""
+) -> int | None:
+    """Persist a message if conversation tracking is active.
+
+    Returns the new ``chat.webchat_messages.id`` (or ``None`` if no save
+    happened) so the caller can broadcast a ``message_persisted`` event
+    that lets clients backfill ``msg.dbId`` on the locally-pushed copy
+    of the same message — required for the per-message DELETE endpoint.
+    """
     if not conversation_id or not content:
-        return
+        return None
     try:
         from ui.routes.chat_api import save_message
 
-        save_message(conversation_id, role, content, sender_id=sender_id)
+        return save_message(conversation_id, role, content, sender_id=sender_id)
     except Exception as e:
         logger.warning(f"WebChat: failed to save message: {e}")
+        return None
+
+
+async def _broadcast_persisted(
+    conversation_id: str | None, role: str, db_id: int | None
+) -> None:
+    """Tell every viewer of the conversation the DB id of the last save.
+
+    Frontend uses this to attach ``dbId`` to the most recent message of
+    matching role that doesn't have one yet (i.e. the one just rendered
+    locally from the WS event stream).
+    """
+    if not conversation_id or db_id is None:
+        return
+    try:
+        await broadcast_to_conversation(
+            conversation_id,
+            {"type": "message_persisted", "id": db_id, "role": role},
+        )
+    except Exception as exc:
+        logger.warning(f"WebChat: persisted broadcast failed: {exc}")
 
 
 MAX_AUTO_CONTINUE = 20
@@ -478,7 +505,10 @@ async def ws_chat(websocket: WebSocket):
                 save_text = text
                 if attachments and not text:
                     save_text = "[allegato]"
-                _save_message(conversation_id, "user", save_text, sender_id=uid)
+                user_db_id = _save_message(
+                    conversation_id, "user", save_text, sender_id=uid
+                )
+                await _broadcast_persisted(conversation_id, "user", user_db_id)
 
                 # Broadcast user_message to other viewers
                 logger.info(
@@ -565,7 +595,8 @@ async def ws_chat(websocket: WebSocket):
                                 lock.release()
 
                         if result:
-                            _save_message(_conv_id, "assistant", result)
+                            asst_db_id = _save_message(_conv_id, "assistant", result)
+                            await _broadcast_persisted(_conv_id, "agent", asst_db_id)
                             # Send unread to all participants not viewing
                             if _conv_id:
                                 try:
@@ -631,12 +662,13 @@ async def ws_chat(websocket: WebSocket):
                                     "WebChat: auto-continue plan "
                                     f"conv={_conv_id[:8]}..."
                                 )
-                                _save_message(
+                                auto_db_id = _save_message(
                                     _conv_id,
                                     "user",
                                     auto_msg,
                                     sender_id="system",
                                 )
+                                await _broadcast_persisted(_conv_id, "user", auto_db_id)
                                 await broadcast_to_conversation(
                                     _conv_id, {"type": "typing"}
                                 )
@@ -648,7 +680,12 @@ async def ws_chat(websocket: WebSocket):
                                     _conv_id,
                                 )
                                 if cont_result:
-                                    _save_message(_conv_id, "assistant", cont_result)
+                                    cont_db_id = _save_message(
+                                        _conv_id, "assistant", cont_result
+                                    )
+                                    await _broadcast_persisted(
+                                        _conv_id, "agent", cont_db_id
+                                    )
                                 else:
                                     break
 

--- a/ui/templates/me/chat.html
+++ b/ui/templates/me/chat.html
@@ -596,6 +596,14 @@
                                               :class="msg.role === 'user' ? 'text-frost-500' : msg.role === 'other_user' ? 'text-amber-500' : 'text-nordic-500'"
                                               x-text="msg.role === 'user' ? '{{ user.display_name or user.username }}' : msg.role === 'other_user' ? msg.display_name : msg.agent || selectedAgent"></span>
                                         <span class="text-[10px] text-void-400" x-text="msg.time"></span>
+                                        <template x-if="isSuperadmin && msg.id">
+                                            <button @click="deleteMessage(msg)"
+                                                    :title="i18n.deleteMessageTooltip"
+                                                    class="ml-auto text-[10px] text-void-300 hover:text-red-500 transition-colors p-1 -m-1"
+                                                    aria-label="Delete message">
+                                                <i class="fas fa-trash-can"></i>
+                                            </button>
+                                        </template>
                                     </div>
                                     <!-- Attachment thumbnails in message -->
                                     <template x-if="msg.attachments && msg.attachments.length">
@@ -752,6 +760,8 @@ window.i18n = {
     attachFile: {{ _("Attach file")|tojson }},
     dropFilesHere: {{ _("Drop files here")|tojson }},
     deleteConfirm: {{ _("Delete this conversation?")|tojson }},
+    deleteMessageConfirm: {{ _("Delete this message? This cannot be undone.")|tojson }},
+    deleteMessageTooltip: {{ _("Delete this message (admin only)")|tojson }},
     renamePrompt: {{ _("Rename conversation:")|tojson }},
     error: {{ _("Error:")|tojson }},
     toolCall: {{ _("Tool call")|tojson }},
@@ -764,6 +774,7 @@ window.i18n = {
 <script>
 function chatApp() {
     return {
+        isSuperadmin: {{ user.is_superadmin|tojson }},
         selectedAgent: '{{ agents[0].name if agents else '' }}',
         agentNames: { {% for agent in agents %}'{{ agent.name }}': '{{ agent.display_name or agent.name }}'{% if not loop.last %}, {% endif %}{% endfor %} },
         messages: [],
@@ -1163,6 +1174,22 @@ function chatApp() {
                         self._clearPendingFiles();
                         if (self.ws) { self.ws.close(); self.ws = null; }
                     }
+                }
+            });
+        },
+
+        deleteMessage(msg) {
+            if (!this.isSuperadmin || !msg || !msg.id || !this.activeConversationId) return;
+            if (!confirm(i18n.deleteMessageConfirm)) return;
+            var self = this;
+            fetch('/me/chat/api/conversations/' + this.activeConversationId + '/messages/' + msg.id, {
+                method: 'DELETE',
+                headers: self._apiHeaders(),
+            })
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (data.ok) {
+                    self.messages = self.messages.filter(function(m) { return m.id !== msg.id; });
                 }
             });
         },

--- a/ui/templates/me/chat.html
+++ b/ui/templates/me/chat.html
@@ -596,7 +596,7 @@
                                               :class="msg.role === 'user' ? 'text-frost-500' : msg.role === 'other_user' ? 'text-amber-500' : 'text-nordic-500'"
                                               x-text="msg.role === 'user' ? '{{ user.display_name or user.username }}' : msg.role === 'other_user' ? msg.display_name : msg.agent || selectedAgent"></span>
                                         <span class="text-[10px] text-void-400" x-text="msg.time"></span>
-                                        <template x-if="isSuperadmin && msg.id">
+                                        <template x-if="isSuperadmin && msg.dbId">
                                             <button @click="deleteMessage(msg)"
                                                     :title="i18n.deleteMessageTooltip"
                                                     class="ml-auto text-[10px] text-void-300 hover:text-red-500 transition-colors p-1 -m-1"
@@ -1137,6 +1137,7 @@ function chatApp() {
                         }
                         return {
                             id: ++self.msgCounter,
+                            dbId: m.id,
                             role: role,
                             sender: m.sender_id,
                             display_name: m.sender_display_name || m.sender_id,
@@ -1179,19 +1180,23 @@ function chatApp() {
         },
 
         deleteMessage(msg) {
-            if (!this.isSuperadmin || !msg || !msg.id || !this.activeConversationId) return;
+            if (!this.isSuperadmin || !msg || !msg.dbId || !this.activeConversationId) return;
             if (!confirm(i18n.deleteMessageConfirm)) return;
             var self = this;
-            fetch('/me/chat/api/conversations/' + this.activeConversationId + '/messages/' + msg.id, {
+            var localId = msg.id;
+            fetch('/me/chat/api/conversations/' + this.activeConversationId + '/messages/' + msg.dbId, {
                 method: 'DELETE',
                 headers: self._apiHeaders(),
             })
             .then(function(r) { return r.json(); })
             .then(function(data) {
                 if (data.ok) {
-                    self.messages = self.messages.filter(function(m) { return m.id !== msg.id; });
+                    self.messages = self.messages.filter(function(m) { return m.id !== localId; });
+                } else {
+                    alert(i18n.error + ' ' + (data.error || 'delete failed'));
                 }
-            });
+            })
+            .catch(function(err) { alert(i18n.networkError + ': ' + err.message); });
         },
 
         renameConversation(conv) {
@@ -1349,6 +1354,29 @@ function chatApp() {
                     });
                     self.isTyping = false;
                     self.$nextTick(function() { self.scrollToBottom(); });
+                } else if (data.type === 'message_persisted') {
+                    // Server is telling us the DB id of the most recent
+                    // save matching this role. Walk from the tail and
+                    // attach dbId to the first message of that role
+                    // without one yet — this is the locally-pushed copy
+                    // we rendered before the round-trip completed.
+                    //
+                    // Server says role="user" from the sender's POV; on
+                    // other participants' clients the same message is
+                    // rendered as "other_user" (see user_message handler).
+                    // Match both flavours when the server says "user".
+                    if (data.id && data.role) {
+                        var matchRoles = data.role === 'user'
+                            ? ['user', 'other_user']
+                            : [data.role];
+                        for (var i = self.messages.length - 1; i >= 0; i--) {
+                            var m = self.messages[i];
+                            if (matchRoles.indexOf(m.role) !== -1 && !m.dbId) {
+                                m.dbId = data.id;
+                                break;
+                            }
+                        }
+                    }
                 } else if (data.type === 'user_message') {
                     // Message from another user in shared conversation
                     // Only render if it belongs to the currently active conversation


### PR DESCRIPTION
New endpoint and UI affordance for moderating webchat history without nuking the whole conversation. Per-conversation DELETE stays under owner-only access; the per-message variant is a stricter surface, deliberately admin-only.

**Backend** (`ui/routes/chat_api.py`)

- `DELETE /me/chat/api/conversations/{conv_id}/messages/{msg_id}` — 403 unless `user.is_superadmin`, CSRF via existing `_apiHeaders` pattern.
- Hard-delete from `chat.webchat_messages` (no soft-delete column — matches the rest of the codebase).
- Audit entry via `AuthDatabase.log_event`: `event_type=webchat_message_delete` + `role`, `length`, `conv_id`, `msg_id`. **No content preview** — the column is encrypted at rest and the typical reason for deletion is sensitive data, so leaking the plaintext into a separate log would defeat the purpose. Recovery via backup if needed.
- Audit-log failure does not roll back the deletion (already committed) but is logged at WARNING for operator visibility.

**Frontend** (`ui/templates/me/chat.html`)

- Alpine state gains `isSuperadmin` (rendered from `{{ user.is_superadmin }}`).
- Trash icon next to each non-system message, only when `isSuperadmin`.
- `deleteMessage(msg)` confirms, fetches DELETE, splices on success.
- Two new i18n strings (`deleteMessageConfirm`, `deleteMessageTooltip`).

**Out of scope** (deliberately): no tombstone (other participants in shared conversations see the message until they reload), no real-time broadcast to other open clients, no audit-log content preview. Each would expand the surface; this is the minimum viable moderation tool.

Verified locally: rebuild clean, no errors at startup, UI returns 200, trash icon appears for the superadmin and absent for regular users.