### PR TITLE
[REF] mcp: move to 2.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,14 @@ RUN ARCH=$(dpkg --print-architecture) \
 
 # Install Google Sheets MCP server + boto3 for S3 backup uploads
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system mcp-google-sheets boto3
+    uv pip install --system boto3
+
+# mcp-google-sheets imports mcp.server.fastmcp, which mcp 2.x removed. It is a
+# separate process, so it gets its own environment and its SDK version stays
+# independent of the one the app uses.
+RUN python -m venv /opt/mcp-google-sheets && \
+    /opt/mcp-google-sheets/bin/pip install --no-cache-dir \
+        "mcp-google-sheets" "mcp>=1.8.0,<2.0.0"
 
 COPY . .
 

--- a/core/mcp_gateway/client_manager.py
+++ b/core/mcp_gateway/client_manager.py
@@ -222,6 +222,20 @@ class MCPServerConnection:
     _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
+def _wire_field(model, wire_name: str, default=None):
+    """Read a field by the name it carries on the wire, not by its attribute.
+
+    The SDK renames fields between majors while keeping the protocol alias
+    stable — inputSchema became input_schema, isError became is_error — so
+    reading by attribute silently breaks on an upgrade while reading by alias
+    does not.
+    """
+    for attr, info in type(model).model_fields.items():
+        if (info.alias or attr) == wire_name:
+            return getattr(model, attr)
+    return default
+
+
 def _get_user_credentials(
     unified_id: str,
     connection_id: str,
@@ -709,7 +723,8 @@ class MCPClientManager:
                     )
 
                 result = await conn.session.call_tool(tool_name, normalized_args)
-                if result.isError:
+                is_error = bool(_wire_field(result, "isError", False))
+                if is_error:
                     logger.warning(
                         "MCP Gateway: tool %s/%s returned isError=True, content=%s",
                         server_name,
@@ -746,13 +761,13 @@ class MCPClientManager:
                     else:
                         content.append({"type": "text", "text": str(item)})
 
-                if result.isError:
+                if is_error:
                     cb.record_soft_failure()
                 else:
                     cb.record_success()
                 logger.info(
                     f"MCP Gateway: tool call {server_name}/{tool_name} "
-                    f"({len(content)} content blocks, isError={result.isError})"
+                    f"({len(content)} content blocks, isError={is_error})"
                 )
                 return content
 
@@ -952,7 +967,7 @@ class MCPClientManager:
                     {
                         "name": tool.name,
                         "description": tool.description or "",
-                        "inputSchema": tool.model_dump(by_alias=True)["inputSchema"],
+                        "inputSchema": _wire_field(tool, "inputSchema", {}),
                     }
                     for tool in response.tools
                 ]

--- a/plugins/google-sheets/provider.py
+++ b/plugins/google-sheets/provider.py
@@ -5,10 +5,18 @@ SA credentials managed by the google-sa plugin (vault key: svc:google-sa:credent
 """
 
 import json
+from pathlib import Path
 
 from config.logging_config import logger
 from core.interfaces.mcp_provider import BaseMCPProvider
 from ui.secrets_manager import secrets_manager
+
+# This server is a third-party package that imports mcp.server.fastmcp, a module
+# mcp 2.x removed. It runs as its own process, so the image gives it a private
+# virtualenv and its SDK version stops depending on ours. Falls back to PATH
+# where that venv does not exist, such as a developer machine.
+_ISOLATED_BIN = Path("/opt/mcp-google-sheets/bin/mcp-google-sheets")
+GSHEETS_COMMAND = str(_ISOLATED_BIN) if _ISOLATED_BIN.exists() else "mcp-google-sheets"
 
 SECRET_KEY = "svc:google-sa:credentials"
 
@@ -75,7 +83,7 @@ class GoogleSheetsProvider(BaseMCPProvider):
 
         return {
             "google-sheets": {
-                "command": "mcp-google-sheets",
+                "command": GSHEETS_COMMAND,
                 "args": [],
                 "env": env,
             }
@@ -93,7 +101,7 @@ class GoogleSheetsProvider(BaseMCPProvider):
             env["ENABLED_TOOLS"] = self.enabled_tools
 
         return {
-            "command": "mcp-google-sheets",
+            "command": GSHEETS_COMMAND,
             "args": [],
             "env": env,
         }

--- a/plugins/ms365/server.py
+++ b/plugins/ms365/server.py
@@ -11,10 +11,11 @@ import os
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 import httpx
 import msal
+from pydantic import Field
 
 # Launched as a bare script by provider.get_server_config, so the repo root is
 # not on sys.path. Add it before importing sibling plugin modules.
@@ -26,9 +27,13 @@ from plugins.ms365.extract import encode_sharing_url, extract_text
 
 # MCP server imports
 try:
-    from mcp.server import Server
-    from mcp.server.stdio import stdio_server
-    from mcp.types import TextContent, Tool
+    # The ergonomic server API is FastMCP on mcp 1.x and MCPServer on 2.x. They
+    # are identical for what this file uses, so accepting either lets the major
+    # be switched from pyproject alone. Drop this once the pin moves.
+    try:  # mcp 2.x
+        from mcp.server.mcpserver import MCPServer as _McpServer
+    except ImportError:  # mcp 1.x
+        from mcp.server.fastmcp import FastMCP as _McpServer
 except ImportError:
     print("MCP server library not installed", file=sys.stderr)
     sys.exit(1)
@@ -82,7 +87,7 @@ class MS365Server:
     """MCP server for Microsoft 365 operations."""
 
     def __init__(self):
-        self.server = Server("ms365-server")
+        self.mcp = _McpServer("ms365-server")
         self.http_client: httpx.AsyncClient | None = None
         self.access_token: str | None = token_info.get("access_token")
         self.refresh_token: str | None = token_info.get("refresh_token")
@@ -114,322 +119,351 @@ class MS365Server:
         self._setup_tools()
 
     def _setup_tools(self):
-        """Register MCP tools."""
+        """Register every tool with the SDK.
 
-        @self.server.list_tools()
-        async def list_tools() -> list[Tool]:
-            return [
-                # SharePoint tools
-                Tool(
-                    name="m365_list_sites",
-                    description="List accessible SharePoint sites",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "search": {
-                                "type": "string",
-                                "description": "Optional search query",
-                            },
-                        },
-                    },
-                ),
-                Tool(
-                    name="m365_get_site_by_url",
-                    description="Get SharePoint site info by URL. Use this for guest tenant access.",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "site_url": {
-                                "type": "string",
-                                "description": "SharePoint site URL, e.g. https://contoso.sharepoint.com/sites/MySite",
-                            },
-                        },
-                        "required": ["site_url"],
-                    },
-                ),
-                Tool(
-                    name="m365_list_files",
-                    description="List files in a SharePoint folder",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "site_id": {
-                                "type": "string",
-                                "description": "SharePoint site ID",
-                            },
-                            "folder_path": {
-                                "type": "string",
-                                "description": "Folder path (default: root)",
-                                "default": "",
-                            },
-                        },
-                        "required": ["site_id"],
-                    },
-                ),
-                Tool(
-                    name="m365_read_file",
-                    description="Read file content from SharePoint",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "site_id": {
-                                "type": "string",
-                                "description": "SharePoint site ID",
-                            },
-                            "file_path": {
-                                "type": "string",
-                                "description": "Path to the file",
-                            },
-                        },
-                        "required": ["site_id", "file_path"],
-                    },
-                ),
-                Tool(
-                    name="m365_read_shared",
-                    description=(
-                        "Read a document SHARED WITH the user — by share link "
-                        "(from email) or by drive_id+item_id from m365_list_shared. "
-                        "Returns extracted text for Word/Excel/PDF."
-                    ),
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "sharing_url": {
-                                "type": "string",
-                                "description": "Share link URL (from an email/message)",
-                            },
-                            "drive_id": {
-                                "type": "string",
-                                "description": "Drive ID (from m365_list_shared)",
-                            },
-                            "item_id": {
-                                "type": "string",
-                                "description": "Item ID (from m365_list_shared)",
-                            },
-                        },
-                    },
-                ),
-                Tool(
-                    name="m365_list_shared",
-                    description=(
-                        "List documents shared WITH the user (Shared with me). "
-                        "Returns items with drive_id/item_id to pass to m365_read_shared."
-                    ),
-                    inputSchema={"type": "object", "properties": {}},
-                ),
-                Tool(
-                    name="m365_write_file",
-                    description="Write/upload file to SharePoint",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "site_id": {
-                                "type": "string",
-                                "description": "SharePoint site ID",
-                            },
-                            "file_path": {
-                                "type": "string",
-                                "description": "Path for the file",
-                            },
-                            "content": {
-                                "type": "string",
-                                "description": "File content",
-                            },
-                        },
-                        "required": ["site_id", "file_path", "content"],
-                    },
-                ),
-                Tool(
-                    name="m365_search_files",
-                    description="Search for files across SharePoint",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "query": {
-                                "type": "string",
-                                "description": "Search query",
-                            },
-                            "site_id": {
-                                "type": "string",
-                                "description": "Optional: limit to specific site",
-                            },
-                        },
-                        "required": ["query"],
-                    },
-                ),
-                # Planner tools
-                Tool(
-                    name="m365_list_groups",
-                    description="List Microsoft 365 groups the user is a member of",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {},
-                    },
-                ),
-                Tool(
-                    name="m365_list_plans",
-                    description="List Planner plans. Use list_all=true to get plans from all groups.",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "group_id": {
-                                "type": "string",
-                                "description": "Optional: filter by specific group ID",
-                            },
-                            "list_all": {
-                                "type": "boolean",
-                                "description": "If true, list plans from ALL groups (slower but complete)",
-                                "default": False,
-                            },
-                        },
-                    },
-                ),
-                Tool(
-                    name="m365_get_plan_by_id",
-                    description="Get Planner plan details by ID. Use this for guest access to shared plans.",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "plan_id": {
-                                "type": "string",
-                                "description": "The Planner plan ID (from URL or shared link)",
-                            },
-                        },
-                        "required": ["plan_id"],
-                    },
-                ),
-                Tool(
-                    name="m365_list_tasks",
-                    description="List tasks in a Planner plan",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "plan_id": {
-                                "type": "string",
-                                "description": "Plan ID",
-                            },
-                            "bucket_id": {
-                                "type": "string",
-                                "description": "Optional: filter by bucket",
-                            },
-                        },
-                        "required": ["plan_id"],
-                    },
-                ),
-                Tool(
-                    name="m365_get_task",
-                    description="Get task details including description",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "task_id": {
-                                "type": "string",
-                                "description": "Task ID",
-                            },
-                        },
-                        "required": ["task_id"],
-                    },
-                ),
-                Tool(
-                    name="m365_create_task",
-                    description="Create a new Planner task",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "plan_id": {
-                                "type": "string",
-                                "description": "Plan ID",
-                            },
-                            "title": {
-                                "type": "string",
-                                "description": "Task title",
-                            },
-                            "bucket_id": {
-                                "type": "string",
-                                "description": "Optional: bucket ID",
-                            },
-                            "due_date": {
-                                "type": "string",
-                                "description": "Optional: due date (ISO format)",
-                            },
-                        },
-                        "required": ["plan_id", "title"],
-                    },
-                ),
-                Tool(
-                    name="m365_complete_task",
-                    description="Mark a task as complete",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "task_id": {
-                                "type": "string",
-                                "description": "Task ID",
-                            },
-                        },
-                        "required": ["task_id"],
-                    },
-                ),
-                # OneDrive tools
-                Tool(
-                    name="m365_list_drive_files",
-                    description="List files in OneDrive",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "folder_path": {
-                                "type": "string",
-                                "description": "Folder path (default: root)",
-                                "default": "",
-                            },
-                        },
-                    },
-                ),
-                Tool(
-                    name="m365_read_drive_file",
-                    description="Read file from OneDrive",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "file_path": {
-                                "type": "string",
-                                "description": "Path to the file",
-                            },
-                        },
-                        "required": ["file_path"],
-                    },
-                ),
-                Tool(
-                    name="m365_write_drive_file",
-                    description="Write file to OneDrive",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "file_path": {
-                                "type": "string",
-                                "description": "Path for the file",
-                            },
-                            "content": {
-                                "type": "string",
-                                "description": "File content",
-                            },
-                        },
-                        "required": ["file_path", "content"],
-                    },
-                ),
-            ]
+        Schemas come from the signatures below, so the declared contract and
+        the arguments the implementation reads cannot drift apart.
+        """
+        self.mcp.add_tool(
+            self.m365_list_sites,
+            name="m365_list_sites",
+            description="List accessible SharePoint sites",
+            structured_output=False,
+        )
+        self.mcp.add_tool(
+            self.m365_get_site_by_url,
+            name="m365_get_site_by_url",
+            description="Get SharePoint site info by URL. Use this for guest tenant access.",
+            structured_output=False,
+        )
+        self.mcp.add_tool(
+            self.m365_list_files,
+            name="m365_list_files",
+            description="List files in a SharePoint folder",
+            structured_output=False,
+        )
+        self.mcp.add_tool(
+            self.m365_read_file,
+            name="m365_read_file",
+            description="Read file content from SharePoint",
+            structured_output=False,
+        )
+        self.mcp.add_tool(
+            self.m365_read_shared,
+            name="m365_read_shared",
+            description="Read a document SHARED WITH the user — by share link (from email) or by drive_id+item_id from m365_list_shared. Returns extracted text for Word/Excel/PDF.",
+            structured_output=False,
+        )
+        self.mcp.add_tool(
+            self.m365_list_shared,
+            name="m365_list_shared",
+            description="List documents shared WITH the user (Shared with me). Returns items with drive_id/item_id to pass to m365_read_shared.",
+            structured_output=False,
+        )
+        self.mcp.add_tool(
+            self.m365_write_file,
+            name="m365_write_file",
+            description="Write/upload file to SharePoint",
+            structured_output=False,
+        )
+        self.mcp.add_tool(
+            self.m365_search_files,
+            name="m365_search_files",
+            description="Search for files across SharePoint",
+            structured_output=False,
+        )
+        self.mcp.add_tool(
+            self.m365_list_groups,
+            name="m365_list_groups",
+            description="List Microsoft 365 groups the user is a member of",
+            structured_output=False,
+        )
+        self.mcp.add_tool(
+            self.m365_list_plans,
+            name="m365_list_plans",
+            description="List Planner plans. Use list_all=true to get plans from all groups.",
+            structured_output=False,
+        )
+        self.mcp.add_tool(
+            self.m365_get_plan_by_id,
+            name="m365_get_plan_by_id",
+            description="Get Planner plan details by ID. Use this for guest access to shared plans.",
+            structured_output=False,
+        )
+        self.mcp.add_tool(
+            self.m365_list_tasks,
+            name="m365_list_tasks",
+            description="List tasks in a Planner plan",
+            structured_output=False,
+        )
+        self.mcp.add_tool(
+            self.m365_get_task,
+            name="m365_get_task",
+            description="Get task details including description",
+            structured_output=False,
+        )
+        self.mcp.add_tool(
+            self.m365_create_task,
+            name="m365_create_task",
+            description="Create a new Planner task",
+            structured_output=False,
+        )
+        self.mcp.add_tool(
+            self.m365_complete_task,
+            name="m365_complete_task",
+            description="Mark a task as complete",
+            structured_output=False,
+        )
+        self.mcp.add_tool(
+            self.m365_list_drive_files,
+            name="m365_list_drive_files",
+            description="List files in OneDrive",
+            structured_output=False,
+        )
+        self.mcp.add_tool(
+            self.m365_read_drive_file,
+            name="m365_read_drive_file",
+            description="Read file from OneDrive",
+            structured_output=False,
+        )
+        self.mcp.add_tool(
+            self.m365_write_drive_file,
+            name="m365_write_drive_file",
+            description="Write file to OneDrive",
+            structured_output=False,
+        )
 
-        @self.server.call_tool()
-        async def call_tool(name: str, arguments: dict) -> list[TextContent]:
-            try:
-                result = await self._call_tool_impl(name, arguments)
-                self._track_operation(name, arguments, result)
-                return [TextContent(type="text", text=json.dumps(result, indent=2))]
-            except Exception as e:
-                error_result = {"success": False, "error": str(e)}
-                return [
-                    TextContent(type="text", text=json.dumps(error_result, indent=2))
-                ]
+    async def _run_tool(self, name: str, args: dict) -> dict:
+        """Dispatch a tool, record the operation, and report failures as data.
+
+        Shared by every tool so tracking and error shape stay in one place.
+        """
+        try:
+            result = await self._call_tool_impl(name, args)
+            self._track_operation(name, args, result)
+            return result
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    async def m365_list_sites(
+        self,
+        search: Annotated[
+            str | None, Field(description="Optional search query")
+        ] = None,
+    ) -> dict:
+        """List accessible SharePoint sites"""
+        args = {"search": search}
+        return await self._run_tool(
+            "m365_list_sites", {k: v for k, v in args.items() if v is not None}
+        )
+
+    async def m365_get_site_by_url(
+        self,
+        site_url: Annotated[
+            str,
+            Field(
+                description="SharePoint site URL, e.g. https://contoso.sharepoint.com/sites/MySite"
+            ),
+        ],
+    ) -> dict:
+        """Get SharePoint site info by URL. Use this for guest tenant access."""
+        args = {"site_url": site_url}
+        return await self._run_tool(
+            "m365_get_site_by_url", {k: v for k, v in args.items() if v is not None}
+        )
+
+    async def m365_list_files(
+        self,
+        site_id: Annotated[str, Field(description="SharePoint site ID")],
+        folder_path: Annotated[
+            str | None, Field(description="Folder path (default: root)")
+        ] = None,
+    ) -> dict:
+        """List files in a SharePoint folder"""
+        args = {"site_id": site_id, "folder_path": folder_path}
+        return await self._run_tool(
+            "m365_list_files", {k: v for k, v in args.items() if v is not None}
+        )
+
+    async def m365_read_file(
+        self,
+        site_id: Annotated[str, Field(description="SharePoint site ID")],
+        file_path: Annotated[str, Field(description="Path to the file")],
+    ) -> dict:
+        """Read file content from SharePoint"""
+        args = {"site_id": site_id, "file_path": file_path}
+        return await self._run_tool(
+            "m365_read_file", {k: v for k, v in args.items() if v is not None}
+        )
+
+    async def m365_read_shared(
+        self,
+        sharing_url: Annotated[
+            str | None, Field(description="Share link URL (from an email/message)")
+        ] = None,
+        drive_id: Annotated[
+            str | None, Field(description="Drive ID (from m365_list_shared)")
+        ] = None,
+        item_id: Annotated[
+            str | None, Field(description="Item ID (from m365_list_shared)")
+        ] = None,
+    ) -> dict:
+        """Read a document SHARED WITH the user — by share link (from email) or by drive_id+item_id from m365_list_shared. Returns extracted text for Word/Excel/PDF."""
+        args = {"sharing_url": sharing_url, "drive_id": drive_id, "item_id": item_id}
+        return await self._run_tool(
+            "m365_read_shared", {k: v for k, v in args.items() if v is not None}
+        )
+
+    async def m365_list_shared(self) -> dict:
+        """List documents shared WITH the user (Shared with me). Returns items with drive_id/item_id to pass to m365_read_shared."""
+        return await self._run_tool("m365_list_shared", {})
+
+    async def m365_write_file(
+        self,
+        site_id: Annotated[str, Field(description="SharePoint site ID")],
+        file_path: Annotated[str, Field(description="Path for the file")],
+        content: Annotated[str, Field(description="File content")],
+    ) -> dict:
+        """Write/upload file to SharePoint"""
+        args = {"site_id": site_id, "file_path": file_path, "content": content}
+        return await self._run_tool(
+            "m365_write_file", {k: v for k, v in args.items() if v is not None}
+        )
+
+    async def m365_search_files(
+        self,
+        query: Annotated[str, Field(description="Search query")],
+        site_id: Annotated[
+            str | None, Field(description="Optional: limit to specific site")
+        ] = None,
+    ) -> dict:
+        """Search for files across SharePoint"""
+        args = {"query": query, "site_id": site_id}
+        return await self._run_tool(
+            "m365_search_files", {k: v for k, v in args.items() if v is not None}
+        )
+
+    async def m365_list_groups(self) -> dict:
+        """List Microsoft 365 groups the user is a member of"""
+        return await self._run_tool("m365_list_groups", {})
+
+    async def m365_list_plans(
+        self,
+        group_id: Annotated[
+            str | None, Field(description="Optional: filter by specific group ID")
+        ] = None,
+        list_all: Annotated[
+            bool | None,
+            Field(
+                description="If true, list plans from ALL groups (slower but complete)"
+            ),
+        ] = None,
+    ) -> dict:
+        """List Planner plans. Use list_all=true to get plans from all groups."""
+        args = {"group_id": group_id, "list_all": list_all}
+        return await self._run_tool(
+            "m365_list_plans", {k: v for k, v in args.items() if v is not None}
+        )
+
+    async def m365_get_plan_by_id(
+        self,
+        plan_id: Annotated[
+            str, Field(description="The Planner plan ID (from URL or shared link)")
+        ],
+    ) -> dict:
+        """Get Planner plan details by ID. Use this for guest access to shared plans."""
+        args = {"plan_id": plan_id}
+        return await self._run_tool(
+            "m365_get_plan_by_id", {k: v for k, v in args.items() if v is not None}
+        )
+
+    async def m365_list_tasks(
+        self,
+        plan_id: Annotated[str, Field(description="Plan ID")],
+        bucket_id: Annotated[
+            str | None, Field(description="Optional: filter by bucket")
+        ] = None,
+    ) -> dict:
+        """List tasks in a Planner plan"""
+        args = {"plan_id": plan_id, "bucket_id": bucket_id}
+        return await self._run_tool(
+            "m365_list_tasks", {k: v for k, v in args.items() if v is not None}
+        )
+
+    async def m365_get_task(
+        self,
+        task_id: Annotated[str, Field(description="Task ID")],
+    ) -> dict:
+        """Get task details including description"""
+        args = {"task_id": task_id}
+        return await self._run_tool(
+            "m365_get_task", {k: v for k, v in args.items() if v is not None}
+        )
+
+    async def m365_create_task(
+        self,
+        plan_id: Annotated[str, Field(description="Plan ID")],
+        title: Annotated[str, Field(description="Task title")],
+        bucket_id: Annotated[
+            str | None, Field(description="Optional: bucket ID")
+        ] = None,
+        due_date: Annotated[
+            str | None, Field(description="Optional: due date (ISO format)")
+        ] = None,
+    ) -> dict:
+        """Create a new Planner task"""
+        args = {
+            "plan_id": plan_id,
+            "title": title,
+            "bucket_id": bucket_id,
+            "due_date": due_date,
+        }
+        return await self._run_tool(
+            "m365_create_task", {k: v for k, v in args.items() if v is not None}
+        )
+
+    async def m365_complete_task(
+        self,
+        task_id: Annotated[str, Field(description="Task ID")],
+    ) -> dict:
+        """Mark a task as complete"""
+        args = {"task_id": task_id}
+        return await self._run_tool(
+            "m365_complete_task", {k: v for k, v in args.items() if v is not None}
+        )
+
+    async def m365_list_drive_files(
+        self,
+        folder_path: Annotated[
+            str | None, Field(description="Folder path (default: root)")
+        ] = None,
+    ) -> dict:
+        """List files in OneDrive"""
+        args = {"folder_path": folder_path}
+        return await self._run_tool(
+            "m365_list_drive_files", {k: v for k, v in args.items() if v is not None}
+        )
+
+    async def m365_read_drive_file(
+        self,
+        file_path: Annotated[str, Field(description="Path to the file")],
+    ) -> dict:
+        """Read file from OneDrive"""
+        args = {"file_path": file_path}
+        return await self._run_tool(
+            "m365_read_drive_file", {k: v for k, v in args.items() if v is not None}
+        )
+
+    async def m365_write_drive_file(
+        self,
+        file_path: Annotated[str, Field(description="Path for the file")],
+        content: Annotated[str, Field(description="File content")],
+    ) -> dict:
+        """Write file to OneDrive"""
+        args = {"file_path": file_path, "content": content}
+        return await self._run_tool(
+            "m365_write_drive_file", {k: v for k, v in args.items() if v is not None}
+        )
 
     async def _get_client(self) -> httpx.AsyncClient:
         """Get or create HTTP client."""
@@ -1191,12 +1225,7 @@ class MS365Server:
 
     async def run(self):
         """Run the MCP server."""
-        async with stdio_server() as (read_stream, write_stream):
-            await self.server.run(
-                read_stream,
-                write_stream,
-                self.server.create_initialization_options(),
-            )
+        await self.mcp.run_stdio_async()
 
 
 async def main():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "psycopg[binary]>=3.3.3",
     "psycopg_pool>=3.1",
     # MCP protocol + primary runner
-    "mcp>=1.0.0,<2.0.0",
+    "mcp>=2.0.0,<3.0.0",
     "anthropic>=0.94.0",
 ]
 

--- a/tests/unit/mcp_gateway/echo_server.py
+++ b/tests/unit/mcp_gateway/echo_server.py
@@ -1,51 +1,29 @@
 """A minimal MCP server, spawned over stdio by the round-trip test.
 
-Deliberately built the way the plugin servers are — `Tool(inputSchema=...)`
-declared through `mcp.server.Server`, served by `stdio_server` — so a breaking
-change in the SDK surfaces here rather than in production.
+Built the way the plugin servers are — the ergonomic API, accepting whichever
+major is installed — so a breaking change in the SDK surfaces here rather than
+in production.
 """
 
 import asyncio
+from typing import Annotated
 
-from mcp.server import Server
-from mcp.server.stdio import stdio_server
-from mcp.types import TextContent, Tool
+from pydantic import Field
 
-ECHO_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "message": {"type": "string", "description": "text to send back"},
-    },
-    "required": ["message"],
-}
+try:  # mcp 2.x
+    from mcp.server.mcpserver import MCPServer as _McpServer
+except ImportError:  # mcp 1.x
+    from mcp.server.fastmcp import FastMCP as _McpServer
 
-server = Server("echo-server")
+mcp = _McpServer("echo-server")
 
 
-@server.list_tools()
-async def list_tools() -> list[Tool]:
-    return [
-        Tool(
-            name="echo",
-            description="Return the message that was passed in.",
-            inputSchema=ECHO_SCHEMA,
-        )
-    ]
-
-
-@server.call_tool()
-async def call_tool(name: str, arguments: dict) -> list[TextContent]:
-    if name != "echo":
-        raise ValueError(f"unknown tool: {name}")
-    return [TextContent(type="text", text=arguments["message"])]
-
-
-async def main() -> None:
-    async with stdio_server() as (read_stream, write_stream):
-        await server.run(
-            read_stream, write_stream, server.create_initialization_options()
-        )
+@mcp.tool(description="Return the message that was passed in.", structured_output=False)
+async def echo(
+    message: Annotated[str, Field(description="text to send back")],
+) -> str:
+    return message
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    asyncio.run(mcp.run_stdio_async())

--- a/tests/unit/mcp_gateway/test_stdio_roundtrip.py
+++ b/tests/unit/mcp_gateway/test_stdio_roundtrip.py
@@ -97,3 +97,27 @@ async def test_cleanup_marks_the_connection_closed():
     await manager._cleanup_connection(conn)
     assert conn.connected is False
     assert conn.tools == []
+
+
+@pytest.mark.asyncio
+async def test_a_tool_call_through_the_gateway_returns_the_result():
+    """Route the call the way production does, not straight at the session.
+
+    The session-level test above passes even when the gateway's own wrapper is
+    broken: it reads `isError` off the result, and an SDK rename of that field
+    took every tool call down while listing kept working. Only a call that goes
+    through `call_tool` covers that.
+    """
+    manager = MCPClientManager()
+    manager._known_servers["echo"] = _echo_server_info()
+    try:
+        blocks = await asyncio.wait_for(
+            manager.call_tool("echo__echo", {"message": "through the gateway"}),
+            timeout=HANDSHAKE_TIMEOUT,
+        )
+        texts = [b.get("text") for b in blocks if b.get("type") == "text"]
+        assert texts == ["through the gateway"]
+    finally:
+        conn = manager._connections.get("echo")
+        if conn:
+            await manager._cleanup_connection(conn)


### PR DESCRIPTION
Closes #190.

`mcp` has been pinned below 2.0.0 since that release took every stdio server
down. This moves to 2.x and unpins.

**How the servers move**

The ergonomic server API is `FastMCP` on mcp 1.x and `MCPServer` on 2.x, and the
two are identical for the way these files use them — same `@tool` parameters,
same `run_stdio_async`, same emitted schema, checked by running one file under
both. Importing whichever is present means the same code runs on either major
and the version is chosen in `pyproject` alone, so trying 2.x cost one line and
would have rolled back in one line.

`ms365` keeps `_call_tool_impl` as its dispatch, so no Graph logic moved and the
existing 53 tests still cover it. Its eighteen schemas are now derived from typed
wrappers rather than hand-written JSON, and the wrappers omit arguments left
unset so the defaults inside the implementation still apply.

**Two things this turned up**

- Tool *calls* read `isError` off the result object, which 2.0 renamed the same
  way it renamed `inputSchema`. Servers connected and then failed on every call
  until the circuit breaker opened. Both reads now resolve fields by their
  protocol alias, which the spec fixes and both majors keep.
- `mcp-google-sheets` imports `mcp.server.fastmcp` and has no 2.x-compatible
  release — the newest predates 2.0. It is a separate process, but it shared the
  application's site-packages, so our SDK version decided a third-party server's.
  The image now builds it a private virtualenv holding mcp 1.x.

**The round-trip test had the blind spot it was built to remove**

It called the session directly, so it passed while the gateway's own wrapper was
broken. It now also routes a call through `call_tool`; that case fails without
the `isError` fix and passes with it.

**Verified**

- ms365 tool surface before and after: same eighteen names, descriptions,
  required arguments and per-argument descriptions — zero diffs.
- 711 unit tests on mcp 2.1.1, including the stdio round trip.
- Container rebuilt: ten stdio servers connect, no failures, `google-sheets`
  starts again.
- Exercised through a live agent against real data, matching the result from
  before the move.
