### PR TITLE
[ADD] rest-api: separate 'create' permission from 'write'

### DIFF
--- a/core/rest_api/acl.py
+++ b/core/rest_api/acl.py
@@ -42,7 +42,9 @@ def _get_model_rule(model_key: str) -> dict | bool | None:
     Returns:
         - False: model is explicitly denied
         - True: full access
-        - dict with {read, write, delete}: granular access
+        - dict with {read, create, write, delete}: granular access
+          (``create`` is optional; falls back to ``write`` for rules
+          predating the create/write split)
         - None: no rule found (will fall back to wildcard or deny)
     """
     config = _load_config()
@@ -65,10 +67,15 @@ def check_access(model_key: str, operation: str) -> bool:
 
     Args:
         model_key: e.g. 'public.admin_users'
-        operation: one of 'read', 'write', 'delete'
+        operation: one of 'read', 'create', 'write', 'delete'
 
     Returns:
         True if the operation is allowed.
+
+    Backward compat: rules predating the create/write split don't carry
+    a ``create`` key. For those, ``create`` falls back to ``write`` so
+    upgrading the codebase doesn't silently revoke POST access on
+    models the operator already authorized for write.
     """
     rule = _get_model_rule(model_key)
 
@@ -82,6 +89,8 @@ def check_access(model_key: str, operation: str) -> bool:
 
     # Dict → granular check
     if isinstance(rule, dict):
+        if operation == "create" and "create" not in rule:
+            return bool(rule.get("write", False))
         return bool(rule.get(operation, False))
 
     return False

--- a/core/rest_api/router.py
+++ b/core/rest_api/router.py
@@ -227,7 +227,7 @@ async def create_record(
         return api_error(403, "REST API is disabled", "forbidden")
 
     model_cls, schema, name = _resolve_model(model_path)
-    _require_access(model_path, "write")
+    _require_access(model_path, "create")
 
     body = await request.json()
     values = body.get("values", {})

--- a/ui/routes/rest_api.py
+++ b/ui/routes/rest_api.py
@@ -68,20 +68,42 @@ def _get_orm_models() -> list[dict]:
 
 
 def _rule_to_perms(rule) -> dict:
-    """Convert an ACL rule to a permissions dict."""
+    """Convert an ACL rule to a permissions dict.
+
+    ``create`` is treated as separate from ``write`` (POST vs PATCH at
+    the router level). For rules predating the split that don't carry
+    a ``create`` key, fall back to the ``write`` value so the checkbox
+    pre-fills sensibly and a save round-trip doesn't accidentally
+    revoke create access.
+    """
+    denied = {
+        "denied": True,
+        "read": False,
+        "create": False,
+        "write": False,
+        "delete": False,
+    }
     if rule is False:
-        return {"denied": True, "read": False, "write": False, "delete": False}
+        return denied
     if rule is True:
-        return {"denied": False, "read": True, "write": True, "delete": True}
+        return {
+            "denied": False,
+            "read": True,
+            "create": True,
+            "write": True,
+            "delete": True,
+        }
     if isinstance(rule, dict):
+        write_val = bool(rule.get("write", False))
         return {
             "denied": False,
             "read": bool(rule.get("read", False)),
-            "write": bool(rule.get("write", False)),
+            "create": bool(rule.get("create", write_val)),
+            "write": write_val,
             "delete": bool(rule.get("delete", False)),
         }
     # No rule = denied
-    return {"denied": True, "read": False, "write": False, "delete": False}
+    return denied
 
 
 @router.get("/", response_class=HTMLResponse)
@@ -141,24 +163,28 @@ async def save_config(request: Request, _=Depends(require_login)):
             models_config[key] = False
         else:
             read = form.get(f"read_{key}") == "on"
+            create = form.get(f"create_{key}") == "on"
             write = form.get(f"write_{key}") == "on"
             delete = form.get(f"delete_{key}") == "on"
             # Only store explicit rules (skip models that match wildcard)
-            if not read and not write and not delete:
+            if not read and not create and not write and not delete:
                 models_config[key] = False
             else:
                 models_config[key] = {
                     "read": read,
+                    "create": create,
                     "write": write,
                     "delete": delete,
                 }
 
     # Wildcard rule
     wc_read = form.get("read_*") == "on"
+    wc_create = form.get("create_*") == "on"
     wc_write = form.get("write_*") == "on"
     wc_delete = form.get("delete_*") == "on"
     models_config["*"] = {
         "read": wc_read,
+        "create": wc_create,
         "write": wc_write,
         "delete": wc_delete,
     }

--- a/ui/templates/rest_api.html
+++ b/ui/templates/rest_api.html
@@ -73,6 +73,12 @@
                     <span class="text-sm text-void-700 dark:text-void-200">Read</span>
                 </label>
                 <label class="flex items-center gap-2 cursor-pointer">
+                    <input type="checkbox" name="create_*"
+                           {% if wildcard_perms.create %}checked{% endif %}
+                           class="w-4 h-4 rounded border-void-300 dark:border-void-600 text-nordic-500 focus:ring-nordic-500/30 bg-void-50 dark:bg-void-800">
+                    <span class="text-sm text-void-700 dark:text-void-200">Create</span>
+                </label>
+                <label class="flex items-center gap-2 cursor-pointer">
                     <input type="checkbox" name="write_*"
                            {% if wildcard_perms.write %}checked{% endif %}
                            class="w-4 h-4 rounded border-void-300 dark:border-void-600 text-nordic-500 focus:ring-nordic-500/30 bg-void-50 dark:bg-void-800">
@@ -131,6 +137,13 @@
                                :disabled="denied"
                                class="w-4 h-4 rounded border-void-300 dark:border-void-600 text-nordic-500 focus:ring-nordic-500/30 bg-void-50 dark:bg-void-800">
                         <span class="text-xs text-void-500 dark:text-void-400">R</span>
+                    </label>
+                    <label class="flex items-center gap-1.5 cursor-pointer" :class="denied ? 'opacity-30 pointer-events-none' : ''">
+                        <input type="checkbox" name="create_{{ m.key }}"
+                               {% if m.perms.create and not m.perms.denied %}checked{% endif %}
+                               :disabled="denied"
+                               class="w-4 h-4 rounded border-void-300 dark:border-void-600 text-nordic-500 focus:ring-nordic-500/30 bg-void-50 dark:bg-void-800">
+                        <span class="text-xs text-void-500 dark:text-void-400">C</span>
                     </label>
                     <label class="flex items-center gap-1.5 cursor-pointer" :class="denied ? 'opacity-30 pointer-events-none' : ''">
                         <input type="checkbox" name="write_{{ m.key }}"


### PR DESCRIPTION
Cosmetic but design-cleaner: the REST API ACL already had granular `read/write/delete` columns but POST (create) and PATCH (update) both routed through `write`. Splitting them lets operators express "user can create new records but not modify existing ones" — the typical audit-log / submission-form pattern that the previous 3-permission model couldn't capture.

Backward compat is the design constraint: every existing rule in `SystemConfig` was stored without a `create` key. After the upgrade those rules MUST keep granting POST access, otherwise an operator who set `write=true` on a model would silently lose create-by-API.

Approach:

- `core/rest_api/acl.py::check_access`: when op=`create` and the rule dict has no `create` key, fall back to the `write` value. Old rules become equivalent to `{read, write, delete}` with `create` shadowing `write`.
- `core/rest_api/router.py`: POST endpoint now requires `create` instead of `write`. PATCH stays on `write`.
- `ui/routes/rest_api.py::_rule_to_perms`: include `create` field; default to `write` value for legacy rules so the checkbox pre-fills matching the effective access (and a save round-trip doesn't invert that intent).
- `ui/routes/rest_api.py::save_config`: parse `create_<key>` alongside others, persist to the rule dict; same for the wildcard.
- `ui/templates/rest_api.html`: new Create column between Read and Write (R/C/W/D order) for both per-model rows and the wildcard default.

Verified locally with rebuild: page renders the new column, no startup errors, UI returns 200.