### PR TITLE
[FIX] middleware: allow /artifacts/ capability URLs for non-superadmin users

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -326,6 +326,14 @@ class _ContextMiddleware:
                 logger.debug("Tenant context setup: %s", exc)
 
         # ── 2. Role-based access enforcement ────────────────────────
+        # The artifacts plugin's public surface uses capability URLs
+        # (?t=<hmac>&s=<share>) verified inside the route by
+        # plugins/artifacts/api/routes.py::_check_access. Without
+        # /artifacts/ in this list, logged-in non-superadmins were
+        # redirected to /me before the route ever ran, breaking
+        # owner-clicks on share links — see gridbeario/gridbear#158.
+        # Trailing slash keeps admin paths like /plugin/artifacts/*
+        # under the role check.
         public_prefixes = (
             "/auth/",
             "/static/",
@@ -334,6 +342,7 @@ class _ContextMiddleware:
             "/ws/",
             "/.well-known/",
             "/notifications",
+            "/artifacts/",
         )
         is_public = any(path.startswith(p) for p in public_prefixes) or path == "/mcp"
 


### PR DESCRIPTION
Closes #158.

`ui/app.py::_ContextMiddleware` redirects logged-in non-superadmin users to `/me` for any path not in `public_prefixes`. `/artifacts/` was missing, so:

- anonymous request → middleware skipped → route runs `_check_access` → share token matches → 200
- superadmin → `is_superadmin` true → middleware skipped → 200
- logged-in regular user (incl. the artifact owner) → middleware redirects to `/me` before `_check_access` ever runs, even with a valid `?t=<hmac>&s=<share>` capability URL

The artifacts plugin already gates access inside the route via the capability token, so the role-based middleware redirect on top of it was both redundant and wrong for this surface.

Adds `/artifacts/` to `public_prefixes` (trailing slash keeps admin paths like `/plugin/artifacts/*` under the role check). Also masks #157 (modal regex fix) for non-superadmin users — same iframe, now arrives at the route instead of bouncing to `/me` first.

Follow-up noted in #158: any future plugin shipping a public-capability surface will hit the same trap. Two fixes were proposed there (auto-extend `public_prefixes` from manifests, or new `public_capability_api` flag); deferring to a separate issue once this one lands so the production-blocker stays a one-liner.