### PR TITLE
[ADD] openai: route reasoning models to /v1/responses

### DIFF
--- a/plugins/openai/api_backend.py
+++ b/plugins/openai/api_backend.py
@@ -32,6 +32,14 @@ _TRANSIENT_ERRORS = (
 # Legacy models that still use max_tokens instead of max_completion_tokens
 _LEGACY_MAX_TOKENS_MODELS = ("gpt-4o", "gpt-3.5")
 
+# Reasoning models that require the Responses API (/v1/responses) instead of
+# the Chat Completions API. Detected by name pattern; can be overridden per
+# model via the registry's "endpoint" field (see _uses_responses_api).
+_RESPONSES_API_PATTERNS = (
+    re.compile(r"-pro$"),  # gpt-5.5-pro, gpt-5-pro, etc.
+    re.compile(r"^o[1-9]"),  # o1, o3, o4-mini, ...
+)
+
 
 def resolve_model(name: str) -> str:
     """Map model names via registry, passthrough for unknown IDs."""
@@ -52,6 +60,33 @@ def _uses_legacy_max_tokens(model: str) -> bool:
     Only older models (gpt-4o, gpt-3.5) still use max_tokens.
     """
     return any(model.startswith(prefix) for prefix in _LEGACY_MAX_TOKENS_MODELS)
+
+
+def _uses_responses_api(model: str) -> bool:
+    """Return True if the model needs the Responses API, not Chat Completions.
+
+    Detection precedence:
+      1. Registry entry has explicit ``endpoint == "responses"`` for the model
+      2. Model name matches a reasoning-family pattern (`-pro` suffix or
+         o-series prefix)
+
+    Reasoning models (gpt-*-pro, o1/o3/o4) error out with HTTP 404 on
+    /v1/chat/completions because they are not exposed there — they only
+    answer on /v1/responses.
+    """
+    from core.registry import get_models_registry
+
+    registry = get_models_registry()
+    if registry:
+        meta = registry.get_metadata("openai")
+        if meta:
+            for entry in meta.get("models", []) or []:
+                if entry.get("api_id") == model or entry.get("id") == model:
+                    endpoint = entry.get("endpoint")
+                    if endpoint:
+                        return endpoint == "responses"
+                    break
+    return any(p.search(model) for p in _RESPONSES_API_PATTERNS)
 
 
 class OpenAIApiBackend:
@@ -368,7 +403,18 @@ class OpenAIApiBackend:
         messages: list[dict],
         tools: list[dict] | None,
     ) -> tuple[str, list[dict] | None, tuple[int, int, float] | None]:
-        """Non-streaming API call."""
+        """Non-streaming API call. Dispatches to chat or responses backend."""
+        if _uses_responses_api(model):
+            return await self._call_unary_responses(model, messages, tools)
+        return await self._call_unary_chat(model, messages, tools)
+
+    async def _call_unary_chat(
+        self,
+        model: str,
+        messages: list[dict],
+        tools: list[dict] | None,
+    ) -> tuple[str, list[dict] | None, tuple[int, int, float] | None]:
+        """Non-streaming /v1/chat/completions call."""
         kwargs = self._build_api_kwargs(model, messages, tools)
         response = await self._client.chat.completions.create(**kwargs)
 
@@ -379,6 +425,22 @@ class OpenAIApiBackend:
 
         return text, tool_calls, usage_info
 
+    async def _call_unary_responses(
+        self,
+        model: str,
+        messages: list[dict],
+        tools: list[dict] | None,
+    ) -> tuple[str, list[dict] | None, tuple[int, int, float] | None]:
+        """Non-streaming /v1/responses call for reasoning models."""
+        kwargs = self._build_responses_kwargs(model, messages, tools)
+        response = await self._client.responses.create(**kwargs)
+
+        text = getattr(response, "output_text", "") or ""
+        tool_calls = self._extract_responses_tool_calls(response)
+        usage_info = self._extract_usage_responses(response, model)
+
+        return text, tool_calls, usage_info
+
     async def _call_streaming(
         self,
         model: str,
@@ -386,7 +448,21 @@ class OpenAIApiBackend:
         tools: list[dict] | None,
         stream_callback,
     ) -> tuple[str, list[dict] | None, tuple[int, int, float] | None]:
-        """Streaming API call — calls stream_callback with accumulated text."""
+        """Streaming API call. Dispatches to chat or responses backend."""
+        if _uses_responses_api(model):
+            return await self._call_streaming_responses(
+                model, messages, tools, stream_callback
+            )
+        return await self._call_streaming_chat(model, messages, tools, stream_callback)
+
+    async def _call_streaming_chat(
+        self,
+        model: str,
+        messages: list[dict],
+        tools: list[dict] | None,
+        stream_callback,
+    ) -> tuple[str, list[dict] | None, tuple[int, int, float] | None]:
+        """Streaming /v1/chat/completions call."""
         kwargs = self._build_api_kwargs(model, messages, tools)
         kwargs["stream"] = True
         kwargs["stream_options"] = {"include_usage": True}
@@ -443,6 +519,210 @@ class OpenAIApiBackend:
                 tc = tool_calls_acc[idx]
                 try:
                     tc["arguments"] = json.loads(tc["arguments"])
+                except (json.JSONDecodeError, TypeError):
+                    tc["arguments"] = {}
+                tool_calls.append(tc)
+
+        return accumulated_text, tool_calls, usage_info
+
+    # ── Responses API helpers (reasoning models: gpt-*-pro, o-series) ────
+
+    def _build_responses_kwargs(
+        self,
+        model: str,
+        messages: list[dict],
+        tools: list[dict] | None,
+    ) -> dict:
+        """Translate chat-style messages into Responses API kwargs.
+
+        - system role → ``instructions`` parameter (concatenated)
+        - user/assistant text → ``input`` items of type "message"
+        - assistant tool_calls → ``input`` items of type "function_call"
+        - tool role (results) → ``input`` items of type "function_call_output"
+        - tools list (Chat Completions shape) → flattened to Responses shape
+        """
+        instructions_parts: list[str] = []
+        input_items: list[dict] = []
+
+        for m in messages:
+            role = m.get("role")
+            content = m.get("content")
+
+            if role == "system":
+                if content:
+                    instructions_parts.append(content)
+                continue
+
+            if role == "tool":
+                input_items.append(
+                    {
+                        "type": "function_call_output",
+                        "call_id": m.get("tool_call_id", ""),
+                        "output": content
+                        if isinstance(content, str)
+                        else json.dumps(content),
+                    }
+                )
+                continue
+
+            if role == "assistant" and m.get("tool_calls"):
+                if content:
+                    input_items.append(
+                        {"type": "message", "role": "assistant", "content": content}
+                    )
+                for tc in m["tool_calls"]:
+                    fn = tc.get("function", {})
+                    input_items.append(
+                        {
+                            "type": "function_call",
+                            "call_id": tc.get("id", ""),
+                            "name": fn.get("name", ""),
+                            "arguments": fn.get("arguments", "")
+                            if isinstance(fn.get("arguments"), str)
+                            else json.dumps(fn.get("arguments") or {}),
+                        }
+                    )
+                continue
+
+            # Plain user/assistant message
+            if content:
+                input_items.append(
+                    {"type": "message", "role": role, "content": content}
+                )
+
+        kwargs: dict = {
+            "model": model,
+            "input": input_items,
+            "max_output_tokens": self.max_output_tokens,
+        }
+        if instructions_parts:
+            kwargs["instructions"] = "\n\n".join(instructions_parts)
+        if tools:
+            kwargs["tools"] = self._convert_tools_for_responses(tools)
+        return kwargs
+
+    @staticmethod
+    def _convert_tools_for_responses(tools: list[dict]) -> list[dict]:
+        """Flatten Chat Completions tool format to Responses format.
+
+        Chat: ``[{"type": "function", "function": {"name", "description",
+                  "parameters"}}]``
+        Responses: ``[{"type": "function", "name", "description",
+                       "parameters"}]``
+        """
+        out = []
+        for t in tools:
+            if t.get("type") == "function" and "function" in t:
+                fn = t["function"]
+                out.append(
+                    {
+                        "type": "function",
+                        "name": fn.get("name", ""),
+                        "description": fn.get("description", ""),
+                        "parameters": fn.get("parameters", {}),
+                    }
+                )
+            else:
+                out.append(t)
+        return out
+
+    @staticmethod
+    def _extract_responses_tool_calls(response) -> list[dict] | None:
+        """Pull function_call items out of a Responses API result."""
+        output = getattr(response, "output", None) or []
+        tool_calls: list[dict] = []
+        for item in output:
+            if getattr(item, "type", None) != "function_call":
+                continue
+            try:
+                args_raw = getattr(item, "arguments", "") or ""
+                args = json.loads(args_raw) if args_raw else {}
+            except (json.JSONDecodeError, TypeError):
+                args = {}
+            tool_calls.append(
+                {
+                    "id": getattr(item, "call_id", "") or getattr(item, "id", ""),
+                    "name": getattr(item, "name", ""),
+                    "arguments": args,
+                }
+            )
+        return tool_calls or None
+
+    @staticmethod
+    def _extract_usage_responses(response, model: str) -> tuple[int, int, float] | None:
+        """Read usage block from a Responses API result."""
+        usage = getattr(response, "usage", None)
+        if not usage:
+            return None
+        in_tok = getattr(usage, "input_tokens", 0) or 0
+        out_tok = getattr(usage, "output_tokens", 0) or 0
+        cost = calculate_cost(model, in_tok, out_tok)
+        return (in_tok, out_tok, cost)
+
+    async def _call_streaming_responses(
+        self,
+        model: str,
+        messages: list[dict],
+        tools: list[dict] | None,
+        stream_callback,
+    ) -> tuple[str, list[dict] | None, tuple[int, int, float] | None]:
+        """Streaming /v1/responses call.
+
+        Listens to the typed event stream and surfaces incremental text via
+        stream_callback. Tool-call deltas are accumulated by call_id.
+        """
+        kwargs = self._build_responses_kwargs(model, messages, tools)
+        kwargs["stream"] = True
+
+        accumulated_text = ""
+        tool_calls_acc: dict[str, dict] = {}
+        usage_info = None
+
+        stream = await self._client.responses.create(**kwargs)
+        async for event in stream:
+            event_type = getattr(event, "type", "")
+
+            if event_type == "response.output_text.delta":
+                delta = getattr(event, "delta", "") or ""
+                if delta:
+                    accumulated_text += delta
+                    try:
+                        await stream_callback(accumulated_text)
+                    except Exception:
+                        pass  # Never interrupt streaming
+
+            elif event_type == "response.output_item.added":
+                item = getattr(event, "item", None)
+                if item and getattr(item, "type", "") == "function_call":
+                    call_id = getattr(item, "call_id", "") or getattr(item, "id", "")
+                    if call_id:
+                        tool_calls_acc[call_id] = {
+                            "id": call_id,
+                            "name": getattr(item, "name", "") or "",
+                            "arguments": getattr(item, "arguments", "") or "",
+                        }
+
+            elif event_type == "response.function_call_arguments.delta":
+                call_id = getattr(event, "item_id", "") or getattr(event, "call_id", "")
+                delta = getattr(event, "delta", "") or ""
+                if call_id and delta and call_id in tool_calls_acc:
+                    tool_calls_acc[call_id]["arguments"] += delta
+
+            elif event_type == "response.completed":
+                final = getattr(event, "response", None)
+                usage_info = (
+                    self._extract_usage_responses(final, model) if final else None
+                )
+
+        # Parse accumulated tool call arguments
+        tool_calls: list[dict] | None = None
+        if tool_calls_acc:
+            tool_calls = []
+            for tc in tool_calls_acc.values():
+                try:
+                    tc["arguments"] = (
+                        json.loads(tc["arguments"]) if tc["arguments"] else {}
+                    )
                 except (json.JSONDecodeError, TypeError):
                     tc["arguments"] = {}
                 tool_calls.append(tc)


### PR DESCRIPTION
## Why

Reasoning models (`gpt-*-pro`, `o1`/`o3`/`o4`) reject calls on
`/v1/chat/completions` with HTTP 404 *"not a chat model"*. The backend
hardcoded `client.chat.completions.create()`, so any agent on
`gpt-5.5-pro` (or any other reasoning model) failed every request.

## What

`_call_unary` and `_call_streaming` are now thin dispatchers that
branch on `_uses_responses_api(model)`:

- name-pattern check: `-pro` suffix or `o[1-9]` prefix
- override via registry: per-model `endpoint: "responses"` wins when present

Added the parallel pair `_call_unary_responses` / `_call_streaming_responses`
plus a translator (`_build_responses_kwargs`) that maps the chat-style
message list + tools to the Responses schema:

- system role → `instructions`
- user/assistant text → `input` items of type `message`
- assistant tool calls → `input` items of type `function_call`
- tool role results → `input` items of type `function_call_output`
- tools list flattened from `{"type":"function","function":{...}}` to
  `{"type":"function", ...}` (Responses shape)

Streaming follows the typed event stream: `response.output_text.delta`
for incremental text, `response.output_item.added` +
`response.function_call_arguments.delta` for tool calls,
`response.completed` for the final usage block.

## Verified

Inline smoke test covering routing across:

| Model | Endpoint |
|---|---|
| `gpt-4.1` | chat ✓ |
| `gpt-4o` | chat ✓ |
| `gpt-5.5` | chat ✓ |
| `gpt-5-pro` | responses ✓ |
| `gpt-5.5-pro` | responses ✓ |
| `o1`, `o3-mini`, `o4-mini` | responses ✓ |

End-to-end run against a live gpt-5.5-pro key: tested locally by
sending a prompt through the agent and observing the call land on
`/v1/responses` with a streamed reply.

## Notes

Bug C (empty content for reasoning models on chat completions when the
budget is consumed entirely by reasoning) is a separate concern tracked
in its own task — that one is about `chat.completions` + reasoning
models that don't move to Responses, not about `gpt-*-pro`.