### PR TITLE
[FIX] ci: ignore CVE-2026-3219 in pip until upstream fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,11 @@ jobs:
           pip install --upgrade "setuptools>=78.1.1"
 
       - name: Dependency vulnerability scan
-        run: pip-audit --desc --skip-editable --ignore-vuln CVE-2026-4539  # pygments regex DoS, local-only
+        # CVE-2026-3219: pip <=26.0.1 conflates concatenated tar+ZIP files.
+        # No fix release as of 2026-04-25; only triggered by malicious package
+        # archives during install — we pin our own deps and don't install
+        # arbitrary user input, so the path isn't reachable in our runtime.
+        run: pip-audit --desc --skip-editable --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219  # pygments regex DoS + pip tar/zip confusion
 
       - name: Secret scan
         run: |


### PR DESCRIPTION
The security job has been failing on every open PR (and on `main` since 2026-04-24 16:50) because pip-audit started flagging **CVE-2026-3219** in pip 26.0.1: pip handles concatenated tar+ZIP files as ZIP regardless of filename or whether the file is both formats. The advisory has no fix release listed yet, and the only path that triggers the issue is installing a deliberately crafted malicious package archive.

In our CI we install only pinned deps from PyPI / our own repos — no arbitrary user input is fed into pip. The runtime exposure is effectively zero, and the alternative (pinning pip to a pre-CVE version that doesn't have the audit metadata yet) makes the noise worse.

Adds `CVE-2026-3219` to the existing `--ignore-vuln` list alongside `CVE-2026-4539` (pygments regex DoS, local-only). The in-place comment explains the rationale + reminds future maintainers to drop the ignore once a pip release with the fix lands.

Without this, none of the open PRs (#161, #162) can go green.