### PR TITLE
[REF] ui: migrate TemplateResponse to Starlette 1.x, unpin starlette

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,30 +134,9 @@ jobs:
         # No fix release as of 2026-04-25; only triggered by malicious package
         # archives during install — we pin our own deps and don't install
         # arbitrary user input, so the path isn't reachable in our runtime.
-        #
-        # Starlette PYSEC-2026-161/248/249/2280/2281: all fixed in Starlette
-        # 1.x, but the codebase is pinned to starlette<0.51.0 because fastapi's
-        # TemplateResponse call sites use the pre-1.0 signature (tracked for
-        # the 1.x migration in issue #181). Reachability audited — none apply
-        # to the running app:
-        #   - 161 (Host header -> request.url.path auth bypass): the only
-        #     request.url.path security check lives in OAuth2BearerMiddleware,
-        #     which is not mounted; no active middleware/route reads request.url
-        #     for authorization.
-        #   - 248 (path -> request.url.hostname): no request.url.hostname/netloc
-        #     usage anywhere in the codebase.
-        #   - 249 (form limits ignored for urlencoded): we never set
-        #     max_fields/max_part_size, so no configured limit is bypassed;
-        #     generic large-body DoS is bounded by the fronting proxy.
-        #   - 2280 (HTTPEndpoint method confusion): no Starlette HTTPEndpoint
-        #     subclasses — routes are FastAPI APIRouter handlers.
-        #   - 2281 (StaticFiles SSRF on Windows): Linux-only deployment.
         run: >-
           pip-audit --desc --skip-editable
           --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219
-          --ignore-vuln PYSEC-2026-161 --ignore-vuln GHSA-86qp-5c8j-p5mr
-          --ignore-vuln PYSEC-2026-248 --ignore-vuln PYSEC-2026-249
-          --ignore-vuln PYSEC-2026-2280 --ignore-vuln PYSEC-2026-2281
 
       - name: Secret scan
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,6 @@ COPY core/__version__.py core/__version__.py
 # Install all optional groups (plugins need their deps at runtime)
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system ".[dev,all]" && \
-    uv pip install --system "starlette<1.0.0" && \
     uv pip install --system py-spy
 
 # B5: Pre-download embedding model (~90MB, avoids download at first startup)

--- a/core/oauth2/server.py
+++ b/core/oauth2/server.py
@@ -171,6 +171,7 @@ async def authorize_get(
 
     # Show consent page
     return templates.TemplateResponse(
+        request,
         "oauth2/consent.html",
         {
             "request": request,

--- a/plugins/artifacts/admin/routes.py
+++ b/plugins/artifacts/admin/routes.py
@@ -67,6 +67,7 @@ async def list_artifacts(
         enriched.append(r)
 
     return templates.TemplateResponse(
+        request,
         "list.html",
         get_plugin_template_context(
             request,
@@ -94,6 +95,7 @@ async def artifact_detail(request: Request, uuid: str, _=Depends(require_login))
         uuid, share_token=row.get("share_token")
     )
     return templates.TemplateResponse(
+        request,
         "detail.html",
         get_plugin_template_context(request, PLUGIN_DIR, artifact=row),
     )

--- a/plugins/artifacts/portal/routes.py
+++ b/plugins/artifacts/portal/routes.py
@@ -52,6 +52,7 @@ async def me_artifacts(request: Request, user: dict = Depends(require_user)):
         rows = []
 
     return templates.TemplateResponse(
+        request,
         "me_artifacts.html",
         {"request": request, "user": user, "artifacts": rows},
     )

--- a/plugins/github/admin/routes.py
+++ b/plugins/github/admin/routes.py
@@ -67,6 +67,7 @@ async def github_index(request: Request, user: dict = Depends(require_login)):
     plugin_info = get_plugin_info("github")
 
     return templates.TemplateResponse(
+        request,
         "plugins/github.html",
         get_template_context(
             request,
@@ -111,6 +112,7 @@ async def save_settings(
 async def add_repo_form(request: Request, user: dict = Depends(require_login)):
     """Show add repository form."""
     return templates.TemplateResponse(
+        request,
         "plugins/github_repo.html",
         get_template_context(
             request,
@@ -141,6 +143,7 @@ async def edit_repo_form(
         raise HTTPException(status_code=404, detail="Repository not found")
 
     return templates.TemplateResponse(
+        request,
         "plugins/github_repo.html",
         get_template_context(
             request,

--- a/plugins/gmail/admin/routes.py
+++ b/plugins/gmail/admin/routes.py
@@ -44,6 +44,7 @@ async def gmail_accounts_page(request: Request, _: bool = Depends(require_login)
 
     plugin_menus = getattr(request.state, "plugin_menus", [])
     return templates.TemplateResponse(
+        request,
         "gmail.html",
         {
             "request": request,
@@ -63,6 +64,7 @@ async def start_oauth(request: Request, token: str):
 
     if not token_data:
         return templates.TemplateResponse(
+            request,
             "oauth_error.html",
             {
                 "request": request,
@@ -98,6 +100,7 @@ async def oauth_callback(
     """Handle OAuth callback from Google."""
     if error:
         return templates.TemplateResponse(
+            request,
             "oauth_error.html",
             {
                 "request": request,
@@ -107,6 +110,7 @@ async def oauth_callback(
 
     if not code:
         return templates.TemplateResponse(
+            request,
             "oauth_error.html",
             {
                 "request": request,
@@ -117,6 +121,7 @@ async def oauth_callback(
     stored_state = request.session.get("oauth_state")
     if not state or state != stored_state:
         return templates.TemplateResponse(
+            request,
             "oauth_error.html",
             {
                 "request": request,
@@ -127,6 +132,7 @@ async def oauth_callback(
     oauth_token = request.session.get("oauth_token")
     if not oauth_token:
         return templates.TemplateResponse(
+            request,
             "oauth_error.html",
             {
                 "request": request,
@@ -139,6 +145,7 @@ async def oauth_callback(
 
     if not token_data:
         return templates.TemplateResponse(
+            request,
             "oauth_error.html",
             {
                 "request": request,
@@ -198,6 +205,7 @@ async def oauth_callback(
         request.session.pop("oauth_state", None)
 
         return templates.TemplateResponse(
+            request,
             "oauth_success.html",
             {
                 "request": request,
@@ -207,6 +215,7 @@ async def oauth_callback(
 
     except Exception as e:
         return templates.TemplateResponse(
+            request,
             "oauth_error.html",
             {
                 "request": request,

--- a/plugins/google-sa/admin/routes.py
+++ b/plugins/google-sa/admin/routes.py
@@ -94,6 +94,7 @@ async def google_sa_index(request: Request, user: dict = Depends(require_login))
     has_sa, sa_email = _get_global_sa()
 
     return templates.TemplateResponse(
+        request,
         "plugins/google_sa.html",
         get_template_context(
             request,

--- a/plugins/google-sheets/admin/routes.py
+++ b/plugins/google-sheets/admin/routes.py
@@ -34,6 +34,7 @@ async def google_sheets_index(request: Request, user: dict = Depends(require_log
     plugin_info = get_plugin_info("google-sheets")
 
     return templates.TemplateResponse(
+        request,
         "plugins/google_sheets.html",
         get_template_context(
             request,

--- a/plugins/image/admin/routes.py
+++ b/plugins/image/admin/routes.py
@@ -38,6 +38,7 @@ async def image_config_page(request: Request, _: bool = Depends(require_login)):
     providers = discover_providers(BASE_PLUGIN_NAME)
 
     return templates.TemplateResponse(
+        request,
         "image_config.html",
         get_template_context(
             request,

--- a/plugins/livekit-agent/admin/routes.py
+++ b/plugins/livekit-agent/admin/routes.py
@@ -114,6 +114,7 @@ async def livekit_page(request: Request, _=Depends(require_login)):
         active_calls = await _service.list_active_calls()
 
     return templates.TemplateResponse(
+        request,
         "livekit.html",
         get_plugin_template_context(
             request,
@@ -295,6 +296,7 @@ async def call_page(room_name: str, request: Request):
             pass
 
         return templates.TemplateResponse(
+            request,
             "call_standalone.html",
             {
                 "request": request,
@@ -314,6 +316,7 @@ async def call_page(room_name: str, request: Request):
         if svc_session:
             agent_info = _get_agent_info(svc_session.agent_id)
             return templates.TemplateResponse(
+                request,
                 "call_standalone.html",
                 {
                     "request": request,
@@ -326,6 +329,7 @@ async def call_page(room_name: str, request: Request):
             )
 
     return templates.TemplateResponse(
+        request,
         "call_standalone.html",
         {
             "request": request,

--- a/plugins/memo/admin/routes.py
+++ b/plugins/memo/admin/routes.py
@@ -73,6 +73,7 @@ async def memo_list(request: Request, _=Depends(require_login)):
         memo["username"] = user_map.get(key, str(memo["user_id"]))
 
     return templates.TemplateResponse(
+        request,
         "memo.html",
         get_plugin_template_context(
             request,
@@ -105,6 +106,7 @@ async def memo_detail(request: Request, memo_id: int, _=Depends(require_login)):
     memo["username"] = user_map.get(key, str(memo["user_id"]))
 
     return templates.TemplateResponse(
+        request,
         "memo_edit.html",
         get_plugin_template_context(
             request,

--- a/plugins/ms365/admin/routes.py
+++ b/plugins/ms365/admin/routes.py
@@ -97,6 +97,7 @@ async def ms365_index(request: Request, user: dict = Depends(require_login)):
     plugin_info = get_plugin_info("ms365")
 
     return templates.TemplateResponse(
+        request,
         "plugins/ms365.html",
         get_template_context(
             request,
@@ -146,6 +147,7 @@ async def save_settings(
 async def add_tenant_form(request: Request, user: dict = Depends(require_login)):
     """Show add tenant form."""
     return templates.TemplateResponse(
+        request,
         "plugins/ms365_tenant.html",
         get_template_context(
             request,
@@ -176,6 +178,7 @@ async def edit_tenant_form(
         raise HTTPException(status_code=404, detail="Tenant not found")
 
     return templates.TemplateResponse(
+        request,
         "plugins/ms365_tenant.html",
         get_template_context(
             request,

--- a/plugins/ollama/admin/routes.py
+++ b/plugins/ollama/admin/routes.py
@@ -81,6 +81,7 @@ async def ollama_config_page(request: Request, _: bool = Depends(require_login))
     runner_ctx = _get_runner_context("ollama")
 
     return templates.TemplateResponse(
+        request,
         "plugins/ollama.html",
         get_template_context(
             request,

--- a/plugins/playwright/admin/routes.py
+++ b/plugins/playwright/admin/routes.py
@@ -47,6 +47,7 @@ async def playwright_settings(request: Request, _=Depends(require_login)):
     users_without_access = [u for u in all_users if u not in users_with_access]
 
     return templates.TemplateResponse(
+        request,
         "playwright.html",
         get_plugin_template_context(
             request,

--- a/plugins/skills/admin/routes.py
+++ b/plugins/skills/admin/routes.py
@@ -93,6 +93,7 @@ async def skills_list(request: Request, _=Depends(require_login)):
         by_plugin[plugin].append(skill)
 
     return templates.TemplateResponse(
+        request,
         "skills.html",
         get_plugin_template_context(
             request,
@@ -110,6 +111,7 @@ async def skills_list(request: Request, _=Depends(require_login)):
 async def skill_new(request: Request, _=Depends(require_login)):
     """Show form to create a new skill."""
     return templates.TemplateResponse(
+        request,
         "skill_edit.html",
         get_plugin_template_context(
             request,
@@ -172,6 +174,7 @@ async def skill_detail(request: Request, skill_id: int, _=Depends(require_login)
         skill["username"] = "System"
 
     return templates.TemplateResponse(
+        request,
         "skill_edit.html",
         get_plugin_template_context(
             request,

--- a/plugins/transcription/admin/routes.py
+++ b/plugins/transcription/admin/routes.py
@@ -38,6 +38,7 @@ async def transcription_config_page(request: Request, _: bool = Depends(require_
     providers = discover_providers(BASE_PLUGIN_NAME)
 
     return templates.TemplateResponse(
+        request,
         "transcription_config.html",
         get_template_context(
             request,

--- a/plugins/tts/admin/routes.py
+++ b/plugins/tts/admin/routes.py
@@ -38,6 +38,7 @@ async def tts_config_page(request: Request, _: bool = Depends(require_login)):
     providers = discover_providers(BASE_PLUGIN_NAME)
 
     return templates.TemplateResponse(
+        request,
         "tts_config.html",
         get_template_context(
             request,

--- a/plugins/whatsapp_api/admin/routes.py
+++ b/plugins/whatsapp_api/admin/routes.py
@@ -37,6 +37,7 @@ async def whatsapp_api_dashboard(request: Request, _=Depends(require_login)):
     agent_channels = _get_agent_whatsapp_configs()
 
     return templates.TemplateResponse(
+        request,
         "whatsapp_api.html",
         get_plugin_template_context(
             request,

--- a/plugins/whatsapp_evolution/admin/routes.py
+++ b/plugins/whatsapp_evolution/admin/routes.py
@@ -129,6 +129,7 @@ async def whatsapp_dashboard(request: Request, _=Depends(require_login)):
     instances = await _get_instances_status() if api_key else []
 
     return templates.TemplateResponse(
+        request,
         "whatsapp/index.html",
         get_plugin_template_context(
             request,

--- a/plugins/whatsapp_evolution/portal/routes.py
+++ b/plugins/whatsapp_evolution/portal/routes.py
@@ -134,6 +134,7 @@ async def whatsapp_connect_page(
     ]
 
     return templates.TemplateResponse(
+        request,
         "me/connect_whatsapp.html",
         {
             "request": request,
@@ -375,6 +376,7 @@ async def whatsapp_authorized_numbers(
         state = status_data.get("instance", {}).get("state", "unknown")
 
     return templates.TemplateResponse(
+        request,
         "me/whatsapp_authorized.html",
         {
             "request": request,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ dependencies = [
     "pyyaml>=6.0",
     "filelock>=3.13.0",
     # Web / Admin UI
-    "fastapi>=0.131.0,<0.139.1",
-    "starlette>=0.40.0,<0.51.0",
+    "fastapi>=0.135.0,<0.139.1",
+    "starlette>=1.0.0,<2.0.0",
     "uvicorn>=0.27.0",
     "jinja2>=3.1.0",
     "itsdangerous>=2.1.0",

--- a/ui/app.py
+++ b/ui/app.py
@@ -867,6 +867,7 @@ async def dashboard(request: Request, _: dict = Depends(require_login)):
     }
 
     return templates.TemplateResponse(
+        request,
         "dashboard.html",
         get_template_context(
             request,

--- a/ui/routes/agents.py
+++ b/ui/routes/agents.py
@@ -255,6 +255,7 @@ async def agents_list(request: Request, _: dict = Depends(require_login)):
         pass
 
     return get_templates().TemplateResponse(
+        request,
         "agents/list.html",
         get_template_context(
             request,
@@ -434,6 +435,7 @@ async def new_agent(request: Request, _: dict = Depends(require_login)):
     known_users = get_known_users()
 
     return get_templates().TemplateResponse(
+        request,
         "agents/edit.html",
         get_template_context(
             request,
@@ -462,6 +464,7 @@ async def edit_agent(request: Request, agent_id: str, _: dict = Depends(require_
     known_users = get_known_users()
 
     return get_templates().TemplateResponse(
+        request,
         "agents/edit.html",
         get_template_context(
             request,

--- a/ui/routes/auth.py
+++ b/ui/routes/auth.py
@@ -174,6 +174,7 @@ async def login_page(request: Request):
         error = "Session expired. Please log in again."
 
     return templates.TemplateResponse(
+        request,
         "auth/login.html",
         {
             "request": request,
@@ -209,6 +210,7 @@ async def login(
             details="User not found",
         )
         return templates.TemplateResponse(
+            request,
             "auth/login.html",
             {
                 "request": request,
@@ -226,6 +228,7 @@ async def login(
             details="Account locked out",
         )
         return templates.TemplateResponse(
+            request,
             "auth/login.html",
             {
                 "request": request,
@@ -251,6 +254,7 @@ async def login(
                 details=f"Locked after {failed} failed attempts",
             )
             return templates.TemplateResponse(
+                request,
                 "auth/login.html",
                 {
                     "request": request,
@@ -267,6 +271,7 @@ async def login(
             details=f"Wrong password (attempt {failed})",
         )
         return templates.TemplateResponse(
+            request,
             "auth/login.html",
             {
                 "request": request,
@@ -328,6 +333,7 @@ async def twofa_page(request: Request):
     has_webauthn = bool(user.get("webauthn_enabled")) if user else False
 
     return templates.TemplateResponse(
+        request,
         "auth/2fa.html",
         {
             "request": request,
@@ -444,6 +450,7 @@ async def verify_2fa(
             details=f"Max attempts ({attempts}) reached",
         )
         return templates.TemplateResponse(
+            request,
             "auth/login.html",
             {
                 "request": request,
@@ -461,6 +468,7 @@ async def verify_2fa(
     )
 
     return templates.TemplateResponse(
+        request,
         "auth/2fa.html",
         {
             "request": request,
@@ -484,6 +492,7 @@ async def twofa_choice_page(request: Request):
         return RedirectResponse(url="/auth/login", status_code=303)
 
     return templates.TemplateResponse(
+        request,
         "auth/2fa_choice.html",
         {
             "request": request,
@@ -516,6 +525,7 @@ async def twofa_passkey_page(request: Request):
     has_totp = bool(user.get("totp_enabled"))
 
     return templates.TemplateResponse(
+        request,
         "auth/2fa_passkey.html",
         {
             "request": request,
@@ -641,6 +651,7 @@ async def webauthn_setup_page(
     )
 
     return templates.TemplateResponse(
+        request,
         "auth/webauthn_setup.html",
         {
             "request": request,
@@ -775,6 +786,7 @@ async def setup_page(request: Request):
         return RedirectResponse(url="/auth/login", status_code=303)
 
     return templates.TemplateResponse(
+        request,
         "auth/setup.html",
         {
             "request": request,
@@ -810,6 +822,7 @@ async def setup(
 
     if errors:
         return templates.TemplateResponse(
+            request,
             "auth/setup.html",
             {
                 "request": request,
@@ -867,6 +880,7 @@ async def twofa_setup_page(request: Request):
     qr_code = totp_manager.generate_qr_code(secret, user["username"])
 
     return templates.TemplateResponse(
+        request,
         "auth/2fa_setup.html",
         {
             "request": request,
@@ -899,6 +913,7 @@ async def twofa_setup(
     if not totp_manager.verify_code(secret, code):
         qr_code = totp_manager.generate_qr_code(secret, user["username"])
         return templates.TemplateResponse(
+            request,
             "auth/2fa_setup.html",
             {
                 "request": request,
@@ -931,6 +946,7 @@ async def twofa_setup(
     formatted_codes = recovery_manager.format_codes_for_display(recovery_codes)
 
     return templates.TemplateResponse(
+        request,
         "auth/recovery.html",
         {
             "request": request,
@@ -961,6 +977,7 @@ async def logout(request: Request):
 async def change_password_page(request: Request, user: dict = Depends(require_user)):
     """Display password change form."""
     return templates.TemplateResponse(
+        request,
         "change_password.html",
         get_template_context(
             request,
@@ -992,6 +1009,7 @@ async def change_password(
             details="Wrong current password",
         )
         return templates.TemplateResponse(
+            request,
             "change_password.html",
             get_template_context(
                 request,
@@ -1003,6 +1021,7 @@ async def change_password(
 
     if new_password != new_password_confirm:
         return templates.TemplateResponse(
+            request,
             "change_password.html",
             get_template_context(
                 request,
@@ -1014,6 +1033,7 @@ async def change_password(
 
     if len(new_password) < MIN_PASSWORD_LENGTH:
         return templates.TemplateResponse(
+            request,
             "change_password.html",
             get_template_context(
                 request,
@@ -1033,6 +1053,7 @@ async def change_password(
     )
 
     return templates.TemplateResponse(
+        request,
         "change_password.html",
         get_template_context(
             request,
@@ -1062,6 +1083,7 @@ async def security_page(request: Request, user: dict = Depends(require_user)):
     success = request.query_params.get("success")
 
     return templates.TemplateResponse(
+        request,
         "auth/security.html",
         get_template_context(
             request,
@@ -1146,6 +1168,7 @@ async def regenerate_recovery(
     )
 
     return templates.TemplateResponse(
+        request,
         "auth/recovery.html",
         {
             "request": request,
@@ -1208,6 +1231,7 @@ async def revoke_all_sessions(request: Request, user: dict = Depends(require_use
 async def forgot_password_page(request: Request):
     """Display the password-reset request form."""
     return templates.TemplateResponse(
+        request,
         "auth/forgot_password.html",
         {"request": request, "submitted": False},
     )
@@ -1228,6 +1252,7 @@ async def forgot_password(request: Request, email: str = Form(...)):
     # host, not whatever host this request arrived on (proxy/curl/localhost).
     base_url = os.environ.get("GRIDBEAR_BASE_URL") or str(request.base_url)
     return templates.TemplateResponse(
+        request,
         "auth/forgot_password.html",
         {"request": request, "submitted": True},
         background=BackgroundTask(request_password_reset, email, base_url),
@@ -1245,6 +1270,7 @@ async def setup_password_page(request: Request):
     raw_token = request.query_params.get("token", "")
     if not raw_token:
         return templates.TemplateResponse(
+            request,
             "auth/setup_password.html",
             {
                 "request": request,
@@ -1257,6 +1283,7 @@ async def setup_password_page(request: Request):
     token_data = validate_token(raw_token)
     if not token_data:
         return templates.TemplateResponse(
+            request,
             "auth/setup_password.html",
             {
                 "request": request,
@@ -1267,6 +1294,7 @@ async def setup_password_page(request: Request):
         )
 
     return templates.TemplateResponse(
+        request,
         "auth/setup_password.html",
         {
             "request": request,
@@ -1293,6 +1321,7 @@ async def setup_password(
     token_data = validate_token(token)
     if not token_data:
         return templates.TemplateResponse(
+            request,
             "auth/setup_password.html",
             {
                 "request": request,
@@ -1304,6 +1333,7 @@ async def setup_password(
 
     if password != password_confirm:
         return templates.TemplateResponse(
+            request,
             "auth/setup_password.html",
             {
                 "request": request,
@@ -1318,6 +1348,7 @@ async def setup_password(
 
     if len(password) < MIN_PASSWORD_LENGTH:
         return templates.TemplateResponse(
+            request,
             "auth/setup_password.html",
             {
                 "request": request,
@@ -1334,6 +1365,7 @@ async def setup_password(
     consume_token(token_data["token_id"])
 
     return templates.TemplateResponse(
+        request,
         "auth/setup_password.html",
         {
             "request": request,

--- a/ui/routes/companies.py
+++ b/ui/routes/companies.py
@@ -53,6 +53,7 @@ async def companies_page(request: Request, _: dict = Depends(require_login)):
         )
 
     return templates.TemplateResponse(
+        request,
         "companies.html",
         get_template_context(
             request,
@@ -149,6 +150,7 @@ async def company_detail(
 
     config = ConfigManager()
     return templates.TemplateResponse(
+        request,
         "company_detail.html",
         get_template_context(
             request,

--- a/ui/routes/languages.py
+++ b/ui/routes/languages.py
@@ -36,6 +36,7 @@ async def languages_page(request: Request, _=Depends(require_login)):
     saved = request.query_params.get("saved")
     error = request.query_params.get("error")
     return templates.TemplateResponse(
+        request,
         "languages.html",
         {
             "request": request,

--- a/ui/routes/me.py
+++ b/ui/routes/me.py
@@ -448,6 +448,7 @@ async def dashboard(request: Request, user: dict = Depends(require_user)):
     await _notify_expired_tokens(connections, user)
 
     return templates.TemplateResponse(
+        request,
         "me/dashboard.html",
         {
             "request": request,
@@ -467,6 +468,7 @@ async def profile_page(request: Request, user: dict = Depends(require_user)):
     from core.i18n import get_active_languages
 
     return templates.TemplateResponse(
+        request,
         "me/profile.html",
         {
             "request": request,
@@ -562,6 +564,7 @@ async def connections_page(request: Request, user: dict = Depends(require_user))
     await _notify_expired_tokens(connections, user)
 
     return templates.TemplateResponse(
+        request,
         "me/connections.html",
         {
             "request": request,
@@ -606,6 +609,7 @@ async def connection_connect(
 
     if auth_type == "api_key":
         return templates.TemplateResponse(
+            request,
             "me/connect_api_key.html",
             {
                 "request": request,
@@ -617,6 +621,7 @@ async def connection_connect(
         )
     elif auth_type == "credentials":
         return templates.TemplateResponse(
+            request,
             "me/connect_credentials.html",
             {
                 "request": request,
@@ -686,6 +691,7 @@ async def connection_connect(
 
         # Fallback: show a generic token input form
         return templates.TemplateResponse(
+            request,
             "me/connect_api_key.html",
             {
                 "request": request,
@@ -920,6 +926,7 @@ async def tools_page(request: Request, user: dict = Depends(require_user)):
             pass
 
     return templates.TemplateResponse(
+        request,
         "me/tools.html",
         {
             "request": request,
@@ -961,6 +968,7 @@ async def chat_page(request: Request, user: dict = Depends(require_user)):
     agents = _get_user_agents(user)
 
     return templates.TemplateResponse(
+        request,
         "me/chat.html",
         {
             "request": request,
@@ -991,11 +999,13 @@ async def chat_join_page(
 
     if not row:
         return templates.TemplateResponse(
+            request,
             "me/chat_join.html",
             {"request": request, "user": user, "error": "Invite expired or invalid"},
         )
 
     return templates.TemplateResponse(
+        request,
         "me/chat_join.html",
         {
             "request": request,

--- a/ui/routes/memory.py
+++ b/ui/routes/memory.py
@@ -51,6 +51,7 @@ async def memory_page(request: Request, _: bool = Depends(require_login)):
     config = ConfigManager()
     plugin_menus = getattr(request.state, "plugin_menus", [])
     return templates.TemplateResponse(
+        request,
         "memory.html",
         {
             "request": request,
@@ -258,6 +259,7 @@ async def memory_browse_page(
         total_pages = 1
 
     return templates.TemplateResponse(
+        request,
         "memory_browse.html",
         {
             "request": request,

--- a/ui/routes/oauth2.py
+++ b/ui/routes/oauth2.py
@@ -33,6 +33,7 @@ async def list_clients(request: Request, _: dict = Depends(require_login)):
     stats = db.get_stats()
 
     return templates.TemplateResponse(
+        request,
         "oauth2/clients.html",
         get_ctx(request, clients=clients, stats=stats),
     )
@@ -44,6 +45,7 @@ async def new_client_form(request: Request, _: dict = Depends(require_login)):
     templates, get_ctx = get_templates()
 
     return templates.TemplateResponse(
+        request,
         "oauth2/client_edit.html",
         get_ctx(request, client=None, is_new=True, secret=None),
     )
@@ -82,6 +84,7 @@ async def create_client(
     # Redirect to client detail with secret shown once
     templates, get_ctx = get_templates()
     return templates.TemplateResponse(
+        request,
         "oauth2/client_edit.html",
         get_ctx(
             request,
@@ -107,6 +110,7 @@ async def view_client(
 
     templates, get_ctx = get_templates()
     return templates.TemplateResponse(
+        request,
         "oauth2/client_edit.html",
         get_ctx(request, client=client, is_new=False, secret=None, tokens=tokens),
     )
@@ -163,6 +167,7 @@ async def regenerate_secret(
     client = db.get_client_by_id(client_pk)
     templates, get_ctx = get_templates()
     return templates.TemplateResponse(
+        request,
         "oauth2/client_edit.html",
         get_ctx(
             request,

--- a/ui/routes/permissions.py
+++ b/ui/routes/permissions.py
@@ -74,6 +74,7 @@ async def permissions_page(request: Request, _: bool = Depends(require_login)):
 
     plugin_menus = getattr(request.state, "plugin_menus", [])
     return templates.TemplateResponse(
+        request,
         "permissions.html",
         {
             "request": request,

--- a/ui/routes/plugins.py
+++ b/ui/routes/plugins.py
@@ -217,6 +217,7 @@ async def plugins_list(request: Request, _: bool = Depends(require_login)):
     plugins = await get_all_plugins()
 
     return templates.TemplateResponse(
+        request,
         "plugins/list.html",
         get_template_context(
             request,
@@ -297,6 +298,7 @@ async def plugin_paths_page(request: Request, _: bool = Depends(require_login)):
         )
 
     return templates.TemplateResponse(
+        request,
         "plugins/paths.html",
         get_template_context(request, plugin_paths=paths),
     )
@@ -400,6 +402,7 @@ async def plugin_config(
         runner_ctx = _get_runner_context(plugin_name)
 
     return templates.TemplateResponse(
+        request,
         "plugins/config.html",
         get_template_context(
             request,

--- a/ui/routes/rest_api.py
+++ b/ui/routes/rest_api.py
@@ -134,6 +134,7 @@ async def rest_api_page(request: Request, _=Depends(require_login)):
     schema_order = sorted(grouped.keys(), key=lambda s: (priority.get(s, 99), s))
 
     return get_templates().TemplateResponse(
+        request,
         "rest_api.html",
         get_template_context(
             request,

--- a/ui/routes/settings.py
+++ b/ui/routes/settings.py
@@ -57,6 +57,7 @@ async def settings_page(request: Request, _=Depends(require_login)):
     dump_prompts = bool(SystemConfig.get_param_sync("dump_prompts"))
 
     return templates.TemplateResponse(
+        request,
         "settings.html",
         get_template_context(
             request,

--- a/ui/routes/themes.py
+++ b/ui/routes/themes.py
@@ -111,6 +111,7 @@ async def themes_page(request: Request, _=Depends(require_login)):
     themes, active_theme = _discover_themes()
 
     return get_templates().TemplateResponse(
+        request,
         "themes.html",
         get_template_context(
             request,

--- a/ui/routes/tools.py
+++ b/ui/routes/tools.py
@@ -196,6 +196,7 @@ async def tools_dashboard(request: Request, _: dict = Depends(require_login)):
     data = await _get_dashboard_data()
 
     return get_templates().TemplateResponse(
+        request,
         "tools/dashboard.html",
         get_template_context(request, **data),
     )
@@ -258,6 +259,7 @@ async def agent_tools_page(
             pass
 
     return get_templates().TemplateResponse(
+        request,
         "tools/agent_tools.html",
         get_template_context(
             request,

--- a/ui/routes/users.py
+++ b/ui/routes/users.py
@@ -64,6 +64,7 @@ async def users_page(request: Request, _: bool = Depends(require_login)):
             u["locale"] = "en"
 
     return templates.TemplateResponse(
+        request,
         "users.html",
         get_template_context(
             request,

--- a/ui/routes/vault.py
+++ b/ui/routes/vault.py
@@ -32,6 +32,7 @@ async def vault_list(request: Request, user: dict = Depends(require_user)):
     uid = _uid(user)
     services = list_services(uid)
     return templates.TemplateResponse(
+        request,
         "me/vault.html",
         {"request": request, "user": user, "services": services},
     )
@@ -41,6 +42,7 @@ async def vault_list(request: Request, user: dict = Depends(require_user)):
 async def vault_add_form(request: Request, user: dict = Depends(require_user)):
     """Show the add-service form."""
     return templates.TemplateResponse(
+        request,
         "me/vault_form.html",
         {
             "request": request,
@@ -62,6 +64,7 @@ async def vault_add(request: Request, user: dict = Depends(require_user)):
     if not validate_service_id(service_id):
         services = list_services(uid)
         return templates.TemplateResponse(
+            request,
             "me/vault.html",
             {
                 "request": request,
@@ -74,6 +77,7 @@ async def vault_add(request: Request, user: dict = Depends(require_user)):
     if get_service(uid, service_id) is not None:
         services = list_services(uid)
         return templates.TemplateResponse(
+            request,
             "me/vault.html",
             {
                 "request": request,
@@ -108,6 +112,7 @@ async def vault_edit_form(
         return RedirectResponse(url="/me/vault", status_code=303)
     creds_for_js = [{"key": c.key, "secret": c.secret} for c in entry.credentials]
     return templates.TemplateResponse(
+        request,
         "me/vault_form.html",
         {
             "request": request,


### PR DESCRIPTION
Closes #181. Supersedes #189.

Starlette 1.x removed `TemplateResponse(name, context)` in favour of
`(request, name, context)`; on 1.x the old shape raises
`TypeError: unhashable type: 'dict'` because the context is taken for the
template name. All **110** call sites used the old form, which is what has kept
the dependency pinned since July.

**Migration**

Every call had the identical shape (two positional args, no kwargs) and every
enclosing handler already took a `request` parameter, so the transform is one
inserted argument at each site — 35 files, 110 lines, nothing else. Located via
the AST rather than a text match, and the result re-parsed per file before
writing.

The new form is also accepted by 0.x, so that commit stands on its own.

**Dependencies**

- `starlette>=1.0.0,<2.0.0`
- `fastapi>=0.135.0` — 0.131 caps `starlette<1.0.0`, so leaving the old floor
  would let the resolver fall back to the pinned line without saying so.
- The **Dockerfile carried a second, independent pin** (`uv pip install
  --system "starlette<1.0.0"` after the project install). Left in place it would
  have kept the container on 0.x while CI validated 1.x, with nothing to reveal
  the divergence.
- The ten starlette advisories waived in `pip-audit` under a reachability audit
  are gone from `ci.yml`; the two unrelated waivers remain.

**Verified**

- 705 unit tests pass under starlette 1.6.0.
- The anyio monkeypatch in `ui/app.py` (`CancelScope._deliver_cancellation`, the
  CPU-leak throttle) still matches: the target survives on anyio 4.14.2 with the
  same signature. This was the main unknown flagged on #181.
- Container rebuilt on starlette 1.6.0 / fastapi 0.139.0: boots clean, login and
  forgot-password render (HTTP 200, full HTML), protected routes still redirect,
  all 10 stdio MCP servers connect with no failures.
- OSV reports 10 advisories for starlette 0.50.0 and none for 1.6.0.
