### PR TITLE
[ADD] ui: expose the current user's agents to templates

### DIFF
--- a/ui/jinja_env.py
+++ b/ui/jinja_env.py
@@ -31,6 +31,27 @@ def _jinja_translate(message: str) -> str:
 templates.env.globals["_"] = _jinja_translate
 
 
+def _user_agents(request) -> list[dict]:
+    """Agents the current user may reach.
+
+    A sidebar is rendered on every page but the agent list is only built by the
+    chat route, so any other page showed it as empty. Exposing it as a global
+    lets a template ask for it wherever it is drawn, without every route having
+    to carry it. Imported lazily: ui.routes.me imports this module.
+    """
+    try:
+        from ui.auth.session import session_manager
+        from ui.routes.me import _get_user_agents
+
+        user = session_manager.validate_session(request)
+        return _get_user_agents(user) if user else []
+    except Exception:
+        return []
+
+
+templates.env.globals["user_agents"] = _user_agents
+
+
 def _plugin_enabled(name: str) -> bool:
     """Template helper: is the given plugin installed and enabled?
 


### PR DESCRIPTION
A sidebar that lists the current user's agents is drawn on every `/me` page, but
only the chat route builds that list — so on workflows, connections, dashboard,
tools and vault it rendered empty, reading as "no agents available" to anyone
whose theme shows it.

It stayed hidden because the two conditions rarely meet: superadmins bypass the
per-user check entirely, and the one page that does pass the list is the one
most used. It surfaces for a non-superadmin on any other page.

`user_agents(request)` lets a template ask for the list wherever it is drawn,
instead of every route having to carry it — including routes in plugins mounted
from elsewhere, which cannot be changed from here. The import is lazy because
`ui.routes.me` imports this module, and it returns an empty list rather than
raising when there is no session, so a template can call it unguarded.

Nothing in this repository consumes it yet; the core pages keep passing their
own context and behave exactly as before.
