### PR TITLE
[FIX] rest-api: hide ORM models from disabled plugins on REST API surfaces

### DIFF
--- a/core/orm/registry.py
+++ b/core/orm/registry.py
@@ -21,6 +21,41 @@ if TYPE_CHECKING:
     from core.orm.model import Model
 
 
+# Path components that mark the parent of a plugin directory. The first
+# component immediately below any of these is treated as the plugin name
+# for `_plugin_name` tagging. Covers in-tree plugins, the premium tree,
+# and the conventional external mount point used by GRIDBEAR_PLUGIN_PATHS.
+_PLUGIN_PARENTS = ("plugins", "plugins-premium", "gridbear-plugins")
+
+
+def _derive_plugin_name(filepath: Path) -> str | None:
+    """Return the plugin name owning ``filepath``, or None for core/ui."""
+    parts = filepath.parts
+    for i, segment in enumerate(parts):
+        if segment in _PLUGIN_PARENTS and i + 1 < len(parts):
+            return parts[i + 1]
+    return None
+
+
+def _enabled_plugin_names() -> set[str] | None:
+    """Best-effort fetch of enabled plugin names. Returns None on failure.
+
+    Used by REST API surfaces to decide whether to surface a model that
+    came from a plugin. ``None`` means "couldn't tell — show everything"
+    so an empty/broken DB never accidentally hides core surfaces.
+    """
+    try:
+        from core.plugin_registry.models import PluginRegistryEntry
+
+        rows = PluginRegistryEntry.search_sync(
+            [("state", "=", "installed"), ("enabled", "=", True)]
+        )
+        return {r["name"] for r in rows}
+    except Exception as exc:
+        logger.debug("_enabled_plugin_names: %s", exc)
+        return None
+
+
 class Registry:
     """Central ORM model registry."""
 
@@ -88,8 +123,38 @@ class Registry:
 
     @classmethod
     def get_models(cls) -> list[type[Model]]:
-        """Return all registered models (sorted by dependency order)."""
+        """Return all registered models (sorted by dependency order).
+
+        Includes models from disabled plugins — useful for the ORM core
+        itself (auto-migrations create their tables in case the plugin
+        is later enabled). Surfaces that expose models to humans should
+        prefer ``get_visible_models()``.
+        """
         return list(cls._models)
+
+    @classmethod
+    def get_visible_models(cls) -> list[type[Model]]:
+        """Return models that should appear in user-facing surfaces.
+
+        Filters out models whose owning plugin isn't installed+enabled
+        in ``app.plugin_registry`` — without this, the REST API admin
+        page (``/rest-api``) and the generic CRUD endpoints
+        (``/api/v1/models``) leak schemas like ``vault.ms365_tokens`` or
+        ``whatsapp.user_instances`` even when the plugin was never
+        installed. Models tagged with ``_plugin_name = None`` (core / ui
+        resident) are always visible.
+
+        On DB lookup failure, falls back to ``get_models()`` to avoid
+        silently hiding core surfaces.
+        """
+        enabled = _enabled_plugin_names()
+        if enabled is None:
+            return list(cls._models)
+        return [
+            m
+            for m in cls._models
+            if getattr(m, "_plugin_name", None) is None or m._plugin_name in enabled
+        ]
 
     @classmethod
     def get_model(cls, schema: str, name: str) -> type[Model] | None:
@@ -108,7 +173,15 @@ class Registry:
 
     @classmethod
     def _scan_directory(cls, directory: Path) -> None:
-        """Scan a directory tree for models.py files and import them."""
+        """Scan a directory tree for models.py files and import them.
+
+        Each imported model class is tagged with ``_plugin_name`` derived
+        from the file path so consumers can filter models that belong to
+        a disabled plugin (the on-disk DDL still runs, but UI surfaces
+        like the REST API admin page can hide them — see
+        gridbeario/gridbear: REST API page lists models from
+        plugins that aren't installed).
+        """
         for models_file in directory.rglob("models.py"):
             # Skip __pycache__, .venv, etc.
             if any(p.startswith((".", "__")) for p in models_file.parts):
@@ -117,7 +190,8 @@ class Registry:
             # Always use file-based import to avoid triggering package
             # __init__.py side effects (some plugins have runtime imports
             # in __init__ that fail during early ORM discovery).
-            cls._import_from_file(models_file)
+            plugin_name = _derive_plugin_name(models_file)
+            cls._import_from_file(models_file, plugin_name=plugin_name)
 
     @classmethod
     def _file_to_module(cls, filepath: Path) -> str | None:
@@ -140,23 +214,34 @@ class Registry:
             return None
 
     @classmethod
-    def _import_from_file(cls, filepath: Path) -> None:
+    def _import_from_file(cls, filepath: Path, plugin_name: str | None = None) -> None:
         """Import a models module directly from file path.
 
         Uses spec_from_file_location to avoid triggering package __init__.py
         files, which may contain runtime imports that fail during early
         ORM discovery.
+
+        ``plugin_name`` (when provided) is attached as ``_plugin_name`` to
+        each Model class registered during this import — used by REST API
+        consumers to hide models that belong to a disabled plugin. ``None``
+        means "core/ui-resident model, always visible".
         """
         # Build a unique module name from the directory path
         # e.g. /app/plugins/memo/models.py -> _orm_models_plugins_memo
         parts = [p.replace("-", "_") for p in filepath.parent.parts if p and p != "/"]
         module_name = "_orm_models_" + "_".join(parts)
         try:
+            from core.orm.model import ModelMeta
+
+            before = len(ModelMeta._all_models)
             spec = importlib.util.spec_from_file_location(module_name, filepath)
             if spec and spec.loader:
                 mod = importlib.util.module_from_spec(spec)
                 spec.loader.exec_module(mod)
                 logger.debug("ORM: imported %s from file %s", module_name, filepath)
+            # Tag every model that was newly registered by this import.
+            for new_model in ModelMeta._all_models[before:]:
+                new_model._plugin_name = plugin_name
         except Exception as e:
             logger.warning("ORM: failed to import %s: %s", filepath, e)
 

--- a/core/rest_api/router.py
+++ b/core/rest_api/router.py
@@ -94,7 +94,7 @@ async def list_models(_auth: dict = Depends(require_api_auth)):
         return api_error(403, "REST API is disabled", "forbidden")
 
     result = []
-    for model_cls in Registry.get_models():
+    for model_cls in Registry.get_visible_models():
         key = f"{model_cls._schema}.{model_cls._name}"
         if is_model_visible(key):
             result.append(

--- a/ui/routes/rest_api.py
+++ b/ui/routes/rest_api.py
@@ -54,7 +54,7 @@ def _get_orm_models() -> list[dict]:
     from core.orm.registry import Registry
 
     models = []
-    for model_cls in Registry.get_models():
+    for model_cls in Registry.get_visible_models():
         key = f"{model_cls._schema}.{model_cls._name}"
         models.append(
             {


### PR DESCRIPTION
The REST API admin page (`/rest-api`) lists models like `vault.ms365_tokens`, `whatsapp.user_instances`, `whatsapp.authorized_numbers`, `whatsapp_api.authorized_numbers` even on a fresh install where the owning plugins are `state='available' enabled=false`. The underlying generic CRUD endpoint `/api/v1/models` has the same leak.

Root cause: `Registry._scan_directory` iterates ALL `plugins/**/models.py` files on disk regardless of plugin state, so every model class defined anywhere in the tree ends up in `Registry._models`. Both the admin page and the CRUD endpoint then list them indiscriminately. Plugins without any `models.py` (like `telegram`) don't appear because they have nothing to register — that's why the leak was selective.

Patch keeps the auto-migration scope unchanged (DDL still runs for every discovered model — useful so tables exist if a plugin is later enabled) and only filters the UI/API list:

- `_derive_plugin_name(filepath)` extracts the plugin name from the path (handles `plugins/`, `plugins-premium/`, `gridbear-plugins/`). Returns `None` for `core/` and `ui/` resident models.
- `_import_from_file` tags every newly-registered Model class with `_plugin_name` (None for core/ui).
- New `Registry.get_visible_models()` returns only models with `_plugin_name is None` or whose plugin is `installed+enabled`. On DB lookup failure it falls back to `get_models()` so a broken DB never silently hides core surfaces.
- `core/rest_api/router.py` and `ui/routes/rest_api.py` switch from `get_models()` to `get_visible_models()`.

**Out of scope** (deliberate): the disabled-plugin tables themselves still get created in the DB by `migrate_all`. Filtering scan-time would require solving the chicken-and-egg of needing `plugin_registry` to query plugin state. The visible surface is the user-facing concern; the empty tables sitting in PG are noise but not a leak.

Verified locally: container rebuilds clean, ORM still discovers the same 45 models. Best tested on a deployment where plugins are actually disabled — there `vault.ms365_tokens` and the `whatsapp.*` schemas should disappear from the REST API admin page after merge.