### PR TITLE
[ADD] ms365: read shared O365 documents (Graph Shares + text extraction)

### DIFF
--- a/plugins/ms365/admin/routes.py
+++ b/plugins/ms365/admin/routes.py
@@ -1,6 +1,7 @@
 """Microsoft 365 plugin admin routes."""
 
 import json
+import os
 import secrets
 from datetime import datetime
 
@@ -20,7 +21,7 @@ router = APIRouter(prefix="/plugins/ms365", tags=["ms365"])
 _MS365_DEFAULTS = {
     "client_id": "",
     "client_secret_env": "MS365_CLIENT_SECRET",
-    "redirect_uri": "http://localhost:8080/auth/ms365/callback",
+    "redirect_uri": "",
     "database_path": "data/ms365_tokens.db",
     "encryption_key_env": "MS365_ENCRYPTION_KEY",
     "health_check_interval": 300,
@@ -43,9 +44,23 @@ def _scopes_for_role(tenant_role: str) -> str:
     return _SCOPES_OWNER if tenant_role == "owner" else _SCOPES_GUEST
 
 
+def _default_redirect_uri() -> str:
+    """OAuth callback URL, derived from the deployment's public base URL.
+
+    Must point at the callback this router actually serves and be registered
+    verbatim in the Azure app registration: Azure compares it literally and
+    rejects the login otherwise.
+    """
+    base = os.getenv("GRIDBEAR_BASE_URL", "").rstrip("/") or "http://localhost:8088"
+    return f"{base}/plugins/ms365/callback"
+
+
 def get_ms365_config() -> dict:
     """Get MS365-specific configuration."""
-    return {**_MS365_DEFAULTS, **load_plugin_config("ms365")}
+    config = {**_MS365_DEFAULTS, **load_plugin_config("ms365")}
+    if not config.get("redirect_uri"):
+        config["redirect_uri"] = _default_redirect_uri()
+    return config
 
 
 def save_ms365_config(ms365_config: dict) -> None:
@@ -106,7 +121,7 @@ async def ms365_index(request: Request, user: dict = Depends(require_login)):
 async def save_settings(
     request: Request,
     client_id: str = Form(""),
-    redirect_uri: str = Form("http://localhost:8080/auth/ms365/callback"),
+    redirect_uri: str = Form(""),
     health_check_interval: int = Form(300),
     client_secret: str = Form(""),
     csrf_token: str = Form(...),
@@ -117,7 +132,7 @@ async def save_settings(
 
     config = get_ms365_config()
     config["client_id"] = client_id.strip()
-    config["redirect_uri"] = redirect_uri.strip()
+    config["redirect_uri"] = redirect_uri.strip() or _default_redirect_uri()
     config["health_check_interval"] = health_check_interval
     save_ms365_config(config)
 

--- a/plugins/ms365/admin/routes.py
+++ b/plugins/ms365/admin/routes.py
@@ -27,6 +27,21 @@ _MS365_DEFAULTS = {
     "tenants": [],
 }
 
+# Delegated scopes requested during the consent flow, per tenant role.
+# Files.Read.All covers files the user can access but does not own, which is what
+# the Graph Shares API needs to read documents shared by someone else; plain
+# Files.ReadWrite is limited to the user's own drive and 403s on shared items.
+_SCOPES_OWNER = (
+    "User.Read Files.ReadWrite Files.Read.All Tasks.ReadWrite "
+    "Sites.ReadWrite.All Group.Read.All offline_access"
+)
+_SCOPES_GUEST = "User.Read Files.ReadWrite.All Tasks.ReadWrite offline_access"
+
+
+def _scopes_for_role(tenant_role: str) -> str:
+    """Return the delegated scopes to request for a tenant role."""
+    return _SCOPES_OWNER if tenant_role == "owner" else _SCOPES_GUEST
+
 
 def get_ms365_config() -> dict:
     """Get MS365-specific configuration."""
@@ -266,10 +281,7 @@ async def start_oauth(
 
     state = secrets.token_urlsafe(32)
 
-    if tenant_role == "owner":
-        scopes = "User.Read Files.ReadWrite Tasks.ReadWrite Sites.ReadWrite.All Group.Read.All offline_access"
-    else:
-        scopes = "User.Read Files.ReadWrite.All Tasks.ReadWrite offline_access"
+    scopes = _scopes_for_role(tenant_role)
 
     _oauth_states[state] = {
         "tenant_name": tenant_name,

--- a/plugins/ms365/admin/routes.py
+++ b/plugins/ms365/admin/routes.py
@@ -328,8 +328,10 @@ async def oauth_callback(
 ):
     """Handle OAuth callback from Microsoft."""
     if error:
+        detail = error_description or error
+        logger.error("MS365 OAuth: authorization denied by Azure: %s", detail)
         return RedirectResponse(
-            url=f"/plugins/ms365?error={error_description or error}",
+            url=f"/plugins/ms365?error={detail[:100]}",
             status_code=303,
         )
 
@@ -378,6 +380,15 @@ async def oauth_callback(
 
         if "error" in result:
             error_msg = result.get("error_description", result.get("error", "Unknown"))
+            logger.error(
+                "MS365 OAuth: token exchange failed (tenant=%s authority=%s "
+                "redirect_uri=%s scopes=%s): %s",
+                tenant_name,
+                azure_authority,
+                redirect_uri,
+                " ".join(scopes_list),
+                error_msg,
+            )
             return RedirectResponse(
                 url=f"/plugins/ms365?error={error_msg[:100]}", status_code=303
             )
@@ -408,6 +419,7 @@ async def oauth_callback(
         )
 
     except Exception as e:
+        logger.exception("MS365 OAuth: callback failed for tenant=%s", tenant_name)
         return RedirectResponse(
             url=f"/plugins/ms365?error={str(e)[:100]}",
             status_code=303,

--- a/plugins/ms365/admin/templates/plugins/ms365.html
+++ b/plugins/ms365/admin/templates/plugins/ms365.html
@@ -64,7 +64,7 @@
                     <label class="block text-sm font-medium text-void-700 dark:text-void-200">Redirect URI</label>
                     <input type="text" name="redirect_uri" value="{{ redirect_uri }}"
                            class="w-full bg-void-50 dark:bg-void-800/50 border border-void-200 dark:border-void-700 rounded-xl py-2.5 px-4 text-void-900 dark:text-white focus:outline-none focus:border-frost-500/50 transition-all font-mono"
-                           placeholder="http://localhost:8080/auth/ms365/callback">
+                           placeholder="https://esempio.tld/plugins/ms365/callback">
                     <p class="text-sm text-void-500">
                         Must match the redirect URI configured in Azure AD
                     </p>

--- a/plugins/ms365/context.py
+++ b/plugins/ms365/context.py
@@ -23,6 +23,10 @@ You have access to Microsoft 365 services. Available operations:
 - m365_read_drive_file(tenant, file_path) - Read file from OneDrive
 - m365_write_drive_file(tenant, file_path, content) - Write file to OneDrive
 
+**Shared with me:**
+- m365_list_shared() - List documents shared with you (Shared with me)
+- m365_read_shared(sharing_url | drive_id, item_id) - Read a shared document's text
+
 Use tags in your response to execute operations:
 [M365_LIST_SITES tenant="tenant_name"]
 [M365_LIST_FILES tenant="tenant_name" site_id="..." folder_path="/Documents"]

--- a/plugins/ms365/extract.py
+++ b/plugins/ms365/extract.py
@@ -2,6 +2,11 @@
 Microsoft Graph sharing-URL encoding. No plugin state, no I/O."""
 
 import base64
+import io
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 def encode_sharing_url(url: str) -> str:
@@ -12,3 +17,60 @@ def encode_sharing_url(url: str) -> str:
     """
     b64 = base64.b64encode(url.encode("utf-8")).decode("ascii")
     return "u!" + b64.rstrip("=").replace("/", "_").replace("+", "-")
+
+
+_TEXT_EXTS = (".txt", ".md", ".csv", ".json", ".xml")
+
+
+def _truncate(text: str, max_chars: int) -> str:
+    if len(text) > max_chars:
+        return text[:max_chars] + "\n...(truncated)"
+    return text
+
+
+def extract_text(content: bytes, filename: str, max_chars: int = 200_000) -> str:
+    """Extract readable text from document bytes, sniffing by extension.
+
+    Never raises: parse errors and unsupported/empty inputs return a readable
+    note. `filename` is only used for the extension; `content` is the bytes.
+    """
+    ext = Path(filename).suffix.lower()
+
+    if ext in _TEXT_EXTS:
+        return _truncate(content.decode("utf-8", errors="replace"), max_chars)
+
+    if ext not in (".pdf", ".docx", ".xlsx", ".xls"):
+        return f"unsupported format ({ext or 'no extension'}) — cannot extract text"
+
+    bio = io.BytesIO(content)
+    try:
+        if ext == ".pdf":
+            from pypdf import PdfReader
+
+            reader = PdfReader(bio)
+            pages = [p.extract_text() for p in reader.pages]
+            text = "\n\n".join(p for p in pages if p)
+        elif ext == ".docx":
+            from docx import Document
+
+            doc = Document(bio)
+            text = "\n\n".join(p.text for p in doc.paragraphs if p.text)
+        else:  # .xlsx / .xls
+            from openpyxl import load_workbook
+
+            wb = load_workbook(bio, read_only=True, data_only=True)
+            lines = []
+            for sheet in wb.sheetnames:
+                ws = wb[sheet]
+                lines.append(f"[Sheet: {sheet}]")
+                for row in ws.iter_rows(values_only=True):
+                    lines.append("\t".join("" if c is None else str(c) for c in row))
+            wb.close()
+            text = "\n".join(lines)
+    except Exception as err:
+        logger.warning("ms365 extract_text failed for %s: %s", filename, err)
+        return f"could not parse {filename}: {type(err).__name__}: {err}"
+
+    if not text or not text.strip():
+        return "no extractable text (document may be image-only/scanned or empty)"
+    return _truncate(text, max_chars)

--- a/plugins/ms365/extract.py
+++ b/plugins/ms365/extract.py
@@ -1,0 +1,14 @@
+"""Pure helpers for the ms365 MCP server: Office/PDF text extraction and
+Microsoft Graph sharing-URL encoding. No plugin state, no I/O."""
+
+import base64
+
+
+def encode_sharing_url(url: str) -> str:
+    """Encode a sharing URL into a Graph shareId (already `u!`-prefixed).
+
+    Callers use it as `/shares/{enc}/driveItem` — NOT `/shares/u!{enc}` (that
+    would double the prefix to `u!u!…` and 400).
+    """
+    b64 = base64.b64encode(url.encode("utf-8")).decode("ascii")
+    return "u!" + b64.rstrip("=").replace("/", "_").replace("+", "-")

--- a/plugins/ms365/manifest.json
+++ b/plugins/ms365/manifest.json
@@ -70,7 +70,10 @@
   "dependencies": [
     "msal",
     "httpx",
-    "cryptography"
+    "cryptography",
+    "python-docx",
+    "openpyxl",
+    "pypdf"
   ],
   "private_only": true
 }

--- a/plugins/ms365/provider.py
+++ b/plugins/ms365/provider.py
@@ -167,6 +167,9 @@ class MS365Provider(BaseMCPProvider):
             "m365_list_drive_files",
             "m365_read_drive_file",
             "m365_write_drive_file",
+            # Shared with me
+            "m365_list_shared",
+            "m365_read_shared",
         ]
 
         allowed = []

--- a/plugins/ms365/server.py
+++ b/plugins/ms365/server.py
@@ -742,8 +742,17 @@ class MS365Server:
                     for it in data.get("value", []):
                         remote = it.get("remoteItem") or {}
                         parent = remote.get("parentReference") or {}
-                        created = remote.get("createdBy") or it.get("createdBy") or {}
-                        shared_by = (created.get("user") or {}).get("displayName")
+                        # Graph reports the sharer under shared.sharedBy on
+                        # sharedWithMe entries and leaves createdBy null there;
+                        # createdBy stays as a fallback for other shapes.
+                        shared = remote.get("shared") or {}
+                        sharer = (shared.get("sharedBy") or {}).get("user") or {}
+                        shared_by = sharer.get("displayName")
+                        if not shared_by:
+                            created = (
+                                remote.get("createdBy") or it.get("createdBy") or {}
+                            )
+                            shared_by = (created.get("user") or {}).get("displayName")
                         items.append(
                             {
                                 "name": it.get("name"),

--- a/plugins/ms365/server.py
+++ b/plugins/ms365/server.py
@@ -53,6 +53,23 @@ class SharedReadError(Exception):
     """Actionable, user-facing error from a shared-item read."""
 
 
+def _graph_error_message(err: Exception, action: str) -> str:
+    """Map a _graph_request exception to an actionable message.
+
+    NOTE: depends on _graph_request's message format
+    "Graph API error ({status}): {msg}". If that format changes, update this.
+    """
+    msg = str(err)
+    if "(403)" in msg:
+        return (
+            "access denied — the token likely lacks Files.Read.All; "
+            "re-authenticate this account with the broader scope"
+        )
+    if "(404)" in msg:
+        return "not found — link expired/revoked, or not shared to this account"
+    return f"{action} failed: {msg}"
+
+
 class MS365Server:
     """MCP server for Microsoft 365 operations."""
 
@@ -704,29 +721,8 @@ class MS365Server:
                 return {"success": True, "content": text, "name": fname}
             except SharedReadError as err:
                 return {"success": False, "error": str(err)}
-            # NOTE: status-code detection below depends on _graph_request's
-            # exception message format: "Graph API error ({status}): {msg}".
-            # If that format changes, update these substring checks.
             except Exception as err:
-                msg = str(err)
-                if "(403)" in msg:
-                    return {
-                        "success": False,
-                        "error": (
-                            "access denied — the token likely lacks "
-                            "Files.Read.All; re-authenticate this account "
-                            "with the broader scope"
-                        ),
-                    }
-                if "(404)" in msg:
-                    return {
-                        "success": False,
-                        "error": (
-                            "shared item not found — link expired/revoked, "
-                            "or not shared to this account"
-                        ),
-                    }
-                return {"success": False, "error": f"read failed: {msg}"}
+                return {"success": False, "error": _graph_error_message(err, "read")}
 
         elif name == "m365_list_shared":
             items = []
@@ -769,21 +765,8 @@ class MS365Server:
                     "items": items,
                     "truncated": truncated,
                 }
-            # NOTE: status-code detection below depends on _graph_request's
-            # exception message format: "Graph API error ({status}): {msg}".
-            # If that format changes, update these substring checks.
             except Exception as err:
-                msg = str(err)
-                if "(403)" in msg:
-                    return {
-                        "success": False,
-                        "error": (
-                            "access denied — the token likely lacks "
-                            "Files.Read.All; re-authenticate this account "
-                            "with the broader scope"
-                        ),
-                    }
-                return {"success": False, "error": f"list failed: {msg}"}
+                return {"success": False, "error": _graph_error_message(err, "list")}
 
         elif name == "m365_write_file":
             site_id = args["site_id"]

--- a/plugins/ms365/server.py
+++ b/plugins/ms365/server.py
@@ -38,6 +38,8 @@ ROLE = os.environ.get("MS365_ROLE", "guest")
 
 GRAPH_API_BASE = "https://graph.microsoft.com/v1.0"
 MAX_INLINE_READ_BYTES = 50 * 1024 * 1024
+_SHARED_MAX_ITEMS = 200
+_SHARED_MAX_PAGES = 5
 STATE_FILE = Path("/app/data/ms365_context.json")
 
 # Parse token data
@@ -181,6 +183,14 @@ class MS365Server:
                             },
                         },
                     },
+                ),
+                Tool(
+                    name="m365_list_shared",
+                    description=(
+                        "List documents shared WITH the user (Shared with me). "
+                        "Returns items with drive_id/item_id to pass to m365_read_shared."
+                    ),
+                    inputSchema={"type": "object", "properties": {}},
                 ),
                 Tool(
                     name="m365_write_file",
@@ -720,6 +730,63 @@ class MS365Server:
                         ),
                     }
                 return {"success": False, "error": f"read failed: {msg}"}
+
+        elif name == "m365_list_shared":
+            items = []
+            truncated = False
+            endpoint = "/me/drive/sharedWithMe"
+            try:
+                for _page in range(_SHARED_MAX_PAGES):
+                    data = await self._graph_request("GET", endpoint)
+                    if not isinstance(data, dict):
+                        break
+                    for it in data.get("value", []):
+                        remote = it.get("remoteItem") or {}
+                        parent = remote.get("parentReference") or {}
+                        created = remote.get("createdBy") or it.get("createdBy") or {}
+                        shared_by = (created.get("user") or {}).get("displayName")
+                        items.append(
+                            {
+                                "name": it.get("name"),
+                                "shared_by": shared_by,
+                                "last_modified": it.get("lastModifiedDateTime"),
+                                "drive_id": parent.get("driveId"),
+                                "item_id": remote.get("id"),
+                                "web_url": it.get("webUrl"),
+                                "is_folder": remote.get("folder") is not None,
+                            }
+                        )
+                        if len(items) >= _SHARED_MAX_ITEMS:
+                            truncated = True
+                            break
+                    next_link = data.get("@odata.nextLink")
+                    if truncated or not next_link:
+                        break
+                    endpoint = next_link  # absolute URL — httpx uses it as-is
+                else:
+                    # loop ran the full page cap without a break → more pages exist
+                    truncated = True
+                return {
+                    "success": True,
+                    "count": len(items),
+                    "items": items,
+                    "truncated": truncated,
+                }
+            # NOTE: status-code detection below depends on _graph_request's
+            # exception message format: "Graph API error ({status}): {msg}".
+            # If that format changes, update these substring checks.
+            except Exception as err:
+                msg = str(err)
+                if "(403)" in msg:
+                    return {
+                        "success": False,
+                        "error": (
+                            "access denied — the token likely lacks "
+                            "Files.Read.All; re-authenticate this account "
+                            "with the broader scope"
+                        ),
+                    }
+                return {"success": False, "error": f"list failed: {msg}"}
 
         elif name == "m365_write_file":
             site_id = args["site_id"]

--- a/plugins/ms365/server.py
+++ b/plugins/ms365/server.py
@@ -68,8 +68,10 @@ def _graph_error_message(err: Exception, action: str) -> str:
     msg = str(err)
     if "(403)" in msg:
         return (
-            "access denied — the token likely lacks Files.Read.All; "
-            "re-authenticate this account with the broader scope"
+            "access denied — either this account lacks Files.Read.All "
+            "(re-authenticate it with the broader scope), or the item lives in "
+            "another tenant where the access is a guest grant, which a token "
+            "issued by this account's own tenant cannot use"
         )
     if "(404)" in msg:
         return "not found — link expired/revoked, or not shared to this account"

--- a/plugins/ms365/server.py
+++ b/plugins/ms365/server.py
@@ -664,14 +664,11 @@ class MS365Server:
             if isinstance(content, bytes):
                 try:
                     text = content.decode("utf-8")
-                    if len(text) > 10000:
-                        text = text[:10000] + "\n...(truncated)"
-                    return {"success": True, "content": text, "file_path": file_path}
+                    if len(text) > 50_000:
+                        text = text[:50_000] + "\n...(truncated)"
                 except UnicodeDecodeError:
-                    return {
-                        "success": False,
-                        "error": "Binary file cannot be displayed as text",
-                    }
+                    text = extract_text(content, file_path, max_chars=50_000)
+                return {"success": True, "content": text, "file_path": file_path}
             return {"success": False, "error": "Could not read file"}
 
         elif name == "m365_read_shared":
@@ -1082,11 +1079,11 @@ class MS365Server:
             if isinstance(content, bytes):
                 try:
                     text = content.decode("utf-8")
-                    if len(text) > 10000:
-                        text = text[:10000] + "\n...(truncated)"
-                    return {"success": True, "content": text, "file_path": file_path}
+                    if len(text) > 50_000:
+                        text = text[:50_000] + "\n...(truncated)"
                 except UnicodeDecodeError:
-                    return {"success": False, "error": "Binary file"}
+                    text = extract_text(content, file_path, max_chars=50_000)
+                return {"success": True, "content": text, "file_path": file_path}
             return {"success": False, "error": "Could not read file"}
 
         elif name == "m365_write_drive_file":

--- a/plugins/ms365/server.py
+++ b/plugins/ms365/server.py
@@ -35,6 +35,7 @@ TOKEN_DATA = os.environ.get("MS365_TOKEN_DATA", "{}")
 ROLE = os.environ.get("MS365_ROLE", "guest")
 
 GRAPH_API_BASE = "https://graph.microsoft.com/v1.0"
+MAX_INLINE_READ_BYTES = 50 * 1024 * 1024
 STATE_FILE = Path("/app/data/ms365_context.json")
 
 # Parse token data
@@ -42,6 +43,10 @@ try:
     token_info = json.loads(TOKEN_DATA)
 except json.JSONDecodeError:
     token_info = {}
+
+
+class SharedReadError(Exception):
+    """Actionable, user-facing error from a shared-item read."""
 
 
 class MS365Server:
@@ -459,6 +464,60 @@ class MS365Server:
         if "application/json" in content_type_header:
             return response.json()
         return response.content
+
+    async def _download_stream(
+        self, url: str, max_bytes: int = MAX_INLINE_READ_BYTES
+    ) -> bytes:
+        """Download a pre-authenticated URL with NO auth header, streaming with a
+        size guard. Aborts as soon as the running byte count exceeds max_bytes."""
+        buf = bytearray()
+        async with httpx.AsyncClient(follow_redirects=True, timeout=60.0) as client:
+            async with client.stream("GET", url) as resp:
+                if resp.status_code >= 400:
+                    raise SharedReadError(f"download failed (HTTP {resp.status_code})")
+                clen = resp.headers.get("content-length")
+                if clen and clen.isdigit() and int(clen) > max_bytes:
+                    raise SharedReadError(
+                        f"file too large (>{max_bytes // (1024 * 1024)} MB) "
+                        "to read inline"
+                    )
+                async for chunk in resp.aiter_bytes():
+                    buf.extend(chunk)
+                    if len(buf) > max_bytes:
+                        raise SharedReadError(
+                            f"file too large (>{max_bytes // (1024 * 1024)} MB) "
+                            "to read inline"
+                        )
+        return bytes(buf)
+
+    async def _read_item(self, metadata: dict) -> tuple[bytes, str]:
+        """From a resolved driveItem's metadata, return (content_bytes, filename).
+        Guards folders; downloads via the pre-authenticated downloadUrl."""
+        if metadata.get("folder") is not None:
+            raise SharedReadError("shared item is a folder, not a readable document")
+        name = metadata.get("name", "file")
+        download_url = metadata.get("@microsoft.graph.downloadUrl")
+        if download_url:
+            return await self._download_stream(download_url), name
+        # Fallback (rare): a file with no downloadUrl. Fetch /content without
+        # following the redirect, read the 302 Location, download it unauthenticated.
+        drive_id = (metadata.get("parentReference") or {}).get("driveId")
+        item_id = metadata.get("id")
+        if drive_id and item_id:
+            token = await self._get_valid_token()
+            async with httpx.AsyncClient(
+                base_url=GRAPH_API_BASE, follow_redirects=False, timeout=30.0
+            ) as client:
+                resp = await client.get(
+                    f"/drives/{drive_id}/items/{item_id}/content",
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+            if resp.status_code >= 400:
+                raise SharedReadError(f"cannot read item (HTTP {resp.status_code})")
+            loc = resp.headers.get("location")
+            if loc:
+                return await self._download_stream(loc), name
+        raise SharedReadError("cannot read this item (no download URL available)")
 
     async def _call_tool_impl(self, name: str, args: dict) -> dict:
         """Execute tool and return result."""

--- a/plugins/ms365/server.py
+++ b/plugins/ms365/server.py
@@ -16,6 +16,8 @@ from typing import Any
 import httpx
 import msal
 
+from plugins.ms365.extract import encode_sharing_url, extract_text
+
 # MCP server imports
 try:
     from mcp.server import Server
@@ -153,6 +155,31 @@ class MS365Server:
                             },
                         },
                         "required": ["site_id", "file_path"],
+                    },
+                ),
+                Tool(
+                    name="m365_read_shared",
+                    description=(
+                        "Read a document SHARED WITH the user — by share link "
+                        "(from email) or by drive_id+item_id from m365_list_shared. "
+                        "Returns extracted text for Word/Excel/PDF."
+                    ),
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "sharing_url": {
+                                "type": "string",
+                                "description": "Share link URL (from an email/message)",
+                            },
+                            "drive_id": {
+                                "type": "string",
+                                "description": "Drive ID (from m365_list_shared)",
+                            },
+                            "item_id": {
+                                "type": "string",
+                                "description": "Item ID (from m365_list_shared)",
+                            },
+                        },
                     },
                 ),
                 Tool(
@@ -636,6 +663,63 @@ class MS365Server:
                         "error": "Binary file cannot be displayed as text",
                     }
             return {"success": False, "error": "Could not read file"}
+
+        elif name == "m365_read_shared":
+            sharing_url = args.get("sharing_url")
+            drive_id = args.get("drive_id")
+            item_id = args.get("item_id")
+            has_pair = bool(drive_id) and bool(item_id)
+            if sharing_url and (drive_id or item_id):
+                return {
+                    "success": False,
+                    "error": "provide only one of: sharing_url, or drive_id+item_id",
+                }
+            if not sharing_url and (bool(drive_id) != bool(item_id)):
+                return {
+                    "success": False,
+                    "error": "drive_id and item_id must be supplied together",
+                }
+            if not sharing_url and not has_pair:
+                return {
+                    "success": False,
+                    "error": "provide either sharing_url or both drive_id and item_id",
+                }
+            try:
+                if sharing_url:
+                    endpoint = f"/shares/{encode_sharing_url(sharing_url)}/driveItem"
+                else:
+                    endpoint = f"/drives/{drive_id}/items/{item_id}"
+                metadata = await self._graph_request("GET", endpoint)
+                if not isinstance(metadata, dict):
+                    return {"success": False, "error": "could not resolve shared item"}
+                content, fname = await self._read_item(metadata)
+                text = extract_text(content, fname, max_chars=50_000)
+                return {"success": True, "content": text, "name": fname}
+            except SharedReadError as err:
+                return {"success": False, "error": str(err)}
+            # NOTE: status-code detection below depends on _graph_request's
+            # exception message format: "Graph API error ({status}): {msg}".
+            # If that format changes, update these substring checks.
+            except Exception as err:
+                msg = str(err)
+                if "(403)" in msg:
+                    return {
+                        "success": False,
+                        "error": (
+                            "access denied — the token likely lacks "
+                            "Files.Read.All; re-authenticate this account "
+                            "with the broader scope"
+                        ),
+                    }
+                if "(404)" in msg:
+                    return {
+                        "success": False,
+                        "error": (
+                            "shared item not found — link expired/revoked, "
+                            "or not shared to this account"
+                        ),
+                    }
+                return {"success": False, "error": f"read failed: {msg}"}
 
         elif name == "m365_write_file":
             site_id = args["site_id"]

--- a/plugins/ms365/server.py
+++ b/plugins/ms365/server.py
@@ -585,8 +585,12 @@ class MS365Server:
         # SharePoint tools
         if name == "m365_list_sites":
             search = args.get("search", "*")
+            # search goes through params, not the path: httpx replaces a URL's
+            # existing query when params is given, which silently dropped the
+            # term and made every listing come back empty. Passing it here also
+            # encodes terms containing & or spaces.
             result = await self._graph_request(
-                "GET", f"/sites?search={search}", params={"$top": "50"}
+                "GET", "/sites", params={"search": search, "$top": "50"}
             )
             if isinstance(result, dict) and "value" in result:
                 sites = [

--- a/plugins/ms365/server.py
+++ b/plugins/ms365/server.py
@@ -16,6 +16,12 @@ from typing import Any
 import httpx
 import msal
 
+# Launched as a bare script by provider.get_server_config, so the repo root is
+# not on sys.path. Add it before importing sibling plugin modules.
+_REPO_ROOT = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
 from plugins.ms365.extract import encode_sharing_url, extract_text
 
 # MCP server imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "psycopg[binary]>=3.3.3",
     "psycopg_pool>=3.1",
     # MCP protocol + primary runner
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2.0.0",
     "anthropic>=0.94.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ google = [
 ]
 ms365 = [
     "msal>=1.36.0",
+    "openpyxl>=3.1.0",
+    "pypdf>=4.0.0",
+    "python-docx>=1.2.0",
 ]
 livekit = [
     "livekit>=1.0.0",

--- a/tests/unit/plugins/ms365/test_extract.py
+++ b/tests/unit/plugins/ms365/test_extract.py
@@ -1,4 +1,6 @@
-from plugins.ms365.extract import encode_sharing_url
+import io
+
+from plugins.ms365.extract import encode_sharing_url, extract_text
 
 
 def test_encode_sharing_url_microsoft_example():
@@ -16,3 +18,75 @@ def test_encode_sharing_url_is_url_safe_and_unpadded():
     assert enc.startswith("u!")
     body = enc[2:]
     assert "+" not in body and "/" not in body and "=" not in body
+
+
+def _docx_bytes(paragraphs):
+    from docx import Document
+
+    doc = Document()
+    for p in paragraphs:
+        doc.add_paragraph(p)
+    buf = io.BytesIO()
+    doc.save(buf)
+    return buf.getvalue()
+
+
+def _xlsx_bytes(rows):
+    from openpyxl import Workbook
+
+    wb = Workbook()
+    ws = wb.active
+    for row in rows:
+        ws.append(row)
+    buf = io.BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+def test_extract_docx():
+    out = extract_text(_docx_bytes(["Hello world", "Second line"]), "shared.docx")
+    assert "Hello world" in out and "Second line" in out
+
+
+def test_extract_xlsx():
+    out = extract_text(_xlsx_bytes([["Name", "Qty"], ["Widget", 5]]), "sheet.xlsx")
+    assert "Name" in out and "Widget" in out and "5" in out
+
+
+def test_extract_txt():
+    assert extract_text(b"plain text here", "notes.txt") == "plain text here"
+
+
+def test_extract_uppercase_extension_g5():
+    out = extract_text(_docx_bytes(["Case test"]), "SHARED.DOCX")
+    assert "Case test" in out
+
+
+def test_extract_unsupported_format():
+    png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+    out = extract_text(png, "image.png")
+    assert "unsupported format" in out.lower() and ".png" in out
+
+
+def test_extract_empty_docx_g4():
+    out = extract_text(_docx_bytes([]), "empty.docx")
+    assert out != ""
+    assert "no extractable text" in out.lower()
+
+
+def test_extract_corrupt_docx_returns_note():
+    out = extract_text(b"not a real docx", "broken.docx")
+    assert out != ""
+    assert "broken.docx" in out
+
+
+def test_extract_no_extension_and_dotfile():
+    assert "no extension" in extract_text(b"data", "README").lower()
+    assert "no extension" in extract_text(b"data", ".bashrc").lower()
+
+
+def test_extract_truncation_marker():
+    big = "x" * 300
+    out = extract_text(big.encode(), "big.txt", max_chars=100)
+    assert out.endswith("...(truncated)")
+    assert len(out) <= 100 + len("\n...(truncated)")

--- a/tests/unit/plugins/ms365/test_extract.py
+++ b/tests/unit/plugins/ms365/test_extract.py
@@ -1,0 +1,18 @@
+from plugins.ms365.extract import encode_sharing_url
+
+
+def test_encode_sharing_url_microsoft_example():
+    # From Microsoft Graph docs: this exact URL encodes to this exact shareId.
+    url = "https://onedrive.live.com/redir?resid=1231244193912!12&authKey=Foo"
+    assert (
+        encode_sharing_url(url)
+        == "u!aHR0cHM6Ly9vbmVkcml2ZS5saXZlLmNvbS9yZWRpcj9yZXNpZD0xMjMxMjQ0MTkzOTEyITEyJmF1dGhLZXk9Rm9v"
+    )
+
+
+def test_encode_sharing_url_is_url_safe_and_unpadded():
+    # A URL whose base64 contains '+' and '/' must come back with '-'/'_' and no '='.
+    enc = encode_sharing_url("https://x/??>>>")  # base64 of this contains + and /
+    assert enc.startswith("u!")
+    body = enc[2:]
+    assert "+" not in body and "/" not in body and "=" not in body

--- a/tests/unit/plugins/ms365/test_oauth_redirect_uri.py
+++ b/tests/unit/plugins/ms365/test_oauth_redirect_uri.py
@@ -1,0 +1,63 @@
+"""Default OAuth redirect URI for the MS365 consent flow.
+
+Azure matches the redirect URI verbatim against the app registration, so a
+default pointing at a route this router does not serve can never complete a
+login. The callback is served at /plugins/ms365/callback.
+"""
+
+import plugins.ms365.admin.routes as routes
+
+
+def test_default_redirect_uri_targets_the_real_callback_route():
+    assert routes._default_redirect_uri().endswith("/plugins/ms365/callback")
+
+
+def test_default_redirect_uri_uses_configured_base_url(monkeypatch):
+    monkeypatch.setenv("GRIDBEAR_BASE_URL", "https://gridbear.example.com")
+    assert (
+        routes._default_redirect_uri()
+        == "https://gridbear.example.com/plugins/ms365/callback"
+    )
+
+
+def test_default_redirect_uri_tolerates_trailing_slash(monkeypatch):
+    monkeypatch.setenv("GRIDBEAR_BASE_URL", "https://gridbear.example.com/")
+    assert (
+        routes._default_redirect_uri()
+        == "https://gridbear.example.com/plugins/ms365/callback"
+    )
+
+
+def test_default_redirect_uri_falls_back_when_base_url_unset(monkeypatch):
+    monkeypatch.delenv("GRIDBEAR_BASE_URL", raising=False)
+    assert routes._default_redirect_uri().startswith("http://localhost:")
+
+
+def test_config_fills_redirect_uri_when_never_configured(monkeypatch):
+    monkeypatch.setenv("GRIDBEAR_BASE_URL", "https://gridbear.example.com")
+    monkeypatch.setattr(routes, "load_plugin_config", lambda _name: {})
+    assert (
+        routes.get_ms365_config()["redirect_uri"]
+        == "https://gridbear.example.com/plugins/ms365/callback"
+    )
+
+
+def test_config_fills_redirect_uri_when_stored_value_is_blank(monkeypatch):
+    monkeypatch.setenv("GRIDBEAR_BASE_URL", "https://gridbear.example.com")
+    monkeypatch.setattr(
+        routes, "load_plugin_config", lambda _name: {"redirect_uri": ""}
+    )
+    assert (
+        routes.get_ms365_config()["redirect_uri"]
+        == "https://gridbear.example.com/plugins/ms365/callback"
+    )
+
+
+def test_config_preserves_an_explicitly_configured_redirect_uri(monkeypatch):
+    monkeypatch.setenv("GRIDBEAR_BASE_URL", "https://gridbear.example.com")
+    monkeypatch.setattr(
+        routes,
+        "load_plugin_config",
+        lambda _name: {"redirect_uri": "https://custom.example.org/cb"},
+    )
+    assert routes.get_ms365_config()["redirect_uri"] == "https://custom.example.org/cb"

--- a/tests/unit/plugins/ms365/test_oauth_scopes.py
+++ b/tests/unit/plugins/ms365/test_oauth_scopes.py
@@ -1,0 +1,39 @@
+"""OAuth delegated scopes requested during the MS365 consent flow.
+
+Reading documents shared BY OTHERS goes through the Graph Shares API, which
+requires a scope covering files the user can access but does not own. Plain
+``Files.ReadWrite`` only covers the user's own drive, so a token minted without
+``.All`` coverage gets a 403 on every shared item.
+"""
+
+import plugins.ms365.admin.routes as routes
+
+
+def test_owner_scopes_allow_reading_shared_documents():
+    assert "Files.Read.All" in routes._scopes_for_role("owner")
+
+
+def test_guest_scopes_allow_reading_shared_documents():
+    # Files.ReadWrite.All subsumes Files.Read.All.
+    assert "Files.ReadWrite.All" in routes._scopes_for_role("guest")
+
+
+def test_owner_scopes_keep_existing_grants():
+    scopes = routes._scopes_for_role("owner").split()
+    for required in (
+        "User.Read",
+        "Files.ReadWrite",
+        "Tasks.ReadWrite",
+        "Sites.ReadWrite.All",
+        "Group.Read.All",
+    ):
+        assert required in scopes
+
+
+def test_both_roles_request_offline_access_for_silent_refresh():
+    assert "offline_access" in routes._scopes_for_role("owner")
+    assert "offline_access" in routes._scopes_for_role("guest")
+
+
+def test_unknown_role_falls_back_to_guest_scopes():
+    assert routes._scopes_for_role("nonsense") == routes._scopes_for_role("guest")

--- a/tests/unit/plugins/ms365/test_server_entrypoint.py
+++ b/tests/unit/plugins/ms365/test_server_entrypoint.py
@@ -1,0 +1,36 @@
+"""The MCP server must survive being launched the way the provider launches it.
+
+provider.get_server_config spawns it as a bare script (``python .../server.py``),
+so the repo root is not on sys.path. Importing it as a package — which every
+other test does — cannot catch a failure in that mode.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+SERVER = Path(__file__).resolve().parents[4] / "plugins" / "ms365" / "server.py"
+
+
+def _run_as_script(timeout=20):
+    """Spawn server.py exactly as the provider does; return its stderr."""
+    proc = subprocess.Popen(
+        [sys.executable, str(SERVER)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=str(SERVER.parent),
+    )
+    try:
+        _, err = proc.communicate(input="", timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        _, err = proc.communicate()
+    return err
+
+
+def test_server_script_resolves_its_sibling_imports():
+    err = _run_as_script()
+    assert "ModuleNotFoundError" not in err, err
+    assert "No module named 'plugins'" not in err, err

--- a/tests/unit/plugins/ms365/test_shared_tools.py
+++ b/tests/unit/plugins/ms365/test_shared_tools.py
@@ -403,3 +403,38 @@ async def test_list_shared_survives_a_share_block_without_an_identity():
     s._graph_request = AsyncMock(return_value={"value": [item]})
     res = await s._call_tool_impl("m365_list_shared", {})
     assert res["success"] is True and res["items"][0]["shared_by"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_sites_keeps_the_search_term_in_the_request():
+    """httpx drops a URL's existing query when params= is also given.
+
+    Asserting the call shape is not enough — the check has to go through the
+    request httpx actually builds, which is where the term was being lost.
+    """
+    import httpx
+
+    s = _server()
+    s._graph_request = AsyncMock(return_value={"value": []})
+    await s._call_tool_impl("m365_list_sites", {"search": "Contoso"})
+
+    call_args, call_kwargs = s._graph_request.call_args
+    built = httpx.Client(base_url="https://graph.microsoft.com/v1.0").build_request(
+        call_args[0], call_args[1], params=call_kwargs.get("params")
+    )
+    assert "search=Contoso" in str(built.url), str(built.url)
+
+
+@pytest.mark.asyncio
+async def test_list_sites_encodes_a_search_term_with_special_characters():
+    import httpx
+
+    s = _server()
+    s._graph_request = AsyncMock(return_value={"value": []})
+    await s._call_tool_impl("m365_list_sites", {"search": "R&D team"})
+
+    call_args, call_kwargs = s._graph_request.call_args
+    built = httpx.Client(base_url="https://graph.microsoft.com/v1.0").build_request(
+        call_args[0], call_args[1], params=call_kwargs.get("params")
+    )
+    assert "R%26D" in str(built.url), str(built.url)

--- a/tests/unit/plugins/ms365/test_shared_tools.py
+++ b/tests/unit/plugins/ms365/test_shared_tools.py
@@ -357,3 +357,49 @@ async def test_read_shared_404_message():
     s._graph_request = AsyncMock(side_effect=Exception("Graph API error (404): gone"))
     res = await s._call_tool_impl("m365_read_shared", {"sharing_url": "https://s/d"})
     assert res["success"] is False and "not found" in res["error"]
+
+
+def _shared_item_graph_shape(name, drive, item, sharer="Alice Example"):
+    """Shape /me/drive/sharedWithMe actually returns (captured from live Graph).
+
+    Graph leaves createdBy null on these entries and reports the sharer under
+    remoteItem.shared.sharedBy, so a fixture modelled on createdBy alone cannot
+    tell whether the mapping works.
+    """
+    return {
+        "name": name,
+        "webUrl": f"https://w/{item}",
+        "lastModifiedDateTime": "2026-06-17T09:46:26Z",
+        "createdBy": None,
+        "remoteItem": {
+            "id": item,
+            "parentReference": {"driveId": drive},
+            "createdBy": None,
+            "lastModifiedBy": None,
+            "shared": {
+                "scope": "users",
+                "sharedDateTime": "2026-06-17T09:47:00Z",
+                "sharedBy": {"user": {"displayName": sharer}},
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_shared_reports_who_shared_the_item():
+    s = _server()
+    s._graph_request = AsyncMock(
+        return_value={"value": [_shared_item_graph_shape("a.docx", "D", "I1")]}
+    )
+    res = await s._call_tool_impl("m365_list_shared", {})
+    assert res["items"][0]["shared_by"] == "Alice Example"
+
+
+@pytest.mark.asyncio
+async def test_list_shared_survives_a_share_block_without_an_identity():
+    s = _server()
+    item = _shared_item_graph_shape("a.docx", "D", "I1")
+    item["remoteItem"]["shared"] = {"scope": "anonymous"}
+    s._graph_request = AsyncMock(return_value={"value": [item]})
+    res = await s._call_tool_impl("m365_list_shared", {})
+    assert res["success"] is True and res["items"][0]["shared_by"] is None

--- a/tests/unit/plugins/ms365/test_shared_tools.py
+++ b/tests/unit/plugins/ms365/test_shared_tools.py
@@ -336,3 +336,24 @@ def test_new_tools_in_provider_allowlist():
     allowed = provider.get_allowed_tools()
     assert "mcp__ms365-test__m365_list_shared" in allowed
     assert "mcp__ms365-test__m365_read_shared" in allowed
+
+
+def test_graph_error_message_helper():
+    assert "Files.Read.All" in srv._graph_error_message(
+        Exception("Graph API error (403): x"), "read"
+    )
+    assert "not found" in srv._graph_error_message(
+        Exception("Graph API error (404): x"), "read"
+    )
+    assert (
+        srv._graph_error_message(Exception("Graph API error (500): boom"), "list")
+        == "list failed: Graph API error (500): boom"
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_shared_404_message():
+    s = _server()
+    s._graph_request = AsyncMock(side_effect=Exception("Graph API error (404): gone"))
+    res = await s._call_tool_impl("m365_read_shared", {"sharing_url": "https://s/d"})
+    assert res["success"] is False and "not found" in res["error"]

--- a/tests/unit/plugins/ms365/test_shared_tools.py
+++ b/tests/unit/plugins/ms365/test_shared_tools.py
@@ -190,3 +190,89 @@ async def test_read_shared_403_scope_message():
     s._graph_request = AsyncMock(side_effect=Exception("Graph API error (403): denied"))
     res = await s._call_tool_impl("m365_read_shared", {"sharing_url": "https://s/d"})
     assert res["success"] is False and "Files.Read.All" in res["error"]
+
+
+def _shared_item(name, drive, item, folder=False):
+    it = {
+        "name": name,
+        "webUrl": f"https://w/{item}",
+        "lastModifiedDateTime": "2026-07-20T10:00:00Z",
+        "remoteItem": {
+            "id": item,
+            "parentReference": {"driveId": drive},
+            "createdBy": {"user": {"displayName": "Alice"}},
+        },
+    }
+    if folder:
+        it["remoteItem"]["folder"] = {"childCount": 1}
+    return it
+
+
+@pytest.mark.asyncio
+async def test_list_shared_single_page():
+    s = _server()
+    s._graph_request = AsyncMock(
+        return_value={"value": [_shared_item("a.docx", "D", "I1")]}
+    )
+    res = await s._call_tool_impl("m365_list_shared", {})
+    assert res["success"] is True and res["count"] == 1
+    row = res["items"][0]
+    assert row["name"] == "a.docx" and row["drive_id"] == "D" and row["item_id"] == "I1"
+    assert row["is_folder"] is False and row["shared_by"] == "Alice"
+
+
+@pytest.mark.asyncio
+async def test_list_shared_follows_nextlink():
+    s = _server()
+    page1 = {
+        "value": [_shared_item("a", "D", "I1")],
+        "@odata.nextLink": "https://graph.microsoft.com/v1.0/me/drive/sharedWithMe?$skip=1",
+    }
+    page2 = {"value": [_shared_item("b", "D", "I2")]}
+    s._graph_request = AsyncMock(side_effect=[page1, page2])
+    res = await s._call_tool_impl("m365_list_shared", {})
+    assert res["count"] == 2 and res.get("truncated") is not True
+    assert s._graph_request.call_args_list[1][0][1].startswith(
+        "https://graph.microsoft.com"
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_shared_truncates_at_cap(monkeypatch):
+    s = _server()
+    monkeypatch.setattr(srv, "_SHARED_MAX_PAGES", 2)
+    page = {
+        "value": [_shared_item("x", "D", "I")],
+        "@odata.nextLink": "https://graph.microsoft.com/v1.0/next",
+    }
+    s._graph_request = AsyncMock(return_value=page)  # always returns a nextLink
+    res = await s._call_tool_impl("m365_list_shared", {})
+    assert res["truncated"] is True
+    assert s._graph_request.call_count == 2  # stopped at the page cap
+
+
+@pytest.mark.asyncio
+async def test_list_shared_null_fields_robust():
+    s = _server()
+    s._graph_request = AsyncMock(
+        return_value={
+            "value": [
+                {
+                    "name": "x",
+                    "remoteItem": {
+                        "id": "I",
+                        "parentReference": None,
+                        "createdBy": None,
+                    },
+                }
+            ]
+        }
+    )
+    res = await s._call_tool_impl("m365_list_shared", {})
+    assert res["success"] is True and res["count"] == 1
+    row = res["items"][0]
+    assert (
+        row["drive_id"] is None
+        and row["shared_by"] is None
+        and row["is_folder"] is False
+    )

--- a/tests/unit/plugins/ms365/test_shared_tools.py
+++ b/tests/unit/plugins/ms365/test_shared_tools.py
@@ -326,3 +326,13 @@ async def test_read_file_plain_text_preserved():
         "m365_read_file", {"site_id": "S", "file_path": "/app.py"}
     )
     assert res["success"] is True and "print('hello')" in res["content"]
+
+
+def test_new_tools_in_provider_allowlist():
+    from plugins.ms365.provider import MS365Provider
+
+    provider = MS365Provider({"client_id": "x"})
+    provider._server_names = ["ms365-test"]
+    allowed = provider.get_allowed_tools()
+    assert "mcp__ms365-test__m365_list_shared" in allowed
+    assert "mcp__ms365-test__m365_read_shared" in allowed

--- a/tests/unit/plugins/ms365/test_shared_tools.py
+++ b/tests/unit/plugins/ms365/test_shared_tools.py
@@ -120,3 +120,73 @@ async def test_read_item_fallback_error_status(monkeypatch):
         await s._read_item(
             {"name": "f.pdf", "id": "I1", "parentReference": {"driveId": "D1"}}
         )
+
+
+@pytest.mark.asyncio
+async def test_read_shared_by_link(monkeypatch):
+    s = _server()
+    s._graph_request = AsyncMock(
+        return_value={
+            "name": "plan.docx",
+            "@microsoft.graph.downloadUrl": "https://dl/p",
+        }
+    )
+    monkeypatch.setattr(s, "_download_stream", AsyncMock(return_value=b"raw"))
+    monkeypatch.setattr(srv, "extract_text", lambda b, n, **k: f"TEXT:{n}")
+    res = await s._call_tool_impl(
+        "m365_read_shared", {"sharing_url": "https://share/x"}
+    )
+    assert res["success"] is True and res["content"] == "TEXT:plan.docx"
+    endpoint = s._graph_request.call_args[0][1]
+    assert endpoint.startswith("/shares/u!") and "u!u!" not in endpoint
+
+
+@pytest.mark.asyncio
+async def test_read_shared_by_drive_item(monkeypatch):
+    s = _server()
+    s._graph_request = AsyncMock(
+        return_value={"name": "s.xlsx", "@microsoft.graph.downloadUrl": "https://dl/s"}
+    )
+    monkeypatch.setattr(s, "_download_stream", AsyncMock(return_value=b"raw"))
+    monkeypatch.setattr(srv, "extract_text", lambda b, n, **k: "OK")
+    res = await s._call_tool_impl(
+        "m365_read_shared", {"drive_id": "D1", "item_id": "I1"}
+    )
+    assert res["success"] is True
+    assert s._graph_request.call_args[0][1] == "/drives/D1/items/I1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "args,msg",
+    [
+        ({}, "provide either"),
+        ({"drive_id": "D1"}, "supplied together"),
+        ({"item_id": "I1"}, "supplied together"),
+        ({"sharing_url": "u", "drive_id": "D1", "item_id": "I1"}, "only one"),
+    ],
+)
+async def test_read_shared_input_contract(args, msg):
+    s = _server()
+    s._graph_request = AsyncMock()
+    res = await s._call_tool_impl("m365_read_shared", args)
+    assert res["success"] is False and msg in res["error"]
+    s._graph_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_read_shared_folder_guard():
+    s = _server()
+    s._graph_request = AsyncMock(
+        return_value={"name": "Dir", "folder": {"childCount": 2}}
+    )
+    res = await s._call_tool_impl("m365_read_shared", {"sharing_url": "https://s/d"})
+    assert res["success"] is False and "folder" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_read_shared_403_scope_message():
+    s = _server()
+    s._graph_request = AsyncMock(side_effect=Exception("Graph API error (403): denied"))
+    res = await s._call_tool_impl("m365_read_shared", {"sharing_url": "https://s/d"})
+    assert res["success"] is False and "Files.Read.All" in res["error"]

--- a/tests/unit/plugins/ms365/test_shared_tools.py
+++ b/tests/unit/plugins/ms365/test_shared_tools.py
@@ -438,3 +438,15 @@ async def test_list_sites_encodes_a_search_term_with_special_characters():
         call_args[0], call_args[1], params=call_kwargs.get("params")
     )
     assert "R%26D" in str(built.url), str(built.url)
+
+
+def test_denied_message_names_both_plausible_causes():
+    """A 403 on a shared item has two very different causes.
+
+    Blaming the scope alone sends the operator to re-authenticate an account
+    that already carries Files.Read.All, when the item may simply live in a
+    tenant where their access is a guest grant.
+    """
+    msg = srv._graph_error_message(Exception("Graph API error (403): denied"), "read")
+    assert "Files.Read.All" in msg
+    assert "tenant" in msg.lower()

--- a/tests/unit/plugins/ms365/test_shared_tools.py
+++ b/tests/unit/plugins/ms365/test_shared_tools.py
@@ -1,3 +1,4 @@
+import io
 from unittest.mock import AsyncMock
 
 import pytest
@@ -276,3 +277,52 @@ async def test_list_shared_null_fields_robust():
         and row["shared_by"] is None
         and row["is_folder"] is False
     )
+
+
+def _docx_bytes_local(text):
+    from docx import Document
+
+    d = Document()
+    d.add_paragraph(text)
+    b = io.BytesIO()
+    d.save(b)
+    return b.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_read_file_extracts_docx():
+    s = _server()
+    s._graph_request = AsyncMock(
+        side_effect=[
+            {"value": [{"id": "drv1"}]},  # drives lookup
+            _docx_bytes_local("Report body"),  # /content bytes
+        ]
+    )
+    res = await s._call_tool_impl(
+        "m365_read_file", {"site_id": "S", "file_path": "/r.docx"}
+    )
+    assert res["success"] is True and "Report body" in res["content"]
+
+
+@pytest.mark.asyncio
+async def test_read_drive_file_extracts_docx():
+    s = _server()
+    s._graph_request = AsyncMock(return_value=_docx_bytes_local("Drive doc"))
+    res = await s._call_tool_impl("m365_read_drive_file", {"file_path": "/d.docx"})
+    assert res["success"] is True and "Drive doc" in res["content"]
+
+
+@pytest.mark.asyncio
+async def test_read_file_plain_text_preserved():
+    # A non-Office utf-8 file (e.g. .py) must return its content (old behavior).
+    s = _server()
+    s._graph_request = AsyncMock(
+        side_effect=[
+            {"value": [{"id": "drv1"}]},
+            b"print('hello')",
+        ]
+    )
+    res = await s._call_tool_impl(
+        "m365_read_file", {"site_id": "S", "file_path": "/app.py"}
+    )
+    assert res["success"] is True and "print('hello')" in res["content"]

--- a/tests/unit/plugins/ms365/test_shared_tools.py
+++ b/tests/unit/plugins/ms365/test_shared_tools.py
@@ -1,0 +1,122 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+import plugins.ms365.server as srv
+
+
+def _server():
+    s = srv.MS365Server()
+    s._get_valid_token = AsyncMock(return_value="fake-token")
+    return s
+
+
+class _FakeStream:
+    """Minimal async context manager mimicking httpx stream response."""
+
+    def __init__(self, chunks, status=200, headers=None):
+        self._chunks = chunks
+        self.status_code = status
+        self.headers = headers or {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def aiter_bytes(self):
+        for c in self._chunks:
+            yield c
+
+
+class _FakeClient:
+    def __init__(self, stream):
+        self._stream = stream
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    def stream(self, method, url):
+        return self._stream
+
+
+@pytest.mark.asyncio
+async def test_download_stream_ok(monkeypatch):
+    s = _server()
+    stream = _FakeStream([b"abc", b"def"])
+    monkeypatch.setattr(srv.httpx, "AsyncClient", lambda **kw: _FakeClient(stream))
+    assert await s._download_stream("https://dl/x") == b"abcdef"
+
+
+@pytest.mark.asyncio
+async def test_download_stream_size_guard_streamed(monkeypatch):
+    s = _server()
+    # No Content-Length; over the cap only becomes clear while streaming.
+    stream = _FakeStream([b"x" * 10, b"x" * 10])
+    monkeypatch.setattr(srv.httpx, "AsyncClient", lambda **kw: _FakeClient(stream))
+    with pytest.raises(srv.SharedReadError, match="too large"):
+        await s._download_stream("https://dl/x", max_bytes=15)
+
+
+@pytest.mark.asyncio
+async def test_read_item_folder_guard():
+    s = _server()
+    with pytest.raises(srv.SharedReadError, match="folder"):
+        await s._read_item({"name": "Docs", "folder": {"childCount": 3}})
+
+
+@pytest.mark.asyncio
+async def test_read_item_downloads(monkeypatch):
+    s = _server()
+    monkeypatch.setattr(s, "_download_stream", AsyncMock(return_value=b"BYTES"))
+    content, name = await s._read_item(
+        {"name": "f.docx", "@microsoft.graph.downloadUrl": "https://dl/f"}
+    )
+    assert content == b"BYTES" and name == "f.docx"
+
+
+class _FakeResp:
+    def __init__(self, status, headers):
+        self.status_code = status
+        self.headers = headers
+
+
+class _FakeGetClient:
+    def __init__(self, resp):
+        self._resp = resp
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def get(self, url, headers=None):
+        return self._resp
+
+
+@pytest.mark.asyncio
+async def test_read_item_fallback_302(monkeypatch):
+    s = _server()
+    getcli = _FakeGetClient(_FakeResp(302, {"location": "https://dl/redir"}))
+    monkeypatch.setattr(srv.httpx, "AsyncClient", lambda **kw: getcli)
+    monkeypatch.setattr(s, "_download_stream", AsyncMock(return_value=b"FB"))
+    content, name = await s._read_item(
+        {"name": "f.pdf", "id": "I1", "parentReference": {"driveId": "D1"}}
+    )
+    assert content == b"FB" and name == "f.pdf"
+
+
+@pytest.mark.asyncio
+async def test_read_item_fallback_error_status(monkeypatch):
+    s = _server()
+    getcli = _FakeGetClient(_FakeResp(403, {}))
+    monkeypatch.setattr(srv.httpx, "AsyncClient", lambda **kw: getcli)
+    with pytest.raises(srv.SharedReadError, match="HTTP 403"):
+        await s._read_item(
+            {"name": "f.pdf", "id": "I1", "parentReference": {"driveId": "D1"}}
+        )


### PR DESCRIPTION
Extends the ms365 MCP plugin to read Office 365 documents **shared with the
account** — the case the existing tools couldn't reach (they only read files by
known SharePoint `site_id + file_path` or the user's own OneDrive).

**New tools**
- `m365_read_shared(sharing_url | drive_id+item_id)` — reads a shared document by
  share link (from an email) or by an item from `m365_list_shared`. Resolves via
  the Graph Shares API (`/shares/{shareId}/driveItem`) or
  `/drives/{id}/items/{id}`, then returns extracted text.
- `m365_list_shared()` — lists "Shared with me" (`/me/drive/sharedWithMe`),
  paginated (cap 200 items / 5 pages, `truncated` flag), returning
  `drive_id`/`item_id` to pass to `m365_read_shared`.

**What "shared" reaches**

Both tools operate within the account's own tenant. A delegated token cannot
reach another tenant's SharePoint: the Shares API answers 403 and
`/sites/{host}` answers 400 `Invalid hostname for this tenancy`. Holding a B2B
guest account in that tenant does not change this — the guest principal lives
there, not in the token's tenant. Reading documents held by another
organisation requires the app registered as multi-tenant and consented in that
tenant; the existing per-tenant config already covers that case (a tenant entry
carrying its `azure_id`), so no code change would be needed.

**Also**
- New `plugins/ms365/extract.py`: `extract_text` (docx/xlsx/pdf/text via
  python-docx/openpyxl/pypdf) and `encode_sharing_url` (Graph shareId).
- `m365_read_file`/`m365_read_drive_file` extract Office text from binary
  content instead of returning "Binary file"; text files still decode
  utf-8-first.
- Reads resolve the item metadata, then fetch the pre-authenticated
  `@microsoft.graph.downloadUrl` with **no** auth header (avoids handing the
  Graph bearer to the storage host), streamed under a 50 MB guard. Folders and
  items without a download URL are rejected with explicit errors.
- Deps declared in the manifest and the `ms365` pyproject extra.
- Only the MCP-server path (`server.py`) is touched; the legacy in-process tag
  path is untouched.

**Fixes found while exercising this against a live tenant**
- `Files.Read.All` added to the owner scope set. Plain `Files.ReadWrite` covers
  only the user's own drive, so the Shares API rejected every item shared by
  somebody else and the feature could not work at all for owner-role tenants.
- The OAuth callback default pointed at `/auth/ms365/callback`, a route this
  router never served, so the prefilled value could never complete a login. It
  is now derived from `GRIDBEAR_BASE_URL` at the route that exists.
- The MCP server is spawned as a bare script, so the new package import raised
  `ModuleNotFoundError` and killed the subprocess at startup. Tests importing
  the module as a package cannot observe that; the added test spawns the script
  the way the provider does.
- `mcp` pinned `<2.0.0`. 2.0.0 renames `Tool.inputSchema`, and every stdio MCP
  server then failed to connect while agents were served an empty tool list —
  #190 tracks the migration.
- `shared_by` read `createdBy`, which Graph leaves null on `sharedWithMe`
  entries; the sharer is reported under `shared.sharedBy`.
- `m365_list_sites` lost its search term, because httpx replaces a URL's
  existing query when `params` is also given, so site listings came back empty
  against tenants that do have sites.
- OAuth failures were truncated to 100 characters and never logged, and a
  denied read blamed a missing scope even when the cause was a grant held in
  another tenant.

53 unit tests.
