### PR TITLE
Fix Peggy empty replies in shared chats + Claude OAuth login error

### DIFF
--- a/core/mcp_gateway/server.py
+++ b/core/mcp_gateway/server.py
@@ -263,6 +263,14 @@ def _filter_by_user_mcp_permissions(tools: list[dict], unified_id: str) -> list[
         filtered = []
         for tool in tools:
             name = tool.get("name", "")
+            # Built-in virtual tools (handled inside the gateway, not by an
+            # external MCP server) are always allowed regardless of per-user
+            # permissions. Some are non-namespaced (gridbear_help, ask_agent…)
+            # and some are namespaced (conversation_docs__*, chat_history__*,
+            # credential_vault__*) — both shapes must bypass the filter.
+            if name.startswith(_BUILTIN_PREFIXES):
+                filtered.append(tool)
+                continue
             if ns_sep in name:
                 sanitized = name[: name.index(ns_sep)]
                 original = reverse_map.get(sanitized, sanitized)

--- a/plugins/claude/api/routes.py
+++ b/plugins/claude/api/routes.py
@@ -568,10 +568,18 @@ async def auth_submit_code(
         # to .credentials.json on-demand before each CLI spawn
         _save_credentials_to_secrets(oauth_block)
 
-        # Clear any stale auth error flag
-        import plugins.claude.runner as runner_mod
+        # Clear any stale auth error flag. Best-effort: the synthetic
+        # gridbear.plugins.claude namespace package set up by the MCP
+        # provider loader shadows plugins.claude with the runner.py file
+        # itself, which makes `import plugins.claude.runner` fail after
+        # the gateway has loaded the claude plugin. Don't let that block
+        # the successful login flow — credentials are already saved.
+        try:
+            import plugins.claude.runner as runner_mod
 
-        runner_mod._last_auth_error_at = 0.0
+            runner_mod._last_auth_error_at = 0.0
+        except ImportError as exc:
+            logger.debug("Could not reset auth error flag: %s", exc)
 
         logger.info("Claude OAuth login completed successfully")
         return api_ok()

--- a/sessions/context_builder.py
+++ b/sessions/context_builder.py
@@ -601,11 +601,12 @@ When sending emails as {self._agent_display_name or "yourself"}, ALWAYS append t
                     for p in self._channel_metadata["participants"]
                 )
                 source_parts.append(f"participants: {names}")
+                agent_handle = self._agent_name or "yourself"
                 source_parts.append(
                     "This is a shared conversation. When replying, "
                     "always start with @username of the person you are "
                     "responding to (e.g. @dcorio). "
-                    "You only respond when mentioned with @your_name."
+                    f"You only respond when mentioned with @{agent_handle}."
                 )
             parts.append("[Message Source]\n" + "\n".join(source_parts))
 


### PR DESCRIPTION
Three independent runtime bugs surfaced together while debugging Peggy. Each commit stands on its own and is safe to revert in isolation.

## Highlights

- **MCP gateway**: namespaced built-in virtual tools (`conversation_docs__*`, `chat_history__*`, `credential_vault__*`) were silently dropped for any user with an explicit row in `app.user_mcp_permissions`, because the per-user filter only exempted *non-namespaced* tools. They now share the same bypass list (`_BUILTIN_PREFIXES`) already used by the tool budget and the dispatch path.
- **Shared conversations**: the rule "You only respond when mentioned with `@your_name`" was a literal string, not an interpolation. Models following instructions literally compared `@your_name` to real `@peggy` mentions, found no match, and returned empty / garbled refusal sentinels. The rule is now interpolated with the agent's actual handle.
- **Claude OAuth login**: `POST /api/v1/claude/auth/code` returned HTTP 500 even though credentials had already been persisted, because a best-effort `import plugins.claude.runner` (used only to clear a stale error flag) fails after the MCP gateway has set up the synthetic `gridbear.plugins.claude` namespace. The reset is now wrapped in `try/except`.

## Follow-up

The namespace shadowing in `core/mcp_gateway/provider_loader.py:96-111` (registering the entry-point file as the package itself, plus aliasing `plugins.X` to the same module) is the root cause of fix 3 and a likely source of other latent import errors. Worth cleaning up in a separate PR after assessing blast radius across all plugins.