### PR TITLE
[FIX] artifacts: capture &s=<share> in modal regex so iframe gets capability token

### DIFF
--- a/plugins/artifacts/admin/templates/artifact_modal.html
+++ b/plugins/artifacts/admin/templates/artifact_modal.html
@@ -57,8 +57,13 @@ function artifactModal() {
 
 <script>
 (function() {
-  // Matches an absolute or relative artifact URL with a uuid and hex token.
-  const ARTIFACT_RE = /(https?:\/\/[^\s<"'()]+\/artifacts\/[0-9a-f-]{36}\?t=[0-9a-f]{32}|\/artifacts\/[0-9a-f-]{36}\?t=[0-9a-f]{32})/gi;
+  // Matches absolute or relative artifact URLs. The optional `&s=<share>`
+  // tail must be captured too: without it the iframe loads the artifact via
+  // the cookie path (sandbox + SameSite=strict on HTTPS drops the session
+  // cookie -> 303 to /auth/login -> /me dashboard renders inside the modal).
+  // With the share token, _check_access takes the capability path and the
+  // cookie state stops mattering. See gridbeario/gridbear#156.
+  const ARTIFACT_RE = /((?:https?:\/\/[^\s<"'()]+)?\/artifacts\/[0-9a-f-]{36}\?t=[0-9a-f]{32}(?:&s=[A-Za-z0-9_-]+)?)/gi;
 
   function extractUrls(text) {
     if (!text) return [];


### PR DESCRIPTION
Closes #156.

The Preview modal's URL extractor stopped at `?t=<hmac>`, so the iframe `src` never carried the `&s=<share>` capability token even when the chat message had one. Without `s`, `_check_access` falls back to the cookie path; the modal's iframe sandbox doesn't carry `allow-same-origin`, and on HTTPS the session cookie is `SameSite=strict` — so the cookie isn't sent, the request 303s to `/auth/login`, and the user (owner included) ends up looking at the `/me` dashboard inside the artifact modal.

Extending the regex to optionally capture the share tail makes the iframe load via the capability path. `_check_access` takes the share branch and the cookie state stops mattering. The Open-in-new-tab flow already worked because the server-side wrapper html includes the share token in its links (`api/routes.py:_wrapper_html`).

Also refactored the regex to a single pattern with an optional `https?://...` prefix instead of duplicating the absolute/relative alternatives — keeps the new optional `&s=` tail DRY in one place.

Verified the regex against four representative inputs (absolute with share, relative without, absolute with `&s=tok&extra=1` trailing chars, no-match string).

Diagnosed by @dcorio with full root cause + line numbers — credit there.