### PR TITLE
[ADD] ollama admin: per-model Delete and Set-as-Default buttons

### DIFF
--- a/plugins/ollama/admin/routes.py
+++ b/plugins/ollama/admin/routes.py
@@ -147,3 +147,62 @@ async def ollama_pull_model(request: Request, _: bool = Depends(require_login)):
     except Exception as exc:
         logger.error("Ollama pull proxy error: %s", exc)
         return JSONResponse({"ok": False, "error": str(exc)}, status_code=500)
+
+
+@router.post("/delete")
+async def ollama_delete_model(request: Request, _: bool = Depends(require_login)):
+    """Proxy model delete to the bot's Ollama API.
+
+    Mirrors the pull surface so operators can remove a model from the
+    admin UI instead of reaching for ``docker exec ... ollama rm``.
+    Typical use: a model was pulled but turns out to require a paid
+    Ollama Cloud subscription, or just freeing disk space.
+    """
+    body = await request.json()
+    model_name = (body.get("name") or "").strip()
+    if not model_name:
+        return JSONResponse(
+            {"ok": False, "error": "Model name is required"}, status_code=400
+        )
+
+    url = f"{GRIDBEAR_URL}/api/ollama/delete"
+    headers = {
+        "Authorization": f"Bearer {INTERNAL_SECRET}",
+        "Content-Type": "application/json",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(30, connect=10)) as client:
+            resp = await client.post(url, json={"name": model_name}, headers=headers)
+            return JSONResponse(resp.json(), status_code=resp.status_code)
+    except Exception as exc:
+        logger.error("Ollama delete proxy error: %s", exc)
+        return JSONResponse({"ok": False, "error": str(exc)}, status_code=500)
+
+
+@router.post("/set-default")
+async def ollama_set_default_model(request: Request, _: bool = Depends(require_login)):
+    """Promote a locally-installed model to the plugin's default.
+
+    Avoids the operator having to scroll through the Configuration form
+    just to flip one field — the typical "I just pulled a new model and
+    want to try it" workflow becomes a one-click promotion from the
+    Available Models list.
+    """
+    body = await request.json()
+    model_name = (body.get("name") or "").strip()
+    if not model_name:
+        return JSONResponse(
+            {"ok": False, "error": "Model name is required"}, status_code=400
+        )
+
+    try:
+        from ui.plugin_helpers import load_plugin_config, save_plugin_config
+
+        config = load_plugin_config("ollama")
+        config["model"] = model_name
+        save_plugin_config("ollama", config)
+        logger.info("Ollama default model set to: %s", model_name)
+        return JSONResponse({"ok": True, "model": model_name})
+    except Exception as exc:
+        logger.error("Ollama set-default error: %s", exc)
+        return JSONResponse({"ok": False, "error": str(exc)}, status_code=500)

--- a/plugins/ollama/admin/templates/plugins/ollama.html
+++ b/plugins/ollama/admin/templates/plugins/ollama.html
@@ -247,12 +247,27 @@
                         {% endif %}
                     </div>
                 </div>
-                <div class="flex items-center gap-4 text-sm text-void-500 dark:text-void-400">
+                <div class="flex items-center gap-3 text-sm text-void-500 dark:text-void-400">
                     {% if model.size_gb > 0 %}
                     <span class="tabular-nums">{{ "%.1f"|format(model.size_gb) }} GB</span>
                     {% else %}
                     <span class="text-void-400">—</span>
                     {% endif %}
+                    {% set is_default = model.name == health.configured_model or model.name == health.configured_model ~ ':latest' or model.name.startswith(health.configured_model ~ ':') %}
+                    {% if not is_default %}
+                    <button type="button"
+                            onclick="setDefaultModel(this, '{{ model.name|e }}')"
+                            title="Set as default model"
+                            class="inline-flex items-center justify-center w-8 h-8 rounded-lg text-void-400 hover:text-nordic-500 hover:bg-nordic-500/10 transition-colors">
+                        <i class="far fa-star text-sm"></i>
+                    </button>
+                    {% endif %}
+                    <button type="button"
+                            onclick="deleteModel(this, '{{ model.name|e }}')"
+                            title="Remove this model from local Ollama"
+                            class="inline-flex items-center justify-center w-8 h-8 rounded-lg text-void-400 hover:text-ember-500 hover:bg-ember-500/10 transition-colors">
+                        <i class="fas fa-trash-can text-sm"></i>
+                    </button>
                 </div>
             </div>
             {% endfor %}
@@ -347,6 +362,67 @@ async function pullModel() {
 document.getElementById('pull-model-name')?.addEventListener('keydown', function(e) {
     if (e.key === 'Enter') { e.preventDefault(); pullModel(); }
 });
+
+function _csrfToken() {
+    return document.getElementById('csrf-token')
+        ? document.getElementById('csrf-token').value
+        : (document.querySelector('[name=csrf_token]')?.value || '');
+}
+
+async function setDefaultModel(btn, name) {
+    btn.disabled = true;
+    const icon = btn.querySelector('i');
+    const prevIcon = icon.className;
+    icon.className = 'fas fa-spinner fa-spin text-sm';
+    try {
+        const resp = await fetch('/plugins/ollama/set-default', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': _csrfToken() },
+            body: JSON.stringify({name})
+        });
+        const data = await resp.json();
+        if (data.ok) {
+            location.reload();
+        } else {
+            alert('Failed to set default: ' + (data.error || 'unknown error'));
+            icon.className = prevIcon;
+            btn.disabled = false;
+        }
+    } catch (err) {
+        alert('Network error: ' + err.message);
+        icon.className = prevIcon;
+        btn.disabled = false;
+    }
+}
+
+async function deleteModel(btn, name) {
+    if (!confirm('Remove model "' + name + '" from local Ollama? This frees disk space; you can pull it again later.')) {
+        return;
+    }
+    btn.disabled = true;
+    const icon = btn.querySelector('i');
+    const prevIcon = icon.className;
+    icon.className = 'fas fa-spinner fa-spin text-sm';
+    try {
+        const resp = await fetch('/plugins/ollama/delete', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': _csrfToken() },
+            body: JSON.stringify({name})
+        });
+        const data = await resp.json();
+        if (data.ok) {
+            location.reload();
+        } else {
+            alert('Failed to delete: ' + (data.error || 'unknown error'));
+            icon.className = prevIcon;
+            btn.disabled = false;
+        }
+    } catch (err) {
+        alert('Network error: ' + err.message);
+        icon.className = prevIcon;
+        btn.disabled = false;
+    }
+}
 
 function ollamaAuth() {
     return {

--- a/plugins/ollama/admin/templates/plugins/ollama.html
+++ b/plugins/ollama/admin/templates/plugins/ollama.html
@@ -363,21 +363,22 @@ document.getElementById('pull-model-name')?.addEventListener('keydown', function
     if (e.key === 'Enter') { e.preventDefault(); pullModel(); }
 });
 
-function _csrfToken() {
-    return document.getElementById('csrf-token')
-        ? document.getElementById('csrf-token').value
-        : (document.querySelector('[name=csrf_token]')?.value || '');
-}
-
+// Inline CSRF token lookup — earlier we extracted this into a helper
+// `_csrfToken()` but the name collides with a global of the same name
+// declared by the CSRF partial loaded site-wide. The collision threw
+// `SyntaxError: Identifier '_csrfToken' has already been declared`,
+// aborting the whole script and leaving every function in this block
+// (ollamaAuth, deleteModel, setDefaultModel, pullModel) undefined.
 async function setDefaultModel(btn, name) {
     btn.disabled = true;
     const icon = btn.querySelector('i');
     const prevIcon = icon.className;
     icon.className = 'fas fa-spinner fa-spin text-sm';
+    const csrf = document.querySelector('[name=csrf_token]')?.value || '';
     try {
         const resp = await fetch('/plugins/ollama/set-default', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': _csrfToken() },
+            headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf },
             body: JSON.stringify({name})
         });
         const data = await resp.json();
@@ -403,10 +404,11 @@ async function deleteModel(btn, name) {
     const icon = btn.querySelector('i');
     const prevIcon = icon.className;
     icon.className = 'fas fa-spinner fa-spin text-sm';
+    const csrf = document.querySelector('[name=csrf_token]')?.value || '';
     try {
         const resp = await fetch('/plugins/ollama/delete', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': _csrfToken() },
+            headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf },
             body: JSON.stringify({name})
         });
         const data = await resp.json();

--- a/plugins/ollama/api/routes.py
+++ b/plugins/ollama/api/routes.py
@@ -30,6 +30,10 @@ class PullModelRequest(BaseModel):
     name: str
 
 
+class DeleteModelRequest(BaseModel):
+    name: str
+
+
 @router.get(
     "/models",
     response_model=ApiResponse[dict],
@@ -236,6 +240,45 @@ async def pull_model(
         return api_error(e.response.status_code, msg, "pull_error")
     except Exception as e:
         logger.error("Ollama pull error: %s", e)
+        return api_error(500, str(e), "internal_error")
+
+
+@router.post(
+    "/delete",
+    response_model=ApiResponse,
+    response_model_exclude_none=True,
+)
+async def delete_model(
+    request: DeleteModelRequest,
+    _auth: None = Depends(verify_internal_auth),
+):
+    """Delete a locally-cached model via Ollama's DELETE /api/delete.
+
+    Useful when the operator pulled a model that turns out to be
+    paid-only on Ollama Cloud, or just to free disk space without
+    needing to drop into a shell.
+    """
+    host, _ = _get_ollama_host()
+    model_name = request.name.strip()
+    if not model_name:
+        return api_error(400, "Model name is required", "validation_error")
+
+    logger.info("Ollama delete requested: %s", model_name)
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(30, connect=10)) as client:
+            resp = await client.request(
+                "DELETE", f"{host}/api/delete", json={"name": model_name}
+            )
+            resp.raise_for_status()
+        logger.info("Ollama delete complete: %s", model_name)
+        return api_ok(model=model_name)
+    except httpx.HTTPStatusError as e:
+        msg = str(e)
+        if e.response.status_code == 404:
+            msg = f"Model '{model_name}' not installed locally"
+        return api_error(e.response.status_code, msg, "delete_error")
+    except Exception as e:
+        logger.error("Ollama delete error: %s", e)
         return api_error(500, str(e), "internal_error")
 
 

--- a/plugins/ollama/api/routes.py
+++ b/plugins/ollama/api/routes.py
@@ -66,16 +66,18 @@ async def set_models(
     return api_ok(count=len(models))
 
 
-@router.post(
-    "/models/refresh",
-    response_model=ApiResponse,
-    response_model_exclude_none=True,
-)
-async def refresh_models(_auth: None = Depends(verify_internal_auth)):
-    """Refresh model list from local Ollama instance (/api/tags)."""
+async def _sync_registry_from_ollama() -> int | None:
+    """Pull `ollama list` and overwrite the GridBear models registry.
+
+    Returns the number of models synced, or ``None`` on failure. Used both
+    by the explicit /models/refresh endpoint and as a fire-and-forget
+    follow-up after pull/delete so the agent dropdown stays in lock-step
+    with what's actually installed locally — without this, the operator
+    pulls a model and then has to remember to also click "Refresh" in the
+    Models registry section to make it pickable on agents.
+    """
     from core.registry import get_plugin_manager
 
-    # Get Ollama host from plugin config
     pm = get_plugin_manager()
     host = "http://ollama:11434"
     if pm:
@@ -94,7 +96,6 @@ async def refresh_models(_auth: None = Depends(verify_internal_auth)):
             name = m.get("name", "")
             # Format: "qwen3:8b" → "Qwen3 8B"
             display = name.replace(":", " ").replace("-", " ").title()
-            # Add size info if available
             size_gb = m.get("size", 0) / (1024**3)
             if size_gb > 0.1:
                 display += f" ({size_gb:.1f} GB)"
@@ -105,10 +106,23 @@ async def refresh_models(_auth: None = Depends(verify_internal_auth)):
         registry = get_models_registry()
         if registry:
             registry.set_models("ollama", models, source="api")
-        return api_ok(count=len(models))
+        return len(models)
     except Exception as e:
-        logger.error("Ollama models refresh error: %s", e)
-        return api_error(500, str(e), "internal_error")
+        logger.warning("Ollama registry sync failed: %s", e)
+        return None
+
+
+@router.post(
+    "/models/refresh",
+    response_model=ApiResponse,
+    response_model_exclude_none=True,
+)
+async def refresh_models(_auth: None = Depends(verify_internal_auth)):
+    """Refresh model list from local Ollama instance (/api/tags)."""
+    count = await _sync_registry_from_ollama()
+    if count is None:
+        return api_error(500, "Ollama registry sync failed", "internal_error")
+    return api_ok(count=count)
 
 
 def _get_ollama_host() -> tuple[str, str]:
@@ -249,6 +263,10 @@ async def pull_model(
 
         if "success" in str(last_status.get("status", "")):
             logger.info("Ollama pull complete: %s", model_name)
+            # Auto-sync the GridBear registry so the new model shows up in
+            # agent dropdowns without the operator needing a separate
+            # "Refresh" click in the Models section.
+            await _sync_registry_from_ollama()
             return api_ok(model=model_name)
         return api_error(
             500, f"Pull ended without success: {last_status}", "pull_error"
@@ -293,6 +311,9 @@ async def delete_model(
             )
             resp.raise_for_status()
         logger.info("Ollama delete complete: %s", model_name)
+        # Same registry-sync rationale as in pull above — keep the agent
+        # dropdown in lock-step with the actual local install.
+        await _sync_registry_from_ollama()
         return api_ok(model=model_name)
     except httpx.HTTPStatusError as e:
         msg = str(e)

--- a/plugins/ollama/api/routes.py
+++ b/plugins/ollama/api/routes.py
@@ -112,7 +112,16 @@ async def refresh_models(_auth: None = Depends(verify_internal_auth)):
 
 
 def _get_ollama_host() -> tuple[str, str]:
-    """Return (host, configured_model) from the running Ollama runner."""
+    """Return (host, configured_model).
+
+    The host comes from the running runner instance (env-var overridable
+    at boot, doesn't change at runtime). The configured_model is read
+    fresh from the plugin registry on every call — without this re-read,
+    setting the default via /plugins/ollama/set-default would persist
+    to the DB but the health endpoint would keep returning the boot-time
+    snapshot until a container restart, leaving the admin UI's "default"
+    badge on the wrong model.
+    """
     from core.registry import get_plugin_manager
 
     pm = get_plugin_manager()
@@ -125,6 +134,19 @@ def _get_ollama_host() -> tuple[str, str]:
                 host = ollama.host
             if hasattr(ollama, "model"):
                 model = ollama.model
+
+    # Override model with the latest persisted value so set-default takes
+    # effect immediately without restart. Falls back to runner snapshot if
+    # the registry read fails for any reason.
+    try:
+        from ui.plugin_helpers import load_plugin_config
+
+        cfg = load_plugin_config("ollama")
+        if cfg and cfg.get("model"):
+            model = cfg["model"]
+    except Exception as exc:
+        logger.debug("ollama _get_ollama_host config re-read failed: %s", exc)
+
     return host, model
 
 


### PR DESCRIPTION
The `/plugins/ollama` page exposed Pull but no way to remove a pulled model or to promote one to default without scrolling to the Configuration form. Two friction points the operator hits constantly:

- Pulled a paid-tier `:cloud` model that 403s on chat → had to drop into `docker exec ... ollama rm` to undo.
- Pulled a model to test → had to scroll to Configuration, find the Model dropdown, select, save, just to flip one field.

Adds two action buttons next to each row in the Available Models list:

- ⭐ **Set as default** — `POST /plugins/ollama/set-default` updates the plugin config's `model` key via `load_plugin_config` / `save_plugin_config` (no DB schema change). Hidden when the model is already the default.
- 🗑 **Delete** — `POST /plugins/ollama/delete` proxies to the bot-side `POST /api/ollama/delete`, which in turn issues Ollama's `DELETE /api/delete`. Confirm dialog before destructive action.

Backend additions:
- `plugins/ollama/api/routes.py`: new `POST /delete` (mirrors `/pull` — same pattern, shorter timeout since delete is fast).
- `plugins/ollama/admin/routes.py`: two proxy endpoints (`delete`, `set-default`) following the existing pull proxy template.

Frontend additions:
- Two buttons per model row in `plugins/ollama.html`. Trash button always shown; star button hidden when the model is already the default (avoids "delete the agent's current model" footgun is mitigated by the confirm dialog, but the star is just redundant in that state).
- JS handlers reuse the existing CSRF token reader pattern, do fetch + reload on success, alert on failure.