### PR TITLE
[ADD] tests: connect the gateway to a real MCP server

### DIFF
--- a/tests/unit/mcp_gateway/echo_server.py
+++ b/tests/unit/mcp_gateway/echo_server.py
@@ -1,0 +1,51 @@
+"""A minimal MCP server, spawned over stdio by the round-trip test.
+
+Deliberately built the way the plugin servers are — `Tool(inputSchema=...)`
+declared through `mcp.server.Server`, served by `stdio_server` — so a breaking
+change in the SDK surfaces here rather than in production.
+"""
+
+import asyncio
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import TextContent, Tool
+
+ECHO_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "message": {"type": "string", "description": "text to send back"},
+    },
+    "required": ["message"],
+}
+
+server = Server("echo-server")
+
+
+@server.list_tools()
+async def list_tools() -> list[Tool]:
+    return [
+        Tool(
+            name="echo",
+            description="Return the message that was passed in.",
+            inputSchema=ECHO_SCHEMA,
+        )
+    ]
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+    if name != "echo":
+        raise ValueError(f"unknown tool: {name}")
+    return [TextContent(type="text", text=arguments["message"])]
+
+
+async def main() -> None:
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream, write_stream, server.create_initialization_options()
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/unit/mcp_gateway/test_stdio_roundtrip.py
+++ b/tests/unit/mcp_gateway/test_stdio_roundtrip.py
@@ -1,0 +1,99 @@
+"""Connect the gateway to a real MCP server over stdio.
+
+Every other test in this area substitutes the session with a mock, which means
+none of them exercise the SDK. That gap is not hypothetical: mcp 2.0.0 renamed
+`Tool.inputSchema` to `input_schema`, `_connect` raised AttributeError on every
+server, and agents were served an empty tool list for hours while the suite
+stayed green. These tests spawn an actual subprocess and speak the protocol, so
+a change of that shape fails here instead.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+from core.mcp_gateway.client_manager import MCPClientManager, MCPServerConnection
+from core.mcp_gateway.provider_loader import ServerInfo
+
+ECHO_SERVER = Path(__file__).with_name("echo_server.py")
+
+# Generous: this guards against a hung handshake stalling CI, it is not a
+# performance assertion.
+HANDSHAKE_TIMEOUT = 60
+
+
+def _echo_server_info() -> ServerInfo:
+    return ServerInfo(
+        server_name="echo",
+        config={"command": sys.executable, "args": [str(ECHO_SERVER)]},
+        transport="stdio",
+        provider_name="echo",
+    )
+
+
+async def _connected():
+    """Connect to the echo server; caller must clean up."""
+    manager = MCPClientManager()
+    conn = MCPServerConnection(server_info=_echo_server_info())
+    await asyncio.wait_for(manager._connect(conn), timeout=HANDSHAKE_TIMEOUT)
+    return manager, conn
+
+
+@pytest.mark.asyncio
+async def test_stdio_handshake_reports_the_server_tools():
+    manager, conn = await _connected()
+    try:
+        assert conn.connected is True
+        assert [t["name"] for t in conn.tools] == ["echo"]
+    finally:
+        await manager._cleanup_connection(conn)
+
+
+@pytest.mark.asyncio
+async def test_tool_schema_survives_the_handshake():
+    """The gateway reads the schema off the SDK's Tool object by attribute.
+
+    An empty or missing schema is what agents see as an unusable tool, so assert
+    the contents rather than the key's presence.
+    """
+    manager, conn = await _connected()
+    try:
+        schema = conn.tools[0]["inputSchema"]
+        assert schema["type"] == "object"
+        assert schema["properties"]["message"]["type"] == "string"
+        assert schema["required"] == ["message"]
+    finally:
+        await manager._cleanup_connection(conn)
+
+
+@pytest.mark.asyncio
+async def test_tool_description_survives_the_handshake():
+    manager, conn = await _connected()
+    try:
+        assert conn.tools[0]["description"] == "Return the message that was passed in."
+    finally:
+        await manager._cleanup_connection(conn)
+
+
+@pytest.mark.asyncio
+async def test_a_tool_call_returns_the_servers_result():
+    """Listing tools is only half the protocol; calling one is the other half."""
+    manager, conn = await _connected()
+    try:
+        result = await asyncio.wait_for(
+            conn.session.call_tool("echo", {"message": "round trip"}),
+            timeout=HANDSHAKE_TIMEOUT,
+        )
+        assert [c.text for c in result.content] == ["round trip"]
+    finally:
+        await manager._cleanup_connection(conn)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_marks_the_connection_closed():
+    manager, conn = await _connected()
+    await manager._cleanup_connection(conn)
+    assert conn.connected is False
+    assert conn.tools == []


### PR DESCRIPTION
Groundwork for #190.

Every existing test around `MCPClientManager` replaces the session with a mock,
so none of them exercise the SDK. That gap is what let mcp 2.0.0 through: it
renamed `Tool.inputSchema` to `input_schema`, `_connect` raised `AttributeError`
for every server, and agents were served an empty tool list for hours while the
suite stayed green and CI reported nothing.

These tests spawn a real subprocess over stdio and speak the protocol —
handshake, tool listing, schema contents, a tool call, and cleanup.

**Verified the guard actually guards.** Installing mcp 2.0.0 makes all five fail
and name the incompatibility instead of hanging:

```
AttributeError: 'Server' object has no attribute 'list_tools'
MCP Gateway: connection failed for echo (stdio): Connection closed
```

That run also turned up something worth recording on #190: **2.0 changed the
serving API too**, not only the field read by the gateway — the
`@server.list_tools()` decorator is gone. The migration is wider than the rename.

The fixture server is deliberately written the way the plugin servers are
(`Tool(inputSchema=...)` under `mcp.server.Server`, served by `stdio_server`), so
a break on the serving side is caught alongside one on the reading side.

No credentials, no network, no container — it runs anywhere the SDK is installed.
Adds ~3.5s to the suite.
